### PR TITLE
Remove positional shorthands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plot tries to be **concise and memorable** for common tasks. This makes Plot eas
 <img src="./img/line-aapl-date-close.png" width="640" height="240" alt="A line chart of the daily closing price of Apple stock, 2013–2018">
 
 ```js
-Plot.Line(AAPL, "Date", "Close")
+Plot.Line(AAPL, {x: "Date", y: "Close"})
 ```
 
 And here’s a line chart of unemployment rates across metropolitan area:
@@ -26,13 +26,13 @@ And here’s a line chart of unemployment rates across metropolitan area:
 <img src="./img/line-bls-date-unemployment-division.png" width="640" height="240" alt="A line chart of the unemployment rate for various U.S. metropolitan areas, 2000–2013">
 
 ```js
-Plot.Line(unemployment, "date", "unemployment", "division")
+Plot.Line(unemployment, {x: "date", y: "unemployment", z: "division"})
 ```
 
 A chart created by Plot is simply an SVG element that you can put anywhere on the page.
 
 ```js
-const chart = Plot.Line(AAPL, "Date", "Close");
+const chart = Plot.Line(AAPL, {x: "Date", y: "Close"});
 document.body.appendChild(chart);
 ```
 
@@ -40,15 +40,15 @@ Data in the wild comes in all shapes, so Plot is **flexible regarding input data
 
 ```js
 // As rows…
-Plot.Line(AAPL, "Date", "Close"); // named fields
-Plot.Line(AAPL, d => d.Date, d => d.Close); // accessor functions
+Plot.Line(AAPL, {x: "Date", y: "Close"}); // named fields
+Plot.Line(AAPL, {x: d => d.Date, y: d => d.Close}); // accessor functions
 ```
 
 ```js
 // As columns…
-Plot.Line(null, dates, closes); // explicit values
-Plot.Line({length}, (_, i) => dates[i], (_, i) => closes[i]); // accessor functions
-Plot.Line(index, i => dates[i], i => closes[i]); // as function of index
+Plot.Line(null, {x: dates, y: closes}); // explicit values
+Plot.Line({length}, {x: (_, i) => dates[i], y: (_, i) => closes[i]}); // accessor functions
+Plot.Line(index, {x: i => dates[i], y: i => closes[i]}); // as function of index
 ```
 
 Above, the columns might be computed from rows as:
@@ -60,12 +60,12 @@ const closes = AAPL.map(d => d.Close);
 const index = AAPL.map((d, i) => i);
 ```
 
-For example, here’s a line chart of random *y*-values where *x* encodes the index of the input data:
+For example, here’s a line chart of random *y*-values where *x* implicitly encodes the index of the input data:
 
 <img src="./img/line-random.png" width="640" height="240" alt="A line chart of a uniform random variable">
 
 ```js
-Plot.Line({length: 500}, Math.random)
+Plot.Line({length: 500}, {y: Math.random})
 ```
 
 And similarly here’s a line chart of a random walk using [d3.cumsum](https://github.com/d3/d3-array/blob/master/README.md#cumsum) and [d3.randomNormal](https://github.com/d3/d3-random/blob/master/README.md#randomNormal):
@@ -83,7 +83,7 @@ It’s not just line charts, of course. Here’s another useful chart type, the 
 <img src="./img/histogram-aapl-volume.png" width="640" height="240" alt="A histogram of daily trading volume for Apple stock, 2013–2018">
 
 ```js
-Plot.Histogram(AAPL, "Volume")
+Plot.Histogram(AAPL, {x: "Volume"})
 ```
 
 While the charts above use shorthand defaults, Plot charts are **highly configurable**. Here’s a more longhand representation of the unemployment chart above, with a dash of customization:
@@ -112,14 +112,14 @@ With Plot, **all charts are interactive inputs**. A Plot chart element exposes a
 In vanilla JavaScript:
 
 ```js
-const chart = Plot.Line(AAPL, "Date", "Close");
+const chart = Plot.Line(AAPL, {x: "Date", y: "Close"});
 chart.oninput = () => console.log(chart.value);
 ```
 
 In Observable:
 
 ```js
-viewof selection = Plot.Line(AAPL, "Date", "Close")
+viewof selection = Plot.Line(AAPL, {x: "Date", y: "Close"})
 ```
 ```js
 Table(selection)

