### PR TITLE
offset = {center, normalize}

### DIFF
--- a/README.md
+++ b/README.md
@@ -1243,7 +1243,7 @@ The Plot.normalizeX and Plot.normalizeY transforms normalize series values relat
 The Plot.windowX and Plot.windowY transforms compute a moving window around each data point and then derive a summary statistic from values in the current window, say to compute rolling averages, rolling minimums, or rolling maximums. These transforms also take additional options:
 
 * **k** - the window size (the number of elements in the window)
-* **shift** - how to align the window: *centered*, *leading*, or *trailing*
+* **anchor** - how to align the window: *start*, *middle*, or *end*
 * **reduce** - the aggregation method (window reducer)
 
 The following window reducers are supported:
@@ -1258,7 +1258,7 @@ The following window reducers are supported:
 * *difference* - the difference between the last and first window value
 * *ratio* - the ratio of the last and first window value
 
-By default, **shift** is *centered* and **reduce** is *mean*.
+By default, **anchor** is *middle* and **reduce** is *mean*.
 
 #### Plot.map(*outputs*, *options*)
 
@@ -1306,7 +1306,7 @@ Like [Plot.mapY](#plotmapymap-options), but applies the normalize map method wit
 Plot.windowX(24, {y: "Date", x: "Anomaly"})
 ```
 
-Like [Plot.mapX](#plotmapxmap-options), but applies the window map method with the given window size *k*. For additional options to the window transform, replace the number *k* with an object with properties *k*, *shift*, or *reduce*.
+Like [Plot.mapX](#plotmapxmap-options), but applies the window map method with the given window size *k*. For additional options to the window transform, replace the number *k* with an object with properties *k*, *anchor*, or *reduce*.
 
 #### Plot.windowY(*k*, *options*)
 
@@ -1314,7 +1314,7 @@ Like [Plot.mapX](#plotmapxmap-options), but applies the window map method with t
 Plot.windowY(24, {x: "Date", y: "Anomaly"})
 ```
 
-Like [Plot.mapY](#plotmapymap-options), but applies the window map method with the given window size *k*. For additional options to the window transform, replace the number *k* with an object with properties *k*, *shift*, or *reduce*.
+Like [Plot.mapY](#plotmapymap-options), but applies the window map method with the given window size *k*. For additional options to the window transform, replace the number *k* with an object with properties *k*, *anchor*, or *reduce*.
 
 ### Select
 
@@ -1378,11 +1378,11 @@ The stack transform supports diverging stacks: negative values are stacked below
 After all values have been stacked from zero, an optional **offset** can be applied to translate or scale the stacks. The following **offset** methods are supported:
 
 - null - a zero baseline (default)
-- *expand* - rescale each stack to fill [0, 1]
-- *silhouette* - align the centers of all stacks
+- *expand* (or *normalize*) - rescale each stack to fill [0, 1]
+- *center* (or *silhouette*) - align the centers of all stacks
 - *wiggle* - translate stacks to minimize apparent movement
 
-If a given stack has zero total value, the *expand* offset will not adjust the stack’s position. Both the *silhouette* and *wiggle* offsets ensure that the lowest element across stacks starts at zero for better default axes. The *wiggle* offset is recommended for streamgraphs, and if used, changes the default order to *inside-out*; see [Byron & Wattenberg](http://leebyron.com/streamgraph/).
+If a given stack has zero total value, the *expand* offset will not adjust the stack’s position. Both the *center* and *wiggle* offsets ensure that the lowest element across stacks starts at zero for better default axes. The *wiggle* offset is recommended for streamgraphs, and if used, changes the default order to *inside-out*; see [Byron & Wattenberg](http://leebyron.com/streamgraph/).
 
 In addition to the **y1** and **y2** output channels, Plot.stackY computers a **y** output channel that represents the midpoint of **y1** and **y2**. Plot.stackX does the same for **x**. This can be used to position a label or a dot in the center of a stacked layer. The **x** and **y** output channels are lazy: they are only computed if needed by a downstream mark or transform.
 

--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -113,8 +113,8 @@ function stack(x, y = () => 1, ky, {offset, order, reverse}, options) {
 function maybeOffset(offset) {
   if (offset == null) return;
   switch ((offset + "").toLowerCase()) {
-    case "expand": return offsetExpand;
-    case "silhouette": return offsetSilhouette;
+    case "normalize": case "expand": return offsetExpand;
+    case "center": case "silhouette": return offsetSilhouette;
     case "wiggle": return offsetWiggle;
   }
   throw new Error(`unknown offset: ${offset}`);

--- a/src/transforms/window.js
+++ b/src/transforms/window.js
@@ -13,18 +13,29 @@ export function windowY(windowOptions = {}, options) {
 
 function window(options = {}) {
   if (typeof options === "number") options = {k: options};
-  let {k, reduce, anchor} = options;
+  let {k, reduce, shift, anchor = maybeShift(shift)} = options;
   if (!((k = Math.floor(k)) > 0)) throw new Error("invalid k");
   return maybeReduce(reduce)(k, maybeAnchor(anchor, k));
 }
 
-function maybeAnchor(anchor = "center", k) {
+function maybeAnchor(anchor = "middle", k) {
   switch ((anchor + "").toLowerCase()) {
-    case "center": return (k - 1) >> 1;
+    case "middle": return (k - 1) >> 1;
     case "start": return 0;
     case "end": return k - 1;
   }
   throw new Error("invalid anchor");
+}
+
+function maybeShift(shift) {
+  if (shift === undefined) return;
+  console.warn("shift is deprecated; please use anchor instead");
+  switch ((shift + "").toLowerCase()) {
+    case "centered": return "middle";
+    case "leading": return "start";
+    case "trailing": return "end";
+  }
+  throw new Error("invalid shift");
 }
 
 function maybeReduce(reduce = "mean") {

--- a/test/transforms/windowMax-test.js
+++ b/test/transforms/windowMax-test.js
@@ -36,7 +36,7 @@ it("window max treats null as NaN", () => {
 
 it("window max respects anchor", () => {
   const data = [0, 1, 2, 3, 4, 5];
-  const mc = Plot.windowX({reduce: "max", k: 3, anchor: "center", x: d => d});
+  const mc = Plot.windowX({reduce: "max", k: 3, anchor: "middle", x: d => d});
   mc.transform(data, [range(data.length)]);
   assert.deepStrictEqual(mc.x.transform(), [, 2, 3, 4, 5,, ]);
   const ml = Plot.windowX({reduce: "max", k: 3, anchor: "start", x: d => d});

--- a/test/transforms/windowMean-test.js
+++ b/test/transforms/windowMean-test.js
@@ -4,7 +4,7 @@ import assert from "assert";
 
 /* eslint-disable no-sparse-arrays */
 /* eslint-disable comma-dangle */
-it("movingAverage computes a moving average", () => {
+it("window mean computes a moving average", () => {
   const data = d3.range(6);
   const m1 = Plot.windowX({k: 1, x: d => d});
   m1.transform(data, [d3.range(data.length)]);
@@ -20,23 +20,23 @@ it("movingAverage computes a moving average", () => {
   assert.deepStrictEqual(m4.x.transform(), [, 1.5, 2.5, 3.5,,, ]);
 });
 
-it("movingAverage skips NaN", () => {
+it("window mean skips NaN", () => {
   const data = [1, 1, 1, null, 1, 1, 1, 1, 1, NaN, 1, 1, 1];
   const m3 = Plot.windowX({k: 3, x: d => d});
   m3.transform(data, [d3.range(data.length)]);
   assert.deepStrictEqual(m3.x.transform(), [, 1, NaN, NaN, NaN, 1, 1, 1, NaN, NaN, NaN, 1,, ]);
 });
 
-it("movingAverage treats null as NaN", () => {
+it("window mean treats null as NaN", () => {
   const data = [1, 1, 1, null, 1, 1, 1, 1, 1, null, 1, 1, 1];
   const m3 = Plot.windowX({k: 3, x: d => d});
   m3.transform(data, [d3.range(data.length)]);
   assert.deepStrictEqual(m3.x.transform(), [, 1, NaN, NaN, NaN, 1, 1, 1, NaN, NaN, NaN, 1,, ]);
 });
 
-it("movingAverage respects anchor", () => {
+it("window mean respects anchor", () => {
   const data = [0, 1, 2, 3, 4, 5];
-  const mc = Plot.windowX({k: 3, anchor: "center", x: d => d});
+  const mc = Plot.windowX({k: 3, anchor: "middle", x: d => d});
   mc.transform(data, [d3.range(data.length)]);
   assert.deepStrictEqual(mc.x.transform(), [, 1, 2, 3, 4,, ]);
   const ml = Plot.windowX({k: 3, anchor: "start", x: d => d});


### PR DESCRIPTION
These are for consistency with Vega-Lite:

* offset = center is an alias for offset = silhouette
* offset = normalize is an alias for offset = expand

Although, I thought maybe offset = proportion should be an alias for offset = expand, given that we support a proportion reducer? Though it’s not exactly the same thing. We could have multiple aliases, I suppose, to help people with familiarity with other libraries.