### PR TITLE
avoid illegible ticks when the size of the domain exceeds x times the number of ticks

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -64,8 +64,10 @@ export class AxisX {
       labelOffset,
       line,
       name,
+      ticks,
       tickRotate
     } = this;
+    if (!x.interpolate && x.domain().length > 8 * ticks) return; // avoid a huge ordinal domain
     const offset = name === "x" ? 0 : axis === "top" ? marginTop - facetMarginTop : marginBottom - facetMarginBottom;
     const offsetSign = axis === "top" ? -1 : 1;
     const ty = offsetSign * offset + (axis === "top" ? marginTop : height - marginBottom);
@@ -155,8 +157,10 @@ export class AxisY {
       labelOffset,
       line,
       name,
+      ticks,
       tickRotate
     } = this;
+    if (!y.interpolate && y.domain().length > 8 * ticks) return; // avoid a huge ordinal domain
     const offset = name === "y" ? 0 : axis === "left" ? marginLeft - facetMarginLeft : marginRight - facetMarginRight;
     const offsetSign = axis === "left" ? -1 : 1;
     const tx = offsetSign * offset + (axis === "right" ? width - marginRight : marginLeft);

--- a/src/plot.js
+++ b/src/plot.js
@@ -129,8 +129,14 @@ export function plot(options = {}) {
   const {fx, fy} = scales;
   const axisY = axes[facets !== undefined && fy ? "fy" : "y"];
   const axisX = axes[facets !== undefined && fx ? "fx" : "x"];
-  if (axisY) svg.appendChild(axisY.render(null, scales, dimensions));
-  if (axisX) svg.appendChild(axisX.render(null, scales, dimensions));
+  if (axisY) {
+    const node = axisY.render(null, scales, dimensions);
+    if (node) svg.appendChild(node);
+  }
+  if (axisX) {
+    const node = axisX.render(null, scales, dimensions);
+    if (node) svg.appendChild(node);
+  }
 
   // Render (possibly faceted) marks.
   if (facets !== undefined) {


### PR DESCRIPTION
TODO:
- [ ] update with **tickSpacing**
- [ ] revise with #1790 

http://localhost:8008/?test=mobyDickFaceted has approximately 8 times the number of autoticks (26 letters vs 3.3 autoticks), and it's acceptable because it's single letters (there's even a bit of space left).

<img width="294" alt="Capture d’écran 2021-04-05 à 18 47 50" src="https://user-images.githubusercontent.com/7001/113599899-901f2b80-963f-11eb-96b9-bbb604959d4f.png">

With a threshold at 10, and setting the height at the ultimate point before this kicks in, it's really become illegible. 
<img width="198" alt="threshold10" src="https://user-images.githubusercontent.com/7001/113600654-9cf04f00-9640-11eb-8647-7229bcc35162.png">

With a threshold at 8, it's just barely begun to be illegible. 
<img width="213" alt="threshold8" src="https://user-images.githubusercontent.com/7001/113601048-24d65900-9641-11eb-976a-f71b50e8a9e7.png">

With a threshold at 5, it's packed, but still legible. 
<img width="220" alt="threshold5" src="https://user-images.githubusercontent.com/7001/113600476-5d296780-9640-11eb-9148-5ce9f64e7d2f.png">

closes #74