### PR TITLE
heuristic to prevent tick occlusion

### DIFF
--- a/src/marks/axis.js
+++ b/src/marks/axis.js
@@ -1,3 +1,4 @@
+import {max} from "d3-array";
 import {axisTop, axisBottom, axisRight, axisLeft} from "d3-axis";
 import {interpolateRound} from "d3-interpolate";
 import {create} from "d3-selection";
@@ -53,6 +54,7 @@ export class AxisX {
         .attr("font-size", null)
         .attr("font-family", null)
         .call(g => g.select(".domain").remove())
+        .call(tickOcclusion(width - marginLeft - marginRight, true))
         .call(!grid ? () => {} : g => g.selectAll(".tick line").clone(true)
             .attr("stroke-opacity", 0.1)
             .attr("y2", offsetSign * (marginBottom + marginTop - height)))
@@ -123,6 +125,7 @@ export class AxisY {
         .attr("font-size", null)
         .attr("font-family", null)
         .call(g => g.select(".domain").remove())
+        .call(tickOcclusion(height - marginTop - marginBottom, false))
         .call(!grid ? () => {} : g => g.selectAll(".tick line").clone(true)
             .attr("stroke-opacity", 0.1)
             .attr("x2", offsetSign * (marginLeft + marginRight - width)))
@@ -148,4 +151,17 @@ function round(scale) {
   return scale.interpolate // TODO round band and point scales?
       ? scale.copy().interpolate(interpolateRound)
       : scale;
+}
+
+function tickOcclusion(space, horizontal) {
+  return g => {
+    const tickLabels = g.selectAll(".tick text");
+    const n = tickLabels.size();
+    const M = (.5 + (horizontal ? max(tickLabels, d => d.textContent.length) : 1)) * 6.5;
+    const m = Math.ceil(n * M / space);
+    if (m > 1) {
+      tickLabels.filter((d,i) => i % m).remove();
+      g.selectAll(".tick line").filter((d,i) => i % m).remove();
+    }
+  };
 }


### PR DESCRIPTION
Addressing #74: when we have too many ticks on an axis, occlusion makes the whole axis unreadable. This heuristic tries to skip ticks when there are too many of them. 

In the first iteration of this PR there is no way to disable the function—but maybe we should avoid anything "smart" if the ticks are set explicitly?

Related: #72

The magic numbers (1.5 and 6.5) were chosen so that that select a value of about 10 pixels between lines (on a yAxis).

Some examples :

https://user-images.githubusercontent.com/7001/103017019-40f73400-4543-11eb-997a-1381c3ef5c21.mov


<img width="638" alt="Capture d’écran 2020-12-23 à 17 20 30" src="https://user-images.githubusercontent.com/7001/103017011-3fc60700-4543-11eb-85b4-aca4aa1fd9e5.png">
<img width="69" alt="Capture d’écran 2020-12-23 à 17 20 24" src="https://user-images.githubusercontent.com/7001/103017015-40f73400-4543-11eb-8117-e6e6cc9c6592.png">
<img width="624" alt="Capture d’écran 2020-12-23 à 17 21 46" src="https://user-images.githubusercontent.com/7001/103017164-7e5bc180-4543-11eb-9ea7-68e6a236ff8b.png">


