### PR TITLE
lollipop chart for the athletes' sex-ratio by sport

### DIFF
--- a/test/output/athletesSportSex.svg
+++ b/test/output/athletesSportSex.svg
@@ -1,164 +1,197 @@
-<svg class="plot" fill="currentColor" text-anchor="middle" width="640" height="500" viewBox="0 0 640 500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot" fill="currentColor" text-anchor="middle" width="640" height="396" viewBox="0 0 640 396" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g transform="translate(100,0)" fill="none" text-anchor="end">
-    <g class="tick" opacity="1" transform="translate(0,29.5)">
+    <g class="tick" opacity="1" transform="translate(0,31.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">boxing</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,45.5)">
+    <g class="tick" opacity="1" transform="translate(0,43.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">wrestling</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,61.5)">
+    <g class="tick" opacity="1" transform="translate(0,55.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">canoe</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,77.5)">
+    <g class="tick" opacity="1" transform="translate(0,67.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">cycling</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,93.5)">
+    <g class="tick" opacity="1" transform="translate(0,79.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">equestrian</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,109.5)">
+    <g class="tick" opacity="1" transform="translate(0,91.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">shooting</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,125.5)">
+    <g class="tick" opacity="1" transform="translate(0,103.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">judo</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,141.5)">
+    <g class="tick" opacity="1" transform="translate(0,115.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">rowing</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,157.5)">
+    <g class="tick" opacity="1" transform="translate(0,127.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">weightlifting</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,173.5)">
+    <g class="tick" opacity="1" transform="translate(0,139.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">sailing</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,189.5)">
+    <g class="tick" opacity="1" transform="translate(0,151.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">football</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,205.5)">
+    <g class="tick" opacity="1" transform="translate(0,163.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">tennis</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,221.5)">
+    <g class="tick" opacity="1" transform="translate(0,175.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">athletics</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,237.5)">
+    <g class="tick" opacity="1" transform="translate(0,187.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">golf</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,253.5)">
+    <g class="tick" opacity="1" transform="translate(0,199.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">rugby sevens</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,269.5)">
+    <g class="tick" opacity="1" transform="translate(0,211.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">aquatics</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,285.5)">
+    <g class="tick" opacity="1" transform="translate(0,223.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">handball</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,301.5)">
+    <g class="tick" opacity="1" transform="translate(0,235.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">archery</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,317.5)">
+    <g class="tick" opacity="1" transform="translate(0,247.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">badminton</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,333.5)">
+    <g class="tick" opacity="1" transform="translate(0,259.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">basketball</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,349.5)">
+    <g class="tick" opacity="1" transform="translate(0,271.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">hockey</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,365.5)">
+    <g class="tick" opacity="1" transform="translate(0,283.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">modern pentathlon</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,381.5)">
+    <g class="tick" opacity="1" transform="translate(0,295.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">table tennis</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,397.5)">
+    <g class="tick" opacity="1" transform="translate(0,307.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">taekwondo</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,413.5)">
+    <g class="tick" opacity="1" transform="translate(0,319.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">triathlon</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,429.5)">
+    <g class="tick" opacity="1" transform="translate(0,331.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">volleyball</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,445.5)">
+    <g class="tick" opacity="1" transform="translate(0,343.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">fencing</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(0,461.5)">
+    <g class="tick" opacity="1" transform="translate(0,355.5)">
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">gymnastics</text>
     </g>
   </g>
-  <g transform="translate(0,470)" fill="none" text-anchor="middle">
+  <g transform="translate(0,366)" fill="none" text-anchor="middle">
     <g class="tick" opacity="1" transform="translate(100.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">0</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">0</text>
     </g>
     <g class="tick" opacity="1" transform="translate(152.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
     </g>
     <g class="tick" opacity="1" transform="translate(204.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">20</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">20</text>
     </g>
     <g class="tick" opacity="1" transform="translate(256.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">30</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">30</text>
     </g>
     <g class="tick" opacity="1" transform="translate(308.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">40</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">40</text>
     </g>
     <g class="tick" opacity="1" transform="translate(360.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">50</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">50</text>
     </g>
     <g class="tick" opacity="1" transform="translate(412.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">60</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">60</text>
     </g>
     <g class="tick" opacity="1" transform="translate(464.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">70</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">70</text>
     </g>
     <g class="tick" opacity="1" transform="translate(516.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">80</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">80</text>
     </g>
     <g class="tick" opacity="1" transform="translate(568.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">90</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">90</text>
     </g>
     <g class="tick" opacity="1" transform="translate(620.5,0)">
       <line stroke="currentColor" y2="6"></line>
