### PR TITLE
Plot.compose mark

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {AxisX, AxisY} from "./marks/axis.js";
 export {BarX, BarY, barX, barY} from "./marks/bar.js";
 export {bin, binX, binY} from "./marks/bin.js";
 export {Cell, cell, cellX, cellY} from "./marks/cell.js";
+export {Compose, compose} from "./marks/compose.js";
 export {Dot, dot, dotX, dotY} from "./marks/dot.js";
 export {group, groupX, groupY} from "./marks/group.js";
 export {Line, line, lineX, lineY} from "./marks/line.js";

--- a/src/marks/compose.js
+++ b/src/marks/compose.js
@@ -1,0 +1,58 @@
+import {create} from "d3-selection";
+import {Mark} from "../mark.js";
+
+export class Compose extends Mark {
+  constructor(
+    marks = []
+  ) {
+    const submarkChannels = new Map();
+    const submarkIndex = new Map();
+    const subchannels = [];
+
+    // duplicate initialization from plot.js for submarks
+    for (const [i, mark] of marks.entries()) {
+      const named = Object.create(null);
+      const {index, channels} = mark.initialize(mark.data);
+      for (const [name, channel] of channels) {
+        if (name !== undefined) {
+          named[name] = channel.value;
+        }
+        // collect and flatten all the channels from child marks so Plot can autoScale;
+        subchannels.push({
+          ...mark.channels.find(channel => channel.name === name),
+          name: `mark${i}.${name}`, // namespace to avoid collisions
+          value: channel.value
+        });
+      }
+      submarkChannels.set(mark, named);
+      submarkIndex.set(mark, index);
+    }
+
+    super(
+      [],
+      subchannels,
+      d => d
+    );
+
+    this.marks = marks;
+    this.submarkChannels = submarkChannels;
+    this.submarkIndex = submarkIndex;
+  }
+  render(I, scales, channels, options) {
+    // since index and channels will vary by submark, the `submarkChannels` and
+    // `submarkIndex` maps are used instead of `I` (which is empty) and
+    // `channels` (which is flattened); maybe wasteful!
+    const g = create("svg:g");
+    for (const mark of this.marks) {
+      const subchannels = this.submarkChannels.get(mark);
+      const subindex = this.submarkIndex.get(mark);
+      const node = mark.render(subindex, scales, subchannels, options);
+      if (node != null) g.append(() => node);
+    }
+    return g.node();
+  }
+}
+
+export function compose(data, options) {
+  return new Compose(data, options);
+}

--- a/test/aapl-compose.html
+++ b/test/aapl-compose.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+<script src="https://cdn.jsdelivr.net/npm/d3@6"></script>
+<script src="../dist/@observablehq/plot.umd.js"></script>
+<script>
+
+d3.csv("data/aapl.csv", d3.autoType).then(AAPL => {
+  document.body.appendChild(Plot.plot({
+    y: {
+      grid: true
+    },
+    marks: [
+      Plot.ruleY([0]),
+      Plot.compose([
+        Plot.areaY(AAPL, {x: "Date", y: "Close", fillOpacity: 0.1}),
+        Plot.line(AAPL, {x: "Date", y: "Close"}),
+      ])
+    ]
+  }));
+});
+
+</script>


### PR DESCRIPTION
The `Plot.compose` mark receives an array of marks and renders them roughly the same as if they were spread flat in the `marks` array. I guess that’s kinda trivial; there are more powerful conceivable uses that this doesn’t explore. But I think something like this will be essential if we want people to make their own marks, bc it doesn't require learning so much about Plot internals as making a mark currently does.

Example of making a `boxPlot` function that returns a `Plot.compose` mark:
https://observablehq.com/d/5facc25303305d9c

This is very barebones and there are tons of issues. In the boxplot example, I've lost the axis labels of the original nb I forked. It doesn't have any concept of the Plot.compose mark receiving data itself, doesn't support transforms, and I'm sure faceting doesn't work. It feels weirdly duplicative of the mark initialization code in plot.js. And it leads to the render function receiving useless `I` and `channels` (it instead renders using internal `submarkIndex` and `submarkChannels` Maps).

But I was excited to even get it to this point!! Learned a lot about Plot.