### PR TITLE
Render mark

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -15,11 +15,12 @@ export function plot(options = {}) {
   }
 
   // Flatten any nested marks.
-  const marks = options.marks === undefined ? [] : options.marks.flat(Infinity)
-    .map(mark => typeof mark === "function" ? {
-      initialize: () => ({ index: [], channels: [] }),
-      render: mark
-    } : mark);
+  const marks = options.marks === undefined ? [] : options.marks.flat(Infinity);
+  for (const mark of marks) {
+    if (mark.initialize === undefined) {
+      mark.initialize = () => ({ index: [], channels: [] });
+    }
+  }
 
   // A Map from Mark instance to an object of named channel values.
   const markChannels = new Map();

--- a/src/plot.js
+++ b/src/plot.js
@@ -15,7 +15,11 @@ export function plot(options = {}) {
   }
 
   // Flatten any nested marks.
-  const marks = options.marks === undefined ? [] : options.marks.flat(Infinity);
+  const marks = options.marks === undefined ? [] : options.marks.flat(Infinity)
+    .map(mark => typeof mark === "function" ? {
+      initialize: () => ({ index: [], channels: [] }),
+      render: mark
+    } : mark);
 
   // A Map from Mark instance to an object of named channel values.
   const markChannels = new Map();


### PR DESCRIPTION
I've made two versions of this (in two consecutive commits):

- 1) the function mark:  `marks: [ () => svg'<text>function mark' ]`
- 2) the render mark:  `marks: [ { render: () => svg'<text>render mark' } ]`

The second solution is imo much better since you can discover it by inspecting a mark. (It might be hard to figure out what initialize does without reading the documentation, but the render function is immediate and simple.)

closes #182