-      <line stroke="currentColor" y2="-450" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">100</text>
+      <line stroke="currentColor" y2="-346" stroke-opacity="0.1"></line><text fill="currentColor" y="9" dy="0.71em">100</text>
     </g><text fill="currentColor" transform="translate(640,30)" dy="-0.32em" text-anchor="end">Women (%) →</text>
   </g>
-  <g>
-    <rect x="100" width="257.66089965397924" y="262" height="14"></rect>
-    <rect x="100" width="260" y="294" height="14"></rect>
-    <rect x="100" width="250.20736352094798" y="214" height="14"></rect>
-    <rect x="100" width="260" y="310" height="14"></rect>
-    <rect x="100" width="260" y="326" height="14"></rect>
-    <rect x="100" width="65.45454545454547" y="22" height="14"></rect>
-    <rect x="100" width="174.380664652568" y="54" height="14"></rect>
-    <rect x="100" width="198.09523809523807" y="70" height="14"></rect>
-    <rect x="100" width="199.09909909909908" y="86" height="14"></rect>
-    <rect x="100" width="262.1138211382114" y="438" height="14"></rect>
-    <rect x="100" width="224.68085106382972" y="182" height="14"></rect>
-    <rect x="100" width="255.66666666666663" y="230" height="14"></rect>
-    <rect x="100" width="337.037037037037" y="454" height="14"></rect>
-    <rect x="100" width="257.8512396694215" y="278" height="14"></rect>
-    <rect x="100" width="260" y="342" height="14"></rect>
-    <rect x="100" width="202.9591836734694" y="118" height="14"></rect>
-    <rect x="100" width="260" y="358" height="14"></rect>
-    <rect x="100" width="205.33820840950642" y="134" height="14"></rect>
-    <rect x="100" width="256.5333333333333" y="246" height="14"></rect>
-    <rect x="100" width="223.05263157894734" y="166" height="14"></rect>
-    <rect x="100" width="201.33333333333337" y="102" height="14"></rect>
-    <rect x="100" width="260" y="374" height="14"></rect>
-    <rect x="100" width="260" y="390" height="14"></rect>
-    <rect x="100" width="241.42857142857144" y="198" height="14"></rect>
-    <rect x="100" width="260" y="406" height="14"></rect>
-    <rect x="100" width="260" y="422" height="14"></rect>
-    <rect x="100" width="209.61240310077517" y="150" height="14"></rect>
-    <rect x="100" width="167.93201133144476" y="38" height="14"></rect>
+  <g stroke="currentColor" stroke-dasharray="2,2" transform="translate(0.5,0)">
+    <line x1="360" x2="360" y1="20" y2="366"></line>
+  </g>
+  <g fill="black" transform="translate(0.5,0.5)">
+    <circle cx="357.66089965397924" cy="211" r="2"></circle>
+    <circle cx="360" cy="235" r="2"></circle>
+    <circle cx="350.207363520948" cy="175" r="2"></circle>
+    <circle cx="360" cy="247" r="2"></circle>
+    <circle cx="360" cy="259" r="2"></circle>
+    <circle cx="165.45454545454547" cy="31" r="2"></circle>
+    <circle cx="274.380664652568" cy="55" r="2"></circle>
+    <circle cx="298.0952380952381" cy="67" r="2"></circle>
+    <circle cx="299.0990990990991" cy="79" r="2"></circle>
+    <circle cx="362.1138211382114" cy="343" r="2"></circle>
+    <circle cx="324.6808510638297" cy="151" r="2"></circle>
+    <circle cx="355.66666666666663" cy="187" r="2"></circle>
+    <circle cx="437.037037037037" cy="355" r="2"></circle>
+    <circle cx="357.8512396694215" cy="223" r="2"></circle>
+    <circle cx="360" cy="271" r="2"></circle>
+    <circle cx="302.9591836734694" cy="103" r="2"></circle>
+    <circle cx="360" cy="283" r="2"></circle>
+    <circle cx="305.3382084095064" cy="115" r="2"></circle>
+    <circle cx="356.5333333333333" cy="199" r="2"></circle>
+    <circle cx="323.05263157894734" cy="139" r="2"></circle>
+    <circle cx="301.33333333333337" cy="91" r="2"></circle>
+    <circle cx="360" cy="295" r="2"></circle>
+    <circle cx="360" cy="307" r="2"></circle>
+    <circle cx="341.42857142857144" cy="163" r="2"></circle>
+    <circle cx="360" cy="319" r="2"></circle>
+    <circle cx="360" cy="331" r="2"></circle>
+    <circle cx="309.61240310077517" cy="127" r="2"></circle>
+    <circle cx="267.93201133144476" cy="43" r="2"></circle>
+  </g>
+  <g stroke="currentColor" transform="translate(0,0.5)">
+    <line x1="357.66089965397924" x2="360" y1="211" y2="211"></line>
+    <line x1="360" x2="360" y1="235" y2="235"></line>
+    <line x1="350.207363520948" x2="360" y1="175" y2="175"></line>
+    <line x1="360" x2="360" y1="247" y2="247"></line>
+    <line x1="360" x2="360" y1="259" y2="259"></line>
+    <line x1="165.45454545454547" x2="360" y1="31" y2="31"></line>
+    <line x1="274.380664652568" x2="360" y1="55" y2="55"></line>
+    <line x1="298.0952380952381" x2="360" y1="67" y2="67"></line>
+    <line x1="299.0990990990991" x2="360" y1="79" y2="79"></line>
+    <line x1="362.1138211382114" x2="360" y1="343" y2="343"></line>
+    <line x1="324.6808510638297" x2="360" y1="151" y2="151"></line>
+    <line x1="355.66666666666663" x2="360" y1="187" y2="187"></line>
+    <line x1="437.037037037037" x2="360" y1="355" y2="355"></line>
+    <line x1="357.8512396694215" x2="360" y1="223" y2="223"></line>
+    <line x1="360" x2="360" y1="271" y2="271"></line>
+    <line x1="302.9591836734694" x2="360" y1="103" y2="103"></line>
+    <line x1="360" x2="360" y1="283" y2="283"></line>
+    <line x1="305.3382084095064" x2="360" y1="115" y2="115"></line>
+    <line x1="356.5333333333333" x2="360" y1="199" y2="199"></line>
+    <line x1="323.05263157894734" x2="360" y1="139" y2="139"></line>
+    <line x1="301.33333333333337" x2="360" y1="91" y2="91"></line>
+    <line x1="360" x2="360" y1="295" y2="295"></line>
+    <line x1="360" x2="360" y1="307" y2="307"></line>
+    <line x1="341.42857142857144" x2="360" y1="163" y2="163"></line>
+    <line x1="360" x2="360" y1="319" y2="319"></line>
+    <line x1="360" x2="360" y1="331" y2="331"></line>
+    <line x1="309.61240310077517" x2="360" y1="127" y2="127"></line>
+    <line x1="267.93201133144476" x2="360" y1="43" y2="43"></line>
   </g>
 </svg>

