### PR TITLE
Set currentColor on axis labels so they don't disappear

### DIFF
--- a/src/marks/axis.js
+++ b/src/marks/axis.js
@@ -57,7 +57,7 @@ export class AxisX {
             .attr("stroke-opacity", 0.1)
             .attr("y2", offsetSign * (marginBottom + marginTop - height)))
         .call(label == null ? () => {} : g => g.append("text")
-            .style("fill", "currentColor")
+            .attr("fill", "currentColor")
             .attr("transform", `translate(${
                 labelAnchor === "center" ? (width + marginLeft - marginRight) / 2
                   : labelAnchor === "right" ? width
@@ -127,7 +127,7 @@ export class AxisY {
             .attr("stroke-opacity", 0.1)
             .attr("x2", offsetSign * (marginLeft + marginRight - width)))
         .call(label == null ? () => {} : g => g.append("text")
-            .style("fill", "currentColor")
+            .attr("fill", "currentColor")
             .attr("transform", `translate(${labelOffset * offsetSign},${
                 labelAnchor === "center" ? (height + marginTop - marginBottom) / 2
                   : labelAnchor === "bottom" ? height - marginBottom


### PR DESCRIPTION
Fixes #48. Might be cleaner to give axis a class and target by that in the <style> tag instead of setting on each label element individually.