### PR TITLE
identity scale

### DIFF
--- a/src/scales.js
+++ b/src/scales.js
@@ -1,7 +1,8 @@
 import {registry, position, radius} from "./scales/index.js";
 import {ScaleDiverging, ScaleLinear, ScalePow, ScaleLog, ScaleSymlog} from "./scales/quantitative.js";
 import {ScaleTime, ScaleUtc} from "./scales/temporal.js";
-import {ScaleOrdinal, ScalePoint, ScaleBand, ScaleIdentity} from "./scales/ordinal.js";
+import {ScaleOrdinal, ScalePoint, ScaleBand} from "./scales/ordinal.js";
+import {ScaleIdentity} from "./scales/identity.js";
 
 export function Scales(channels, {inset, round, nice, align, padding, ...options} = {}) {
   const scales = {};

--- a/src/scales/identity.js
+++ b/src/scales/identity.js
@@ -1,0 +1,21 @@
+import {scaleIdentity} from "d3-scale";
+import {ScaleO} from "./ordinal.js";
+import {ScaleQ} from "./quantitative.js";
+
+export function ScaleIdentity(key, channels, options) {
+  let type = "quantitative";
+  for (const c of channels) {
+    for (const v of c.value) {
+      if (typeof v === "string") {
+        type = "ordinal";
+        break;
+      }
+    }
+  }
+  switch (type) {
+    case "ordinal":
+      return ScaleO(Object.assign(x => x, { domain: () => {} }), channels, options);
+    case "quantitative":
+      return ScaleQ(key, scaleIdentity(), channels, options);
+  }
+}

--- a/src/scales/ordinal.js
+++ b/src/scales/ordinal.js
@@ -1,5 +1,5 @@
 import {reverse, sort} from "d3-array";
-import {scaleBand, scaleIdentity, scaleOrdinal, scalePoint} from "d3-scale";
+import {scaleBand, scaleOrdinal, scalePoint} from "d3-scale";
 import {
   schemeAccent,
   schemeBlues,
@@ -41,7 +41,6 @@ import {
 } from "d3-scale-chromatic";
 import {ascendingDefined} from "../defined.js";
 import {registry, color} from "./index.js";
-import {ScaleQ} from "./quantitative.js";
 
 // TODO Allow this to be extended.
 const schemes = new Map([
@@ -164,24 +163,6 @@ export function ScaleBand(key, channels, {
     channels,
     options
   );
-}
-
-export function ScaleIdentity(key, channels, options) {
-  let type = "quantitative";
-  for (const c of channels) {
-    for (const v of c.value) {
-      if (typeof v === "string") {
-        type = "ordinal";
-        break;
-      }
-    }
-  }
-  switch (type) {
-    case "ordinal":
-      return ScaleO(Object.assign(x => x, { domain: () => {} }), channels, options);
-    case "quantitative":
-      return ScaleQ(key, scaleIdentity(), channels, options);
-  }
 }
 
 function inferDomain(channels) {


### PR DESCRIPTION
The ordinal identity scale is not complete in the sense that it offers only a (null) domain method, which is the only method that is called. We could imagine having such a scale in d3-scale, that would provide all the expected methods (domain, range, etc) and return the expected (ie the scale if an argument is given).

Closes #56