### PR TITLE
text fill should be a style

### DIFF
--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -59,7 +59,7 @@ export class Text extends Mark {
             .call(applyTextStyles, this)
             .attr("x", i => x(X[i]))
             .attr("y", i => y(Y[i]))
-            .attr("fill", F && (i => color(F[i])))
+            .style("fill", F && (i => color(F[i])))
             .text(i => T[i])
           .call(L ? text => text
             .filter(i => nonempty(L[i]))


### PR DESCRIPTION
otherwise the css `.plot text { fill: currentColor }` takes over