### PR TITLE
Hyphenated styles

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -1,67 +1,41 @@
 import {string, number} from "./mark.js";
 
-export function Style(mark, {
-  fill,
-  fillOpacity,
-  stroke,
-  strokeWidth,
-  strokeOpacity,
-  strokeLinejoin,
-  strokeLinecap,
-  strokeMiterlimit,
-  strokeDasharray,
-  mixBlendMode,
-  fontFamily,
-  fontSize,
-  fontSizeAdjust,
-  fontStretch,
-  fontStyle,
-  fontVariant,
-  fontWeight
-} = {}) {
-  mark.fill = impliedString(fill, "currentColor");
-  mark.fillOpacity = impliedNumber(fillOpacity, 1);
-  mark.stroke = impliedString(stroke, "none");
-  mark.strokeWidth = impliedNumber(strokeWidth, 1);
-  mark.strokeOpacity = impliedNumber(strokeOpacity, 1);
-  mark.strokeLinejoin = impliedString(strokeLinejoin, "miter");
-  mark.strokeLinecap = impliedString(strokeLinecap, "butt");
-  mark.strokeMiterlimit = impliedNumber(strokeMiterlimit, 1);
-  mark.strokeDasharray = string(strokeDasharray);
-  mark.mixBlendMode = impliedString(mixBlendMode, "normal");
-  
-  mark.font = {
-    family: impliedString(fontFamily, "sans-serif"),
-    size: impliedString(fontSize, "10px"),
-    sizeAdjust: impliedString(fontSizeAdjust, "none"),
-    stretch: impliedString(fontStretch, "normal"),
-    style: impliedString(fontStyle, "normal"),
-    variant: impliedString(fontVariant, "normal"),
-    weight: impliedString(fontWeight, "normal")
-  };
+const stylesList = [
+  ["fill", "fill", "currentColor", impliedString],
+  ["fillOpacity", "fill-opacity", 1, impliedNumber],
+  ["stroke", "stroke", "none", impliedString],
+  ["strokeWidth", "stroke-width", 1, impliedNumber],
+  ["strokeOpacity", "stroke-opacity", 1, impliedNumber],
+  ["strokeLinejoin", "stroke-linejoin", "miter", impliedString],
+  ["strokeLinecap", "stroke-linecap", "butt", impliedString],
+  ["strokeMiterlimit", "stroke-miterlimit", 1, impliedNumber],
+  ["strokeDasharray", "stroke-dasharray", null, string],
+  ["mixBlendMode", "mix-blend-mode", "normal", impliedString, true],
+  ["fontFamily", "font-family", "sans-serif", impliedString],
+  ["fontSize", "font-size", "10px", impliedString],
+  ["fontSizeAdjust", "font-size-adjust", "none", impliedString],
+  ["fontStretch", "font-stretch", "normal", impliedString],
+  ["fontStyle", "font-style", "normal", impliedString],
+  ["fontVariant", "font-variant", "normal", impliedString],
+  ["fontWeight", "font-weight", "normal", impliedString]
+];
+
+export function Style(mark, styles = {}) {
+  for (const [key, hyphenkey, value, type] of stylesList) {
+    mark[key] = type((hyphenkey in styles) ? styles[hyphenkey] : styles[key], value);
+  }
 }
 
 export function applyIndirectStyles(selection, mark) {
-  applyAttr(selection, "fill", mark.fill);
-  applyAttr(selection, "fill-opacity", mark.fillOpacity);
-  applyAttr(selection, "stroke", mark.stroke);
-  applyAttr(selection, "stroke-width", mark.strokeWidth);
-  applyAttr(selection, "stroke-opacity", mark.strokeOpacity);
-  applyAttr(selection, "stroke-linejoin", mark.strokeLinejoin);
-  applyAttr(selection, "stroke-linecap", mark.strokeLinecap);
-  applyAttr(selection, "stroke-miterlimit", mark.strokeMiterlimit);
-  applyAttr(selection, "stroke-dasharray", mark.strokeDasharray);
-  applyAttr(selection, "font-family", mark.font.family);
-  applyAttr(selection, "font-size", mark.font.size);
-  applyAttr(selection, "font-size-adjust", mark.font.sizeAdjust);
-  applyAttr(selection, "font-stretch", mark.font.stretch);
-  applyAttr(selection, "font-style", mark.font.style);
-  applyAttr(selection, "font-variant", mark.font.variant);
-  applyAttr(selection, "font-weight", mark.font.weight);
+  for (const [key, hyphenkey,,, indirect] of stylesList) {
+    if (!indirect) applyAttr(selection, hyphenkey, mark[key]);
+  }
 }
 
 export function applyDirectStyles(selection, mark) {
-  applyStyle(selection, "mix-blend-mode", mark.mixBlendMode);
+  for (const [key, hyphenkey,,, indirect] of stylesList) {
+    if (indirect) applyStyle(selection, hyphenkey, mark[key]);
+  }
 }
 
 export function applyAttr(selection, name, value) {


### PR DESCRIPTION
Support for hyphenated styles (`font-family` on top of `fontFamily`); I tend to think that users who know css will be more accustomed to that syntax, but maybe supporting the two would create confusion (?).

Independently, maybe the restructuring is worth it.