### PR TITLE
labels on barX barY

### DIFF
--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,6 +1,6 @@
 import {ascending} from "d3-array";
 import {create} from "d3-selection";
-import {filter} from "../defined.js";
+import {filter, nonempty} from "../defined.js";
 import {Mark, number, maybeColor, maybeZero, indexOf, title} from "../mark.js";
 import {Style, applyDirectStyles, applyIndirectStyles, applyTransform} from "../style.js";
 
@@ -13,6 +13,7 @@ export class AbstractBar extends Mark {
       title,
       fill,
       stroke,
+      label,
       insetTop = 0,
       insetRight = 0,
       insetBottom = 0,
@@ -29,6 +30,7 @@ export class AbstractBar extends Mark {
         ...channels,
         {name: "z", value: z, optional: true},
         {name: "title", value: title, optional: true},
+        {name: "label", value: label, optional: true},
         {name: "fill", value: vfill, scale: "color", optional: true},
         {name: "stroke", value: vstroke, scale: "color", optional: true}
       ],
@@ -42,9 +44,14 @@ export class AbstractBar extends Mark {
   }
   render(I, scales, channels, options) {
     const {color} = scales;
-    const {z: Z, title: L, fill: F, stroke: S} = channels;
+    const {z: Z, title: T, label: L, fill: F, stroke: S} = channels;
     const index = filter(I, ...this._positions(channels), F, S);
     if (Z) index.sort((i, j) => ascending(Z[i], Z[j]));
+    const x = this._x(scales, channels, options);
+    const width = this._width(scales, channels, options);
+    const y = this._y(scales, channels, options);
+    const height = this._height(scales, channels, options);
+
     return create("svg:g")
         .call(applyIndirectStyles, this)
         .call(this._transform, scales)
@@ -52,13 +59,14 @@ export class AbstractBar extends Mark {
           .data(index)
           .join("rect")
             .call(applyDirectStyles, this)
-            .attr("x", this._x(scales, channels, options))
-            .attr("width", this._width(scales, channels, options))
-            .attr("y", this._y(scales, channels, options))
-            .attr("height", this._height(scales, channels, options))
+            .attr("x", x)
+            .attr("width", width)
+            .attr("y", y)
+            .attr("height", height)
             .attr("fill", F && (i => color(F[i])))
             .attr("stroke", S && (i => color(S[i])))
-            .call(title(L)))
+            .call(title(T)))
+        .call(this._label(L, index, {x, y, width, height}))
       .node();
   }
   _x({x}, {x: X}, {marginLeft}) {
@@ -79,6 +87,7 @@ export class AbstractBar extends Mark {
     const bandwidth = Y ? y.bandwidth() : height - marginTop - marginBottom;
     return Math.max(0, bandwidth - insetTop - insetBottom);
   }
+  _label() { return () => {}; }
 }
 
 export class BarX extends AbstractBar {
@@ -107,6 +116,23 @@ export class BarX extends AbstractBar {
     const {insetLeft, insetRight} = this;
     return i => Math.max(0, Math.abs(x(X2[i]) - x(X1[i])) - insetLeft - insetRight);
   }
+  _label(L, index, {x, y, width, height}) {
+    const h = (typeof height === "function") ? height : () => height;
+    const w = (typeof width === "function") ? width : () => width;
+  
+    return L ? g => {
+      g.selectAll("text")
+      .data(index.filter(i => nonempty(L[i])))
+      .join("text")
+        .text(i => L[i])
+        .attr("x", i => x(i) + w(i))
+        .attr("dx", i => w(i) < 20 ? 4 : -4)
+        .attr("text-anchor", i => w(i) < 20 ? "start" : "end")
+        .attr("y", i => y(i) + h(i) / 2)
+        .attr("dominant-baseline", "central")
+        .style("fill", i => w(i) < 20 ? "black" : "white");
+      } : () => {};
+  }
 }
 
 export class BarY extends AbstractBar {
@@ -134,6 +160,22 @@ export class BarY extends AbstractBar {
   _height({y}, {y1: Y1, y2: Y2}) {
     const {insetTop, insetBottom} = this;
     return i => Math.max(0, Math.abs(y(Y2[i]) - y(Y1[i])) - insetTop - insetBottom);
+  }
+  _label(L, index, {x, y, width, height}) {
+    const h = (typeof height === "function") ? height : () => height;
+    const w = (typeof width === "function") ? width : () => width;
+  
+    return L ? g => {
+      g.selectAll("text")
+      .data(index.filter(i => nonempty(L[i])))
+      .join("text")
+        .text(i => L[i])
+        .attr("x", i => x(i) + w(i) / 2)
+        .attr("text-anchor", "center")
+        .attr("y", i => y(i))
+        .attr("dy", i => h(i) < 20 ? -4 : 12)
+        .style("fill", i => h(i) < 20 ? "black" : "white");
+      } : () => {};
   }
 }
 


### PR DESCRIPTION
Addressing #81
tests at https://observablehq.com/d/93396cc5530e51bc

_Notes:_

This option is difficult to specify: where should the label go? what colors should it have? I chose a solution that I like (put the labels inside the large bars, and after/on top of the smaller bars), with colors white inside / black outside. But this is certainly too opinionated/restrictive. Another difficulty (similar to #74) is to have an idea of what defines "small" / "large".

Anyways, sharing to see if it can help designing this feature.



![untitled - 2020-12-30T171454 491](https://user-images.githubusercontent.com/7001/103366306-8a56fe80-4ac2-11eb-8fd5-230048cdf59e.png)
![untitled - 2020-12-30T171451 167](https://user-images.githubusercontent.com/7001/103366307-8b882b80-4ac2-11eb-9017-6cc53dfdffd3.png)
