### PR TITLE
add a {line: true} option to axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Plot automatically generates axes for position scales. You can configure these a
 * *scale*.**tickFormat** - how to format tick values as a string (a function or format specifier)
 * *scale*.**tickRotate** - whether to rotate tick labels (an angle in degrees clockwise; default 0)
 * *scale*.**grid** - if true, draw grid lines across the plot for each tick
-* *scale*.**axisLine** - if true, draw the axis line
+* *scale*.**line** - if true, draw the axis line
 * *scale*.**label** - a string to label the axis
 * *scale*.**labelAnchor** - the label anchor: *top*, *right*, *bottom*, *left*, or *center*
 * *scale*.**labelOffset** - the label position offset (in pixels; default 0, typically for facet axes)

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Plot automatically generates axes for position scales. You can configure these a
 * *scale*.**tickFormat** - how to format tick values as a string (a function or format specifier)
 * *scale*.**tickRotate** - whether to rotate tick labels (an angle in degrees clockwise; default 0)
 * *scale*.**grid** - if true, draw grid lines across the plot for each tick
+* *scale*.**support** - if true, draw the axis’ support line
 * *scale*.**label** - a string to label the axis
 * *scale*.**labelAnchor** - the label anchor: *top*, *right*, *bottom*, *left*, or *center*
 * *scale*.**labelOffset** - the label position offset (in pixels; default 0, typically for facet axes)

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Plot automatically generates axes for position scales. You can configure these a
 * *scale*.**tickFormat** - how to format tick values as a string (a function or format specifier)
 * *scale*.**tickRotate** - whether to rotate tick labels (an angle in degrees clockwise; default 0)
 * *scale*.**grid** - if true, draw grid lines across the plot for each tick
-* *scale*.**support** - if true, draw the axis’ support line
+* *scale*.**axisLine** - if true, draw the axis line
 * *scale*.**label** - a string to label the axis
 * *scale*.**labelAnchor** - the label anchor: *top*, *right*, *bottom*, *left*, or *center*
 * *scale*.**labelOffset** - the label position offset (in pixels; default 0, typically for facet axes)

--- a/src/axis.js
+++ b/src/axis.js
@@ -14,7 +14,7 @@ export class AxisX {
     label,
     labelAnchor,
     labelOffset,
-    support,
+    axisLine,
     tickRotate
   } = {}) {
     this.name = name;
@@ -27,7 +27,7 @@ export class AxisX {
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "left", "right"]);
     this.labelOffset = number(labelOffset);
