### PR TITLE
Renames

### DIFF
--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -114,7 +114,7 @@ function maybeOffset(offset) {
   if (offset == null) return;
   switch ((offset + "").toLowerCase()) {
     case "expand": return offsetExpand;
-    case "silhouette": return offsetSilhouette;
+    case "center": return offsetCenter;
     case "wiggle": return offsetWiggle;
   }
   throw new Error(`unknown offset: ${offset}`);
@@ -144,7 +144,7 @@ function offsetExpand(stacks, Y1, Y2) {
   }
 }
 
-function offsetSilhouette(stacks, Y1, Y2) {
+function offsetCenter(stacks, Y1, Y2) {
   for (const stack of stacks) {
     const [yn, yp] = extent(stack, Y2);
     for (const i of stack) {

--- a/src/transforms/window.js
+++ b/src/transforms/window.js
@@ -13,19 +13,18 @@ export function windowY(windowOptions = {}, options) {
 
 function window(options = {}) {
   if (typeof options === "number") options = {k: options};
-  let {k, reduce, shift} = options;
+  let {k, reduce, anchor} = options;
   if (!((k = Math.floor(k)) > 0)) throw new Error("invalid k");
-  return maybeReduce(reduce)(k, maybeShift(shift, k));
+  return maybeReduce(reduce)(k, maybeAnchor(anchor, k));
 }
 
-// TODO rename to anchor = {start, center, end}?
-function maybeShift(shift = "centered", k) {
-  switch ((shift + "").toLowerCase()) {
-    case "centered": return (k - 1) >> 1;
-    case "leading": return 0;
-    case "trailing": return k - 1;
+function maybeAnchor(anchor = "center", k) {
+  switch ((anchor + "").toLowerCase()) {
+    case "center": return (k - 1) >> 1;
+    case "start": return 0;
+    case "end": return k - 1;
   }
-  throw new Error("invalid shift");
+  throw new Error("invalid anchor");
 }
 
 function maybeReduce(reduce = "mean") {

--- a/test/transforms/windowMax-test.js
+++ b/test/transforms/windowMax-test.js
@@ -34,15 +34,15 @@ it("window max treats null as NaN", () => {
   assert.deepStrictEqual(m3.x.transform(), [, 1, NaN, NaN, NaN, 1, 1, 1, NaN, NaN, NaN, NaN, NaN,, ]);
 });
 
-it("window max respects shift", () => {
+it("window max respects anchor", () => {
   const data = [0, 1, 2, 3, 4, 5];
-  const mc = Plot.windowX({reduce: "max", k: 3, x: d => d});
+  const mc = Plot.windowX({reduce: "max", k: 3, anchor: "center", x: d => d});
   mc.transform(data, [range(data.length)]);
   assert.deepStrictEqual(mc.x.transform(), [, 2, 3, 4, 5,, ]);
-  const ml = Plot.windowX({reduce: "max", k: 3, shift: "leading", x: d => d});
+  const ml = Plot.windowX({reduce: "max", k: 3, anchor: "start", x: d => d});
   ml.transform(data, [range(data.length)]);
   assert.deepStrictEqual(ml.x.transform(), [2, 3, 4, 5,,, ]);
-  const mt = Plot.windowX({reduce: "max", k: 3, shift: "trailing", x: d => d});
+  const mt = Plot.windowX({reduce: "max", k: 3, anchor: "end", x: d => d});
   mt.transform(data, [range(data.length)]);
   assert.deepStrictEqual(mt.x.transform(), [,, 2, 3, 4, 5]);
 });

--- a/test/transforms/windowMean-test.js
+++ b/test/transforms/windowMean-test.js
@@ -34,16 +34,15 @@ it("movingAverage treats null as NaN", () => {
   assert.deepStrictEqual(m3.x.transform(), [, 1, NaN, NaN, NaN, 1, 1, 1, NaN, NaN, NaN, 1,, ]);
 });
 
-it("movingAverage respects shift", () => {
+it("movingAverage respects anchor", () => {
   const data = [0, 1, 2, 3, 4, 5];
-  const mc = Plot.windowX({k: 3, x: d => d});
+  const mc = Plot.windowX({k: 3, anchor: "center", x: d => d});
   mc.transform(data, [d3.range(data.length)]);
   assert.deepStrictEqual(mc.x.transform(), [, 1, 2, 3, 4,, ]);
-  const ml = Plot.windowX({k: 3, shift: "leading", x: d => d});
+  const ml = Plot.windowX({k: 3, anchor: "start", x: d => d});
   ml.transform(data, [d3.range(data.length)]);
   assert.deepStrictEqual(ml.x.transform(), [1, 2, 3, 4,,, ]);
-  const mt = Plot.windowX({k: 3, shift: "trailing", x: d => d});
+  const mt = Plot.windowX({k: 3, anchor: "end", x: d => d});
   mt.transform(data, [d3.range(data.length)]);
   assert.deepStrictEqual(mt.x.transform(), [,, 1, 2, 3, 4]);
 });
-


### PR DESCRIPTION
* window transform: _shift_ to _anchor_ (old options: _leading/centered/trailing_ ; new options: _start/center/end_)
* stack offset: _silhouette_ to _center_

question:
* stack offset: should "expand" be renamed "normalize"? ; cf #289 (which offers them as aliases)