### PR TITLE
Add constant shorthand.

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -63,6 +63,7 @@ export function valueof(data, value, type) {
   const array = type === undefined ? Array : type;
   return typeof value === "string" ? array.from(data, field(value))
     : typeof value === "function" ? array.from(data, value)
+    : typeof value === "number" || value instanceof Date ? array.from(data, constant(value))
     : value && typeof value.transform === "function" ? arrayify(value.transform(data), type)
     : arrayify(value, type); // preserve undefined type
 }


### PR DESCRIPTION
For example, now you can say

```js
Plot.area(AAPL, {x1: "Date", y1: 0, y2: "Close"})
```

instead of

```js
Plot.area(AAPL, {x1: "Date", y1: () => 0, y2: "Close"})
```