### PR TITLE
create a non-empty bar if the domain is collapsed

### DIFF
--- a/src/transforms/bin.js
+++ b/src/transforms/bin.js
@@ -225,6 +225,7 @@ function bincumset([bin], j, bins) {
 }
 
 function binfilter([{x0, x1}, set]) {
+  if (x0 === x1) x0 -= .5, x1 += .5;
   return [x0, x1, I => I.filter(set.has, set)]; // TODO optimize
 }
 


### PR DESCRIPTION
(e.g. binning of a one-element data)

degenerate case example given by @severo in https://github.com/observablehq/plot/issues/417