--- a/test/plots/athletes-sport-sex.js
+++ b/test/plots/athletes-sport-sex.js
@@ -3,10 +3,8 @@ import * as d3 from "d3";
 
 export default async function() {
   const athletes = await d3.csv("data/athletes.csv", d3.autoType);
-  const female = data => d3.mean(data, d => d.sex === "female");
   return Plot.plot({
     marginLeft: 100,
-    height: 500,
     x: {
       label: "Women (%) →",
       domain: [0, 100],
@@ -16,10 +14,13 @@ export default async function() {
     },
     y: {
       label: null,
-      domain: d3.groupSort(athletes, female, d => d.sport)
+      domain: d3.groupSort(athletes, g => d3.mean(g, d => d.sex === "female"), d => d.sport),
+      round: true
     },
     marks: [
-      Plot.barX(athletes, Plot.groupY({x: female}, {y: "sport"}))
+      Plot.ruleX([.5], {strokeDasharray: [2, 2]}),
+      Plot.dot(athletes, Plot.groupY({x: g => d3.mean(g, d => d === "female")}, {y: "sport", x: "sex", r: 2, fill: "black"})),
+      Plot.ruleY(athletes, Plot.groupY({x: g => d3.mean(g, d => d === "female")}, {y: "sport", x: "sex", x1: () => .5}))
     ]
   });
 }


### PR DESCRIPTION
I feel this does a better service to this aspect of the data?
<img width="662" alt="Capture d’écran 2021-04-20 à 22 42 50" src="https://user-images.githubusercontent.com/7001/115461466-bf31c180-a229-11eb-806f-8a08a1419c98.png">


compared to main:
<img width="649" alt="Capture d’écran 2021-04-20 à 22 43 42" src="https://user-images.githubusercontent.com/7001/115461618-e9837f00-a229-11eb-86b4-8fac829b5fb9.png">