--- a/src/dot.js
+++ b/src/dot.js
@@ -10,8 +10,6 @@ const xDefaults = {value: d => d[0]};
 const yDefaults = {value: d => d[1]};
 
 export function Dot(data, options = {}) {
-  const A = arguments, a = A.length;
-  if (a > 2) options = {x: options, y: A[2]};
   const x = channel(options, "x", xDefaults);
   const y = channel(options, "y", yDefaults);
   const fx = channel(options, "fx");

--- a/src/histogram.js
+++ b/src/histogram.js
@@ -1,7 +1,7 @@
 import {bin as Bin, extent, sum} from "d3-array";
 import {inferDomain, inferOrdinalDomain} from "./domain.js";
 import {Frame} from "./frame.js";
-import {channel, identity, index, isBareValue, inferValues} from "./value.js";
+import {channel, identity, index, inferValues} from "./value.js";
 import {Fragment} from "./mark/fragment.js";
 import {RectXY} from "./mark/rect.js";
 import {RuleX, RuleY} from "./mark/rule.js";
@@ -23,7 +23,6 @@ const yDefaults = {label: "↑ Frequency", rules: [0]};
 const rectDefaults = {roundHorizontal: true, insetLeft: 1};
 
 export function Histogram(data, options = {}) {
-  if (arguments.length === 2 && isBareValue(options)) options = {x: options};
   const x = channel(options, "x", xDefaults);
   const y = channel(options, "y", yDefaults);
   const fx = channel(options, "fx");

--- a/src/line.js
+++ b/src/line.js
@@ -4,16 +4,13 @@ import {Frame} from "./frame.js";
 import {Fragment} from "./mark/fragment.js";
 import {RuleX, RuleY} from "./mark/rule.js";
 import {LineIXYZ} from "./mark/line.js";
-import {channel, identity, indexOf, index, isBareValue, inferValues} from "./value.js";
+import {channel, identity, indexOf, index, inferValues} from "./value.js";
 
 const xImplied = {axis: false};
 const xDefaults = {value: indexOf};
 const yDefaults = {value: identity};
 
 export function Line(data, options = {}) {
-  const A = arguments, a = A.length;
-  if (a === 2 && isBareValue(options)) options = {y: options};
-  else if (a > 2) options = {x: options, y: A[2], z: A[3]};
   const x = channel(options, "x", xDefaults, xImplied);
   const y = channel(options, "y", yDefaults);
   const z = channel(options, "z");

--- a/test/vanilla.html
+++ b/test/vanilla.html
@@ -27,8 +27,8 @@ d3.csv("data/aapl.csv", d3.autoType).then(data => {
 });
 
 d3.csv("data/bls-metro-unemployment.csv", d3.autoType).then(data => {
-  document.body.appendChild(Plot.Line(data, "date", "unemployment", "division"));
-  document.body.appendChild(Plot.Line(data, "unemployment"));
+  document.body.appendChild(Plot.Line(data, {x: "date", y: "unemployment", z: "division"}));
+  document.body.appendChild(Plot.Line(data, {y: "unemployment"}));
 });
 
 document.body.appendChild(Plot.Line(d3.cumsum({length: 500}, d3.randomNormal())));


### PR DESCRIPTION
This removes support for positional shorthands for built-in plot types. The following examples use field names (strings) but any value type (accessor function, array of values) would work.

Before:
```js
Plot.Line(AAPL, "Close")
Plot.Line(AAPL, "Date", "Close")
Plot.Line(unemployment, "date", "unemployment", "division")
Plot.Line({length: 500}, Math.random)
Plot.Histogram(AAPL, "Volume")
```

After:
```js
Plot.Line(AAPL, {y: "Close"})
Plot.Line(AAPL, {x: "Date", y: "Close"})
Plot.Line(unemployment, {x: "date", y: "unemployment", z: "division"})
Plot.Line({length: 500}, {y: Math.random})
Plot.Histogram(AAPL, {x: "Volume"})
```

See [the updated README](https://github.com/observablehq/plot/blob/446431e7a61bee8b9ce2654a0002b0e68652aa1f/README.md) for more examples.

I’m somewhat ambivalent about this change. It means fewer API variants, and it makes the examples slightly more self-describing. But requiring an options object in the simplest cases feels clunkier than just passing in one or two positional arguments.