### PR TITLE
Use columnar data

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -54,25 +54,22 @@ export class Mark {
 
 // TODO Type coercion?
 function Channel(data, {scale, type, value}) {
-  return {
-    scale,
-    type,
-    value: valueof(data, value),
-    label: value ? value.label : undefined
-  };
+  const label = value ? value.label : undefined;
+  value = value._column !== undefined && isColumnar(data) ? data.column(value._column) : valueof(data, value);
+  return {scale, type, value, label};
 }
 
 // This allows transforms to behave equivalently to channels.
 export function valueof(data, value, type) {
   const array = type === undefined ? Array : type;
-  return typeof value === "string" ? array.from(data, field(value))
+  return typeof value === "string" ? isColumnar(data) ? data.column(value) : array.from(data, field(value))
     : typeof value === "function" ? array.from(data, value)
     : typeof value === "number" || value instanceof Date ? array.from(data, constant(value))
     : value && typeof value.transform === "function" ? arrayify(value.transform(data), type)
     : arrayify(value, type); // preserve undefined type
 }
 
-export const field = label => Object.assign(d => d[label], {label});
+export const field = label => Object.assign(d => d[label], {label, _column: label});
 export const indexOf = (d, i) => i;
 export const identity = {transform: d => d};
 export const zero = () => 0;
@@ -135,7 +132,7 @@ export function keyword(input, name, allowed) {
 // the specified data is null or undefined, returns the value as-is.
 export function arrayify(data, type) {
   return data == null ? data : (type === undefined
-    ? (data instanceof Array || data instanceof TypedArray) ? data : Array.from(data)
+    ? (data instanceof Array || data instanceof TypedArray || isColumnar(data)) ? data : Array.from(data)
     : (data instanceof type ? data : type.from(data)));
 }
 
@@ -182,7 +179,7 @@ export function titleGroup(L) {
 
 // Returns a Uint32Array with elements [0, 1, 2, … data.length - 1].
 export function range(data) {
-  return Uint32Array.from(data, indexOf);
+  return Uint32Array.from(data.length ? {length: data.length} : data, indexOf);
 }
 
 // Returns an array [values[index[0]], values[index[1]], …].
@@ -341,4 +338,8 @@ export function isTemporal(values) {
     if (value == null) continue;
     return value instanceof Date;
   }
+}
+
+function isColumnar(data) {
+  return typeof data.column === "function";
 }

--- a/test/columnar-test.js
+++ b/test/columnar-test.js
@@ -1,0 +1,28 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+import tape from "tape-await";
+
+tape("Plot uses the data.column accessor", test => {
+  const columnChecks = [];
+  const columnX = ["A", "B", "C", "D"];
+  const columnY = [1, 1, 2];
+  const data = {
+    length: 5,
+    column: function(field) {
+      columnChecks.push(field);
+      switch(field) {
+        case "x": return columnX;
+        case "y": return columnY;
+      } 
+    },
+    *[Symbol.iterator] () {
+      /* eslint require-yield: 0 */
+      throw new Error("The iterator should not be called");
+    }
+  };
+  const A = Plot.dot(data, {x: "x", y: "y"}).initialize();
+  test.deepEqual(A.index, d3.range(data.length));
+  test.deepEqual(columnChecks, ["x", "y"]);
+  test.strictEqual(A.channels.find(([c]) => c === "x")[1].value, columnX);
+  test.strictEqual(A.channels.find(([c]) => c === "y")[1].value, columnY);
+});


### PR DESCRIPTION
optimizes accesses to arquero tables through *Table*.column(fieldname)

closes #449