### PR TITLE
cap the default number of bins at 200

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,7 @@ Plot.binX({y: "count"}, {x: {thresholds: 20, value: "culmen_length_mm"}})
 
 The **thresholds** option may be specified as a named method or a variety of other ways:
 
-* *auto* (default) - Scott’s rule, capped at 200.
+* *auto* (default) - Scott’s rule, capped at 200
 * *freedman-diaconis* - the [Freedman–Diaconis rule](https://en.wikipedia.org/wiki/Freedman–Diaconis_rule)
 * *scott* - [Scott’s normal reference rule](https://en.wikipedia.org/wiki/Histogram#Scott.27s_normal_reference_rule)
 * *sturges* - [Sturges’ formula](https://en.wikipedia.org/wiki/Histogram#Sturges.27_formula)

--- a/README.md
+++ b/README.md
@@ -1039,6 +1039,7 @@ Plot.binX({y: "count"}, {x: {thresholds: 20, value: "culmen_length_mm"}})
 
 The **thresholds** option may be specified as a named method or a variety of other ways:
 
+* *auto* (default) - Scott’s rule, capped at 200.
 * *freedman-diaconis* - the [Freedman–Diaconis rule](https://en.wikipedia.org/wiki/Freedman–Diaconis_rule)
 * *scott* - [Scott’s normal reference rule](https://en.wikipedia.org/wiki/Histogram#Scott.27s_normal_reference_rule)
 * *sturges* - [Sturges’ formula](https://en.wikipedia.org/wiki/Histogram#Sturges.27_formula)
@@ -1047,7 +1048,7 @@ The **thresholds** option may be specified as a named method or a variety of oth
 * a time interval (for temporal binning)
 * a function that returns an array, count, or time interval
 
-If the **thresholds** option is not specified, it defaults to *scott*, capped at 200. If a function, it is passed three arguments: the array of input values, the domain minimum, and the domain maximum. If a number, [d3.ticks](https://github.com/d3/d3-array/blob/master/README.md#ticks) or [d3.utcTicks](https://github.com/d3/d3-time/blob/master/README.md#ticks) is used to choose suitable nice thresholds.
+If the **thresholds** option is specified as a function, it is passed three arguments: the array of input values, the domain minimum, and the domain maximum. If a number, [d3.ticks](https://github.com/d3/d3-array/blob/master/README.md#ticks) or [d3.utcTicks](https://github.com/d3/d3-time/blob/master/README.md#ticks) is used to choose suitable nice thresholds.
 
 The bin transform supports grouping in addition to binning: you can subdivide bins by up to two additional ordinal or categorical dimensions (not including faceting). If any of **z**, **fill**, or **stroke** is a channel, the first of these channels will be used to subdivide bins. Similarly, Plot.binX will group on **y** if **y** is not an output channel, and Plot.binY will group on **x** if **x** is not an output channel. For example, for a stacked histogram:
 

--- a/README.md
+++ b/README.md
@@ -1047,7 +1047,7 @@ The **thresholds** option may be specified as a named method or a variety of oth
 * a time interval (for temporal binning)
 * a function that returns an array, count, or time interval
 
-If the **thresholds** option is not specified, it defaults to *scott*. If a function, it is passed three arguments: the array of input values, the domain minimum, and the domain maximum. If a number, [d3.ticks](https://github.com/d3/d3-array/blob/master/README.md#ticks) or [d3.utcTicks](https://github.com/d3/d3-time/blob/master/README.md#ticks) is used to choose suitable nice thresholds.
+If the **thresholds** option is not specified, it defaults to *scott*, capped at 200. If a function, it is passed three arguments: the array of input values, the domain minimum, and the domain maximum. If a number, [d3.ticks](https://github.com/d3/d3-array/blob/master/README.md#ticks) or [d3.utcTicks](https://github.com/d3/d3-time/blob/master/README.md#ticks) is used to choose suitable nice thresholds.
 
 The bin transform supports grouping in addition to binning: you can subdivide bins by up to two additional ordinal or categorical dimensions (not including faceting). If any of **z**, **fill**, or **stroke** is a channel, the first of these channels will be used to subdivide bins. Similarly, Plot.binX will group on **y** if **y** is not an output channel, and Plot.binY will group on **x** if **x** is not an output channel. For example, for a stacked histogram:
 

--- a/src/transforms/bin.js
+++ b/src/transforms/bin.js
@@ -171,7 +171,10 @@ function maybeBin(options) {
   return bin;
 }
 
-function maybeThresholds(thresholds = thresholdScott) {
+function maybeThresholds(thresholds) {
+  if (thresholds === undefined) {
+    return (...args) => Math.min(200, thresholdScott(...args));
+  }
   if (typeof thresholds === "string") {
     switch (thresholds.toLowerCase()) {
       case "freedman-diaconis": return thresholdFreedmanDiaconis;

--- a/src/transforms/bin.js
+++ b/src/transforms/bin.js
@@ -172,9 +172,7 @@ function maybeBin(options) {
 }
 
 function maybeThresholds(thresholds) {
-  if (thresholds === undefined) {
-    return (...args) => Math.min(200, thresholdScott(...args));
-  }
+  if (thresholds === undefined) return thresholdDefault;
   if (typeof thresholds === "string") {
     switch (thresholds.toLowerCase()) {
       case "freedman-diaconis": return thresholdFreedmanDiaconis;
@@ -184,6 +182,10 @@ function maybeThresholds(thresholds) {
     throw new Error("invalid thresholds");
   }
   return thresholds; // pass array, count, or function to bin.thresholds
+}
+
+function thresholdDefault(values, min, max) {
+  return Math.min(200, thresholdScott(values, min, max));
 }
 
 function isTimeInterval(t) {

--- a/src/transforms/bin.js
+++ b/src/transforms/bin.js
@@ -171,8 +171,7 @@ function maybeBin(options) {
   return bin;
 }
 
-function maybeThresholds(thresholds) {
-  if (thresholds === undefined) return thresholdDefault;
+function maybeThresholds(thresholds = thresholdDefault) {
   if (typeof thresholds === "string") {
     switch (thresholds.toLowerCase()) {
       case "freedman-diaconis": return thresholdFreedmanDiaconis;

--- a/src/transforms/bin.js
+++ b/src/transforms/bin.js
@@ -177,6 +177,7 @@ function maybeThresholds(thresholds = thresholdDefault) {
       case "freedman-diaconis": return thresholdFreedmanDiaconis;
       case "scott": return thresholdScott;
       case "sturges": return thresholdSturges;
+      case "auto": return thresholdDefault;
     }
     throw new Error("invalid thresholds");
   }

--- a/src/transforms/bin.js
+++ b/src/transforms/bin.js
@@ -171,20 +171,20 @@ function maybeBin(options) {
   return bin;
 }
 
-function maybeThresholds(thresholds = thresholdDefault) {
+function maybeThresholds(thresholds = thresholdAuto) {
   if (typeof thresholds === "string") {
     switch (thresholds.toLowerCase()) {
       case "freedman-diaconis": return thresholdFreedmanDiaconis;
       case "scott": return thresholdScott;
       case "sturges": return thresholdSturges;
-      case "auto": return thresholdDefault;
+      case "auto": return thresholdAuto;
     }
     throw new Error("invalid thresholds");
   }
   return thresholds; // pass array, count, or function to bin.thresholds
 }
 
-function thresholdDefault(values, min, max) {
+function thresholdAuto(values, min, max) {
   return Math.min(200, thresholdScott(values, min, max));
 }
 


### PR DESCRIPTION
(see #417)

(200 is working for almost any chart size; 100 would be a fine choice too)