### PR TITLE
add mark.plot shorthand

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -1,5 +1,6 @@
 import {color} from "d3";
 import {ascendingDefined, nonempty} from "./defined.js";
+import {plot} from "./plot.js";
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 const TypedArray = Object.getPrototypeOf(Uint8Array);
@@ -44,6 +45,9 @@ export class Mark {
         return [name == null ? undefined : name + "", Channel(data, channel)];
       })
     };
+  }
+  plot({marks = [], ...options} = {}) {
+    return plot({...options, marks: [...marks, this]});
   }
 }
 


### PR DESCRIPTION
Goes against parsimony and arguably makes it harder to transition from one mark to more than one mark, but it means you can say

```js
Plot.line(AAPL, {x: "Date", y: "Close"}).plot()
```

instead of

```js
Plot.plot({marks: [Plot.line(AAPL, {x: "Date", y: "Close"})]})
```