### PR TITLE
Smarter automatic rounding.

### DIFF
--- a/src/scales.js
+++ b/src/scales.js
@@ -35,6 +35,7 @@ function autoScaleRangeX(scale, dimensions) {
     const {width, marginLeft = 0, marginRight = 0} = dimensions;
     scale.scale.range([marginLeft + inset, width - marginRight - inset]);
   }
+  autoScaleRound(scale);
 }
 
 function autoScaleRangeY(scale, dimensions) {
@@ -44,6 +45,13 @@ function autoScaleRangeY(scale, dimensions) {
     const range = [height - marginBottom - inset, marginTop + inset];
     if (scale.type === "ordinal") range.reverse();
     scale.scale.range(range);
+  }
+  autoScaleRound(scale);
+}
+
+function autoScaleRound(scale) {
+  if (scale.round === undefined && scale.type === "ordinal" && scale.scale.step() >= 5) {
+    scale.scale.round(true);
   }
 }
 

--- a/src/scales/ordinal.js
+++ b/src/scales/ordinal.js
@@ -209,14 +209,12 @@ export function ScaleOrdinal(key, channels, {
 export function ScalePoint(key, channels, {
   align = 0.5,
   padding = 0.5,
-  round = true,
   ...options
 }) {
-  return ScaleO(
+  return maybeRound(
     scalePoint()
       .align(align)
-      .padding(padding)
-      .round(round),
+      .padding(padding),
     channels,
     options
   );
@@ -227,18 +225,24 @@ export function ScaleBand(key, channels, {
   padding = 0.1,
   paddingInner = padding,
   paddingOuter = key === "fx" || key === "fy" ? 0 : padding,
-  round = true,
   ...options
 }) {
-  return ScaleO(
+  return maybeRound(
     scaleBand()
       .align(align)
       .paddingInner(paddingInner)
-      .paddingOuter(paddingOuter)
-      .round(round),
+      .paddingOuter(paddingOuter),
     channels,
     options
   );
+}
+
+function maybeRound(scale, channels, options = {}) {
+  const {round} = options;
+  if (round !== undefined) scale.round(round);
+  scale = ScaleO(scale, channels, options);
+  scale.round = round;
+  return scale;
 }
 
 function inferDomain(channels) {


### PR DESCRIPTION
Fixes #72 (at least by default). Ordinal scales now only round by default if the unrounded step is greater than five pixels. This heuristic estimates the cardinality of the domain relative to the available range and should prevent bars from disappearing by default. (You can still make the bars disappear by rounding explicitly, which we would need to fix in d3-scale.)