### PR TITLE
tweak autoHeight

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -138,7 +138,7 @@ function ScaleFunctions(scales) {
 }
 
 function autoHeight({y, fy, fx}) {
-  const ny = y && y.type === "ordinal" ? y.scale.domain().length : 6;
+  const ny = y && y.type === "ordinal" ? y.scale.domain().length : 17;
   const nfy = fy ? fy.scale.domain().length : 1;
   return !!(y || fy) * Math.max(1, Math.min(60, ny * nfy)) * 20 + !!fx * 30 + 60;
 }


### PR DESCRIPTION
Here are my proposed tweaks after trying this locally on a few more edge cases:

```js
Plot.barX([], {y: "letter", x: "frequency"})
```
```js
Plot.barX(alphabet.slice(0, 1), {y: "letter", x: "frequency"})
```
```js
Plot.barX([].concat(alphabet, alphabet), {y: (d, i) => i, x: "frequency"}).plot()
```

To summarize my changes:

1. An ordinal scale with an empty domain should still be considered an ordinal scale.
2. I like letting the chart get really short (if _y_ has cardinality 1, it’s effectively like having no _y_ scale).
3. I found it more intuitive to clamp in terms of the expected cardinality ([1, 60]).
4. I increased the target step size from 16 to 20 because 16 felt too cramped.