-    this.support = boolean(support);
+    this.axisLine = boolean(axisLine);
     this.tickRotate = number(tickRotate);
   }
   render(
@@ -53,7 +53,7 @@ export class AxisX {
       label,
       labelAnchor,
       labelOffset,
-      support,
+      axisLine,
       tickRotate
     } = this;
     const offset = this.name === "x" ? 0 : axis === "top" ? marginTop - facetMarginTop : marginBottom - facetMarginBottom;
@@ -65,7 +65,7 @@ export class AxisX {
         .call(maybeTickRotate, tickRotate)
         .attr("font-size", null)
         .attr("font-family", null)
-        .call(!support ? g => g.select(".domain").remove() : () => {})
+        .call(!axisLine ? g => g.select(".domain").remove() : () => {})
         .call(!grid ? () => {}
           : fy ? gridFacetX(fy, -ty)
           : gridX(offsetSign * (marginBottom + marginTop - height)))
@@ -97,7 +97,7 @@ export class AxisY {
     label,
     labelAnchor,
     labelOffset,
-    support,
+    axisLine,
     tickRotate
   } = {}) {
     this.name = name;
@@ -110,7 +110,7 @@ export class AxisY {
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "top", "bottom"]);
     this.labelOffset = number(labelOffset);
-    this.support = boolean(support);
+    this.axisLine = boolean(axisLine);
     this.tickRotate = number(tickRotate);
   }
   render(
@@ -134,7 +134,7 @@ export class AxisY {
       label,
       labelAnchor,
       labelOffset,
-      support,
+      axisLine,
       tickRotate
     } = this;
     const offset = this.name === "y" ? 0 : axis === "left" ? marginLeft - facetMarginLeft : marginRight - facetMarginRight;
@@ -146,7 +146,7 @@ export class AxisY {
         .call(maybeTickRotate, tickRotate)
         .attr("font-size", null)
         .attr("font-family", null)
-        .call(!support ? g => g.select(".domain").remove() : () => {})
+        .call(!axisLine ? g => g.select(".domain").remove() : () => {})
         .call(!grid ? () => {}
           : fx ? gridFacetY(fx, -tx)
           : gridY(offsetSign * (marginLeft + marginRight - width)))

--- a/src/axis.js
+++ b/src/axis.js
@@ -14,6 +14,7 @@ export class AxisX {
     label,
     labelAnchor,
     labelOffset,
+    support,
     tickRotate
   } = {}) {
     this.name = name;
@@ -26,6 +27,7 @@ export class AxisX {
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "left", "right"]);
     this.labelOffset = number(labelOffset);
+    this.support = boolean(support);
     this.tickRotate = number(tickRotate);
   }
   render(
@@ -51,6 +53,7 @@ export class AxisX {
       label,
       labelAnchor,
       labelOffset,
+      support,
       tickRotate
     } = this;
     const offset = this.name === "x" ? 0 : axis === "top" ? marginTop - facetMarginTop : marginBottom - facetMarginBottom;
@@ -62,7 +65,7 @@ export class AxisX {
         .call(maybeTickRotate, tickRotate)
         .attr("font-size", null)
         .attr("font-family", null)
-        .call(g => g.select(".domain").remove())
+        .call(!support ? g => g.select(".domain").remove() : () => {})
         .call(!grid ? () => {}
           : fy ? gridFacetX(fy, -ty)
           : gridX(offsetSign * (marginBottom + marginTop - height)))
@@ -94,6 +97,7 @@ export class AxisY {
     label,
     labelAnchor,
     labelOffset,
+    support,
     tickRotate
   } = {}) {
     this.name = name;
@@ -106,6 +110,7 @@ export class AxisY {
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "top", "bottom"]);
     this.labelOffset = number(labelOffset);
+    this.support = boolean(support);
     this.tickRotate = number(tickRotate);
   }
   render(
@@ -129,6 +134,7 @@ export class AxisY {
       label,
       labelAnchor,
       labelOffset,
+      support,
       tickRotate
     } = this;
     const offset = this.name === "y" ? 0 : axis === "left" ? marginLeft - facetMarginLeft : marginRight - facetMarginRight;
@@ -140,7 +146,7 @@ export class AxisY {
         .call(maybeTickRotate, tickRotate)
         .attr("font-size", null)
         .attr("font-family", null)
-        .call(g => g.select(".domain").remove())
+        .call(!support ? g => g.select(".domain").remove() : () => {})
         .call(!grid ? () => {}
           : fx ? gridFacetY(fx, -tx)
           : gridY(offsetSign * (marginLeft + marginRight - width)))

--- a/src/axis.js
+++ b/src/axis.js
@@ -14,7 +14,7 @@ export class AxisX {
     label,
     labelAnchor,
     labelOffset,
-    axisLine,
+    line,
     tickRotate
   } = {}) {
     this.name = name;
@@ -27,7 +27,7 @@ export class AxisX {
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "left", "right"]);
     this.labelOffset = number(labelOffset);
-    this.axisLine = boolean(axisLine);
+    this.line = boolean(line);
     this.tickRotate = number(tickRotate);
   }
   render(
@@ -53,7 +53,7 @@ export class AxisX {
       label,
       labelAnchor,
       labelOffset,
-      axisLine,
+      line,
       tickRotate
     } = this;
     const offset = this.name === "x" ? 0 : axis === "top" ? marginTop - facetMarginTop : marginBottom - facetMarginBottom;
@@ -65,7 +65,7 @@ export class AxisX {
         .call(maybeTickRotate, tickRotate)
         .attr("font-size", null)
         .attr("font-family", null)
-        .call(!axisLine ? g => g.select(".domain").remove() : () => {})
+        .call(!line ? g => g.select(".domain").remove() : () => {})
         .call(!grid ? () => {}
           : fy ? gridFacetX(fy, -ty)
           : gridX(offsetSign * (marginBottom + marginTop - height)))
@@ -97,7 +97,7 @@ export class AxisY {
     label,
     labelAnchor,
     labelOffset,
-    axisLine,
+    line,
     tickRotate
   } = {}) {
     this.name = name;
@@ -110,7 +110,7 @@ export class AxisY {
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "top", "bottom"]);
     this.labelOffset = number(labelOffset);
-    this.axisLine = boolean(axisLine);
+    this.line = boolean(line);
     this.tickRotate = number(tickRotate);
   }
   render(
@@ -134,7 +134,7 @@ export class AxisY {
       label,
       labelAnchor,
       labelOffset,
-      axisLine,
+      line,
       tickRotate
     } = this;
     const offset = this.name === "y" ? 0 : axis === "left" ? marginLeft - facetMarginLeft : marginRight - facetMarginRight;
@@ -146,7 +146,7 @@ export class AxisY {
         .call(maybeTickRotate, tickRotate)
         .attr("font-size", null)
         .attr("font-family", null)
-        .call(!axisLine ? g => g.select(".domain").remove() : () => {})
+        .call(!line ? g => g.select(".domain").remove() : () => {})
         .call(!grid ? () => {}
           : fx ? gridFacetY(fx, -tx)
           : gridY(offsetSign * (marginLeft + marginRight - width)))

--- a/test/output/athletesSportWeight.svg
+++ b/test/output/athletesSportWeight.svg
@@ -86,6 +86,7 @@
     </g><text fill="currentColor" transform="translate(-100,305) rotate(-90)" dy="0.75em" text-anchor="middle">sport</text>
   </g>
   <g transform="translate(0,590)" fill="none" text-anchor="middle">
+    <path class="domain" stroke="currentColor" d="M100.5,0.5H620.5"></path>
     <g class="tick" opacity="1" transform="translate(137.11971830985914,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">40</text>
       <path stroke="currentColor" stroke-opacity="0.1" d="M0,-564v18M0,-544v18M0,-524v18M0,-504v18M0,-484v18M0,-464v18M0,-444v18M0,-424v18M0,-404v18M0,-384v18M0,-364v18M0,-344v18M0,-324v18M0,-304v18M0,-284v18M0,-264v18M0,-244v18M0,-224v18M0,-204v18M0,-184v18M0,-164v18M0,-144v18M0,-124v18M0,-104v18M0,-84v18M0,-64v18M0,-44v18M0,-24v18"></path>

--- a/test/plots/athletes-sport-weight.js
+++ b/test/plots/athletes-sport-weight.js
@@ -5,7 +5,8 @@ export default async function() {
   const athletes = await d3.csv("data/athletes.csv", d3.autoType);
   return Plot.plot({
     x: {
-      grid: true
+      grid: true,
+      axisLine: true
     },
     color: {
       scheme: "YlGnBu",

--- a/test/plots/athletes-sport-weight.js
+++ b/test/plots/athletes-sport-weight.js
@@ -6,7 +6,7 @@ export default async function() {
   return Plot.plot({
     x: {
       grid: true,
-      axisLine: true
+      line: true
     },
     color: {
       scheme: "YlGnBu",


### PR DESCRIPTION
handy for materializing the vertical axis of a bar chart with an ordinal x
note that in the case of a continuous *X*, tickX([*extent min*]) is often preferable, since it creates the support line for all x/y facets

see https://observablehq.com/@fil/axis-support-406

suggested by @ee2dev