### PR TITLE
ignore fx/fy when facets are inactive

### DIFF
--- a/src/scales.js
+++ b/src/scales.js
@@ -25,8 +25,8 @@ export function Scales(channels, {inset, round, nice, align, padding, ...options
 export function autoScaleRange({x, y, fx, fy}, dimensions) {
   if (fx) autoScaleRangeX(fx, dimensions);
   if (fy) autoScaleRangeY(fy, dimensions);
-  if (x) autoScaleRangeX(x, fx ? {width: fx.scale.bandwidth()} : dimensions);
-  if (y) autoScaleRangeY(y, fy ? {height: fy.scale.bandwidth()} : dimensions);
+  if (x) autoScaleRangeX(x, fx?.scale?.bandwidth ? {width: fx.scale.bandwidth()} : dimensions);
+  if (y) autoScaleRangeY(y, fy?.scale?.bandwidth ? {height: fy.scale.bandwidth()} : dimensions);
 }
 
 function autoScaleRangeX(scale, dimensions) {


### PR DESCRIPTION
test case:
~~~js
Plot.plot({
  fx: {},
  marks: [Plot.dot({length: 100}, {x: Math.random, y: Math.random})]
})
~~~

<img width="599" alt="Capture d’écran 2021-03-14 à 14 23 49" src="https://user-images.githubusercontent.com/7001/111070233-f4cbe800-84d0-11eb-905a-965dcd91d662.png">
