### PR TITLE
expose color schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,31 @@ Plot.plot({
 })
 ```
 
+#### Extending schemes
+
+Ordinal and quantitative color schemes are exposed as Plot.ordinalSchemes and Plot.quantitativeSchemes, respectively, two Maps indexed by the scheme name in lowercase.
+
+Ordinal schemes are either an array of colors, or a function that receives an object with a length and returns an array of colors.
+
+To add an ordinal scheme, you can thus call:
+```js
+Plot.ordinalSchemes.set("sepia", ["#fff2eb", "#ebd4cd", "#cfb8b2", "#a7918b", "#836e69", "#614e48", "#31211c"]);
+```
+or
+```js
+Plot.ordinalSchemes.set("sepia", ({length}) => {
+  if (length === 3) return ["#fff2eb", "#a7918b", "#31211c"];
+  else return ["#fff2eb", "#ebd4cd", "#cfb8b2", "#a7918b", "#836e69", "#614e48", "#31211c"];
+});
+```
+
+Quantitative schemes are color interpolators, functions that receive a number between 0 and 1, and return a color.
+
+To add a quantitative scheme, you can call:
+```js
+Plot.ordinalSchemes.set("sepia", d3.piecewise(["#fff2eb", "#ebd4cd", "#cfb8b2", "#a7918b", "#836e69", "#614e48", "#31211c"]));
+```
+
 ### Facet options
 
 The *facet* option enables [faceting](https://observablehq.com/@data-workflows/plot-facets). When faceting, two additional band scales may be configured:

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ export {group, groupX, groupY, groupZ} from "./transforms/group.js";
 export {normalizeX, normalizeY} from "./transforms/normalize.js";
 export {map, mapX, mapY} from "./transforms/map.js";
 export {windowX, windowY} from "./transforms/window.js";
+export {ordinalSchemes, quantitativeSchemes} from "./scales/schemes.js";
 export {selectFirst, selectLast, selectMaxX, selectMaxY, selectMinX, selectMinY} from "./transforms/select.js";
 export {stackX, stackX1, stackX2, stackY, stackY1, stackY2} from "./transforms/stack.js";
 export {formatIsoDate, formatWeekday, formatMonth} from "./format.js";

--- a/src/scales/schemes.js
+++ b/src/scales/schemes.js
@@ -77,7 +77,7 @@ import {
   schemeYlOrRd
 } from "d3";
 
-const ordinalSchemes = new Map([
+export const ordinalSchemes = new Map([
   // categorical
   ["accent", schemeAccent],
   ["category10", schemeCategory10],
@@ -182,7 +182,7 @@ export function ordinalRange(scheme, length) {
   return r.length !== length ? r.slice(length) : r;
 }
 
-const quantitativeSchemes = new Map([
+export const quantitativeSchemes = new Map([
   // diverging
   ["brbg", interpolateBrBG],
   ["prgn", interpolatePRGn],


### PR DESCRIPTION
Maybe we should tighten the API a bit, for example when an ordinal scheme receives a domain's length it receives in fact the domain in most cases, but we wouldn't want people to think that it is always the domain, since in the case of quantile scales it is only a {length} object.

Also, I don't like the names.