### PR TITLE
accept transforms in bin, group and cell marks

### DIFF
--- a/src/marks/bin.js
+++ b/src/marks/bin.js
@@ -4,7 +4,7 @@ import {rect, rectX, rectY} from "./rect.js";
 
 export function bin(data, {x, y, domain, thresholds, normalize, transform, ...options} = {}) {
   data = arrayify(data);
-  if (transform) data = transform(data);
+  if (transform !== undefined) data = arrayify(transform(data));
   return rect(
     data,
     {
@@ -31,7 +31,7 @@ export function binX(data, {
   ...options
 } = {}) {
   data = arrayify(data);
-  if (transform) data = transform(data);
+  if (transform !== undefined) data = arrayify(transform(data));
   return rectY(
     data,
     {
@@ -55,7 +55,7 @@ export function binY(data, {
   ...options
 } = {}) {
   data = arrayify(data);
-  if (transform) data = transform(data);
+  if (transform !== undefined) data = arrayify(transform(data));
   return rectX(
     data,
     {

--- a/src/marks/group.js
+++ b/src/marks/group.js
@@ -9,7 +9,7 @@ export function group(data, {
   transform,
   ...options
 } = {}) {
-  if (transform) data = transform(arrayify(data));
+  if (transform !== undefined) data = transform(arrayify(data));
   return cell(
     data,
     {
@@ -31,7 +31,7 @@ export function groupX(data, {
   ...options
 } = {}) {
   data = arrayify(data);
-  if (transform) data = transform(data);
+  if (transform !== undefined) data = arrayify(transform(data));
   ([y1, y2] = maybeZero(y, y1, y2, maybeLength(data, options)));
   return barY(
     data,
@@ -54,7 +54,7 @@ export function groupY(data, {
   ...options
 } = {}) {
   data = arrayify(data);
-  if (transform) data = transform(data);
+  if (transform !== undefined) data = arrayify(transform(data));
   ([x1, x2] = maybeZero(x, x1, x2, maybeLength(data, options)));
   return barX(
     data,


### PR DESCRIPTION
This makes bin, cell and group accept `options.transform`

Complements #95 for cases where we want to transform *before* computing the mark.

[My examples](https://observablehq.com/d/34d010115706b65f) use sftemps with rescaled temperatures (raw data in °F, transformed in °C). If I want them to be binned on integer values of their target unit (integer values of °C), using x.transform doesn't work (it bins on integer values of the °F temperatures). 

This can be solved with an options.transform (which is a bit more tedious to write than x.transform), but the bin, group and cell marks didn't have it.

![Capture d’écran 2021-01-14 à 11 43 08](https://user-images.githubusercontent.com/7001/104580552-b72c1980-565d-11eb-80f3-1349578564a4.png)

![Capture d’écran 2021-01-14 à 11 43 54](https://user-images.githubusercontent.com/7001/104580647-cdd27080-565d-11eb-8b91-7ebdcf22ebe1.png)
