### PR TITLE
Don’t promote string channel values to functions.

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -19,9 +19,6 @@ export class Mark {
         if (optional) return false;
         throw new Error(`missing channel value: ${name}`);
       }
-      if (typeof value === "string") {
-        channel.value = field(value);
-      }
       if (name !== undefined) {
         const key = name + "";
         if (key === "__proto__") throw new Error("illegal channel name");
@@ -59,7 +56,7 @@ function Channel(data, {scale, type, value}) {
     scale,
     type,
     value: valueof(data, value),
-    label: value ? value.label : undefined
+    label: labelof(value)
   };
 }
 
@@ -73,7 +70,7 @@ export function valueof(data, value, type) {
     : arrayify(value, type); // preserve undefined type
 }
 
-export const field = label => Object.assign(d => d[label], {label});
+export const field = name => d => d[name];
 export const indexOf = (d, i) => i;
 export const identity = {transform: d => d};
 export const zero = () => 0;

--- a/test/marks/area-test.js
+++ b/test/marks/area-test.js
@@ -7,7 +7,7 @@ tape("area(data, options) has the expected defaults", test => {
   test.strictEqual(area.data, undefined);
   // test.strictEqual(area.transform, undefined);
   test.deepEqual(area.channels.map(c => c.name), ["x1", "y1"]);
-  test.deepEqual(area.channels.map(c => c.value.label), ["0", "1"]);
+  test.deepEqual(area.channels.map(c => c.value), ["0", "1"]);
   test.deepEqual(area.channels.map(c => c.scale), ["x", "y"]);
   test.strictEqual(area.curve, curveLinear);
   test.strictEqual(area.fill, undefined);
@@ -25,28 +25,28 @@ tape("area(data, options) has the expected defaults", test => {
 tape("area(data, {x1, y1, y2}) specifies an optional y2 channel", test => {
   const area = Plot.area(undefined, {x1: "0", y1: "1", y2: "2"});
   const y2 = area.channels.find(c => c.name === "y2");
-  test.strictEqual(y2.value.label, "2");
+  test.strictEqual(y2.value, "2");
   test.strictEqual(y2.scale, "y");
 });
 
 tape("area(data, {x1, x2, y1}) specifies an optional x2 channel", test => {
   const area = Plot.area(undefined, {x1: "0", x2: "1", y1: "2"});
   const x2 = area.channels.find(c => c.name === "x2");
-  test.strictEqual(x2.value.label, "1");
+  test.strictEqual(x2.value, "1");
   test.strictEqual(x2.scale, "x");
 });
 
 tape("area(data, {z}) specifies an optional z channel", test => {
   const area = Plot.area(undefined, {x1: "0", y1: "1", z: "2"});
   const z = area.channels.find(c => c.name === "z");
-  test.strictEqual(z.value.label, "2");
+  test.strictEqual(z.value, "2");
   test.strictEqual(z.scale, undefined);
 });
 
 tape("area(data, {title}) specifies an optional title channel", test => {
   const area = Plot.area(undefined, {x1: "0", y1: "1", title: "2"});
   const title = area.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "2");
+  test.strictEqual(title.value, "2");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -64,14 +64,14 @@ tape("area(data, {fill}) allows fill to be a variable color", test => {
   const area = Plot.area(undefined, {x1: "0", y1: "1", fill: "x"});
   test.strictEqual(area.fill, undefined);
   const fill = area.channels.find(c => c.name === "fill");
-  test.strictEqual(fill.value.label, "x");
+  test.strictEqual(fill.value, "x");
   test.strictEqual(fill.scale, "color");
 });
 
 tape("area(data, {fill}) implies a default z channel if fill is variable", test => {
   const area = Plot.area(undefined, {x1: "0", y1: "1", fill: "2", stroke: "3"}); // fill takes priority
   const z = area.channels.find(c => c.name === "z");
-  test.strictEqual(z.value.label, "2");
+  test.strictEqual(z.value, "2");
   test.strictEqual(z.scale, undefined);
 });
 
@@ -89,14 +89,14 @@ tape("area(data, {stroke}) allows stroke to be a variable color", test => {
   const area = Plot.area(undefined, {x1: "0", y1: "1", stroke: "x"});
   test.strictEqual(area.stroke, undefined);
   const stroke = area.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });
 
 tape("area(data, {stroke}) implies a default z channel if stroke is variable", test => {
   const area = Plot.area(undefined, {x1: "0", y1: "1", stroke: "2"});
   const z = area.channels.find(c => c.name === "z");
-  test.strictEqual(z.value.label, "2");
+  test.strictEqual(z.value, "2");
   test.strictEqual(z.scale, undefined);
 });
 
@@ -114,14 +114,14 @@ tape("areaX(data, {x, y}) defaults x1 to zero, x2 to x, and y1 to y", test => {
   test.strictEqual(x2.value.label, "0");
   test.strictEqual(x2.scale, "x");
   const y1 = area.channels.find(c => c.name === "y1");
-  test.strictEqual(y1.value.label, "1");
+  test.strictEqual(y1.value, "1");
   test.strictEqual(y1.scale, "y");
 });
 
 tape("areaY(data, {x, y}) defaults x1 to x, y1 to zero, and y2 to y", test => {
   const area = Plot.areaY(undefined, {x: "0", y: "1"});
   const x1 = area.channels.find(c => c.name === "x1");
-  test.strictEqual(x1.value.label, "0");
+  test.strictEqual(x1.value, "0");
   test.strictEqual(x1.scale, "x");
   const y1 = area.channels.find(c => c.name === "y1");
   // test.strictEqual(y1.value, 0);

--- a/test/marks/bar-test.js
+++ b/test/marks/bar-test.js
@@ -35,7 +35,7 @@ tape("barX(data, {y}) uses a band scale", test => {
 tape("barX(data, {title}) specifies an optional title channel", test => {
   const bar = Plot.barX(undefined, {title: "x"});
   const title = bar.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "x");
+  test.strictEqual(title.value, "x");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -53,7 +53,7 @@ tape("barX(data, {fill}) allows fill to be a variable color", test => {
   const bar = Plot.barX(undefined, {fill: "x"});
   test.strictEqual(bar.fill, undefined);
   const fill = bar.channels.find(c => c.name === "fill");
-  test.strictEqual(fill.value.label, "x");
+  test.strictEqual(fill.value, "x");
   test.strictEqual(fill.scale, "color");
 });
 
@@ -71,7 +71,7 @@ tape("barX(data, {stroke}) allows stroke to be a variable color", test => {
   const bar = Plot.barX(undefined, {stroke: "x"});
   test.strictEqual(bar.stroke, undefined);
   const stroke = bar.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });
 
@@ -122,7 +122,7 @@ tape("barY(data, {x}) uses a band scale", test => {
 tape("barY(data, {title}) specifies an optional title channel", test => {
   const bar = Plot.barY(undefined, {title: "x"});
   const title = bar.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "x");
+  test.strictEqual(title.value, "x");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -140,7 +140,7 @@ tape("barY(data, {fill}) allows fill to be a variable color", test => {
   const bar = Plot.barY(undefined, {fill: "x"});
   test.strictEqual(bar.fill, undefined);
   const fill = bar.channels.find(c => c.name === "fill");
-  test.strictEqual(fill.value.label, "x");
+  test.strictEqual(fill.value, "x");
   test.strictEqual(fill.scale, "color");
 });
 
@@ -158,7 +158,7 @@ tape("barY(data, {stroke}) allows stroke to be a variable color", test => {
   const bar = Plot.barY(undefined, {stroke: "x"});
   test.strictEqual(bar.stroke, undefined);
   const stroke = bar.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });
 

--- a/test/marks/cell-test.js
+++ b/test/marks/cell-test.js
@@ -29,7 +29,7 @@ tape("cell() has the expected defaults", test => {
 tape("cell(data, {title}) specifies an optional title channel", test => {
   const cell = Plot.cell(undefined, {title: "x"});
   const title = cell.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "x");
+  test.strictEqual(title.value, "x");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -47,7 +47,7 @@ tape("cell(data, {fill}) allows fill to be a variable color", test => {
   const cell = Plot.cell(undefined, {fill: "x"});
   test.strictEqual(cell.fill, undefined);
   const fill = cell.channels.find(c => c.name === "fill");
-  test.strictEqual(fill.value.label, "x");
+  test.strictEqual(fill.value, "x");
   test.strictEqual(fill.scale, "color");
 });
 
@@ -65,7 +65,7 @@ tape("cell(data, {stroke}) allows stroke to be a variable color", test => {
   const cell = Plot.cell(undefined, {stroke: "x"});
   test.strictEqual(cell.stroke, undefined);
   const stroke = cell.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });
 

--- a/test/marks/dot-test.js
+++ b/test/marks/dot-test.js
@@ -30,14 +30,14 @@ tape("dot(data, {r}) allows r to be a variable radius", test => {
   const dot = Plot.dot(undefined, {r: "x"});
   test.strictEqual(dot.r, undefined);
   const r = dot.channels.find(c => c.name === "r");
-  test.strictEqual(r.value.label, "x");
+  test.strictEqual(r.value, "x");
   test.strictEqual(r.scale, "r");
 });
 
 tape("dot(data, {title}) specifies an optional title channel", test => {
   const dot = Plot.dot(undefined, {title: "x"});
   const title = dot.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "x");
+  test.strictEqual(title.value, "x");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -55,7 +55,7 @@ tape("dot(data, {fill}) allows fill to be a variable color", test => {
   const dot = Plot.dot(undefined, {fill: "x"});
   test.strictEqual(dot.fill, undefined);
   const fill = dot.channels.find(c => c.name === "fill");
-  test.strictEqual(fill.value.label, "x");
+  test.strictEqual(fill.value, "x");
   test.strictEqual(fill.scale, "color");
 });
 
@@ -79,7 +79,7 @@ tape("dot(data, {stroke}) allows stroke to be a variable color", test => {
   const dot = Plot.dot(undefined, {stroke: "x"});
   test.strictEqual(dot.stroke, undefined);
   const stroke = dot.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });
 

--- a/test/marks/line-test.js
+++ b/test/marks/line-test.js
@@ -25,14 +25,14 @@ tape("line() has the expected defaults", test => {
 tape("line(data, {z}) specifies an optional z channel", test => {
   const line = Plot.line(undefined, {z: "2"});
   const z = line.channels.find(c => c.name === "z");
-  test.strictEqual(z.value.label, "2");
+  test.strictEqual(z.value, "2");
   test.strictEqual(z.scale, undefined);
 });
 
 tape("line(data, {title}) specifies an optional title channel", test => {
   const line = Plot.line(undefined, {title: "2"});
   const title = line.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "2");
+  test.strictEqual(title.value, "2");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -50,14 +50,14 @@ tape("line(data, {fill}) allows fill to be a variable color", test => {
   const line = Plot.line(undefined, {fill: "x"});
   test.strictEqual(line.fill, undefined);
   const fill = line.channels.find(c => c.name === "fill");
-  test.strictEqual(fill.value.label, "x");
+  test.strictEqual(fill.value, "x");
   test.strictEqual(fill.scale, "color");
 });
 
 tape("line(data, {fill}) implies a default z channel if fill is variable", test => {
   const line = Plot.line(undefined, {fill: "2"});
   const z = line.channels.find(c => c.name === "z");
-  test.strictEqual(z.value.label, "2");
+  test.strictEqual(z.value, "2");
   test.strictEqual(z.scale, undefined);
 });
 
@@ -80,14 +80,14 @@ tape("line(data, {stroke}) allows stroke to be a variable color", test => {
   const line = Plot.line(undefined, {stroke: "x", fill: "3"}); // stroke takes priority
   test.strictEqual(line.stroke, undefined);
   const stroke = line.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });
 
 tape("line(data, {stroke}) implies a default z channel if stroke is variable", test => {
   const line = Plot.line(undefined, {stroke: "2"});
   const z = line.channels.find(c => c.name === "z");
-  test.strictEqual(z.value.label, "2");
+  test.strictEqual(z.value, "2");
   test.strictEqual(z.scale, undefined);
 });
 

--- a/test/marks/link-test.js
+++ b/test/marks/link-test.js
@@ -6,7 +6,7 @@ tape("link(data, options) has the expected defaults", test => {
   test.strictEqual(link.data, undefined);
   test.strictEqual(link.transform, undefined);
   test.deepEqual(link.channels.map(c => c.name), ["x1", "y1", "x2", "y2"]);
-  test.deepEqual(link.channels.map(c => c.value.label), ["0", "1", "2", "3"]);
+  test.deepEqual(link.channels.map(c => c.value), ["0", "1", "2", "3"]);
   test.deepEqual(link.channels.map(c => c.scale), ["x", "y", "x", "y"]);
   test.strictEqual(link.fill, "none");
   test.strictEqual(link.fillOpacity, undefined);
@@ -23,7 +23,7 @@ tape("link(data, options) has the expected defaults", test => {
 tape("link(data, {title}) specifies an optional title channel", test => {
   const link = Plot.link(undefined, {x1: "0", y1: "1", x2: "2", y2: "3", title: "4"});
   const title = link.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "4");
+  test.strictEqual(title.value, "4");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -41,6 +41,6 @@ tape("link(data, {stroke}) allows stroke to be a variable color", test => {
   const link = Plot.link(undefined, {x1: "0", y1: "1", x2: "2", y2: "3", stroke: "4"});
   test.strictEqual(link.stroke, undefined);
   const stroke = link.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "4");
+  test.strictEqual(stroke.value, "4");
   test.strictEqual(stroke.scale, "color");
 });

--- a/test/marks/rect-test.js
+++ b/test/marks/rect-test.js
@@ -6,7 +6,7 @@ tape("rect(data, options) has the expected defaults", test => {
   test.strictEqual(rect.data, undefined);
   test.strictEqual(rect.transform, undefined);
   test.deepEqual(rect.channels.map(c => c.name), ["x1", "y1", "x2", "y2"]);
-  test.deepEqual(rect.channels.map(c => c.value.label), ["0", "1", "2", "3"]);
+  test.deepEqual(rect.channels.map(c => c.value), ["0", "1", "2", "3"]);
   test.deepEqual(rect.channels.map(c => c.scale), ["x", "y", "x", "y"]);
   test.strictEqual(rect.fill, undefined);
   test.strictEqual(rect.fillOpacity, undefined);
@@ -27,7 +27,7 @@ tape("rect(data, options) has the expected defaults", test => {
 tape("rect(data, {title}) specifies an optional title channel", test => {
   const rect = Plot.rect(undefined, {x1: "0", y1: "1", x2: "2", y2: "3", title: "4"});
   const title = rect.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "4");
+  test.strictEqual(title.value, "4");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -45,7 +45,7 @@ tape("rect(data, {fill}) allows fill to be a variable color", test => {
   const rect = Plot.rect(undefined, {x1: "0", y1: "1", x2: "2", y2: "3", fill: "4"});
   test.strictEqual(rect.fill, undefined);
   const fill = rect.channels.find(c => c.name === "fill");
-  test.strictEqual(fill.value.label, "4");
+  test.strictEqual(fill.value, "4");
   test.strictEqual(fill.scale, "color");
 });
 
@@ -63,6 +63,6 @@ tape("rect(data, {stroke}) allows stroke to be a variable color", test => {
   const rect = Plot.rect(undefined, {x1: "0", y1: "1", x2: "2", y2: "3", stroke: "4"});
   test.strictEqual(rect.stroke, undefined);
   const stroke = rect.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "4");
+  test.strictEqual(stroke.value, "4");
   test.strictEqual(stroke.scale, "color");
 });

--- a/test/marks/rule-test.js
+++ b/test/marks/rule-test.js
@@ -23,7 +23,7 @@ tape("ruleX() has the expected defaults", test => {
 tape("ruleX(data, {title}) specifies an optional title channel", test => {
   const rule = Plot.ruleX(undefined, {title: "x"});
   const title = rule.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "x");
+  test.strictEqual(title.value, "x");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -41,7 +41,7 @@ tape("ruleX(data, {stroke}) allows stroke to be a variable color", test => {
   const rule = Plot.ruleX(undefined, {stroke: "x"});
   test.strictEqual(rule.stroke, undefined);
   const stroke = rule.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });
 
@@ -51,7 +51,7 @@ tape("ruleX(data, {x, y}) specifies y1 = zero, y2 = y", test => {
   test.strictEqual(y1.value, 0);
   test.strictEqual(y1.scale, "y");
   const y2 = rule.channels.find(c => c.name === "y2");
-  test.strictEqual(y2.value.label, "1");
+  test.strictEqual(y2.value, "1");
   test.strictEqual(y2.scale, "y");
 });
 
@@ -61,7 +61,7 @@ tape("ruleX(data, {x, y1}) specifies y1 = zero, y2 = y1", test => {
   test.strictEqual(y1.value, 0);
   test.strictEqual(y1.scale, "y");
   const y2 = rule.channels.find(c => c.name === "y2");
-  test.strictEqual(y2.value.label, "1");
+  test.strictEqual(y2.value, "1");
   test.strictEqual(y2.scale, "y");
 });
 
@@ -71,20 +71,20 @@ tape("ruleX(data, {x, y2}) specifies y1 = zero, y2 = y2", test => {
   test.strictEqual(y1.value, 0);
   test.strictEqual(y1.scale, "y");
   const y2 = rule.channels.find(c => c.name === "y2");
-  test.strictEqual(y2.value.label, "1");
+  test.strictEqual(y2.value, "1");
   test.strictEqual(y2.scale, "y");
 });
 
 tape("ruleX(data, {x, y1, y2}) specifies x, y1, y2", test => {
   const rule = Plot.ruleX(undefined, {x: "0", y1: "1", y2: "2"});
   const x = rule.channels.find(c => c.name === "x");
-  test.strictEqual(x.value.label, "0");
+  test.strictEqual(x.value, "0");
   test.strictEqual(x.scale, "x");
   const y1 = rule.channels.find(c => c.name === "y1");
-  test.strictEqual(y1.value.label, "1");
+  test.strictEqual(y1.value, "1");
   test.strictEqual(y1.scale, "y");
   const y2 = rule.channels.find(c => c.name === "y2");
-  test.strictEqual(y2.value.label, "2");
+  test.strictEqual(y2.value, "2");
   test.strictEqual(y2.scale, "y");
 });
 
@@ -110,7 +110,7 @@ tape("ruleY() has the expected defaults", test => {
 tape("ruleY(data, {title}) specifies an optional title channel", test => {
   const rule = Plot.ruleY(undefined, {title: "x"});
   const title = rule.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "x");
+  test.strictEqual(title.value, "x");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -128,7 +128,7 @@ tape("ruleY(data, {stroke}) allows stroke to be a variable color", test => {
   const rule = Plot.ruleY(undefined, {stroke: "x"});
   test.strictEqual(rule.stroke, undefined);
   const stroke = rule.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });
 
@@ -138,7 +138,7 @@ tape("ruleY(data, {x, y}) specifies x1 = zero, x2 = x", test => {
   test.strictEqual(x1.value, 0);
   test.strictEqual(x1.scale, "x");
   const x2 = rule.channels.find(c => c.name === "x2");
-  test.strictEqual(x2.value.label, "0");
+  test.strictEqual(x2.value, "0");
   test.strictEqual(x2.scale, "x");
 });
 
@@ -148,7 +148,7 @@ tape("ruleY(data, {y, x1}) specifies x1 = zero, x2 = x1", test => {
   test.strictEqual(x1.value, 0);
   test.strictEqual(x1.scale, "x");
   const x2 = rule.channels.find(c => c.name === "x2");
-  test.strictEqual(x2.value.label, "0");
+  test.strictEqual(x2.value, "0");
   test.strictEqual(x2.scale, "x");
 });
 
@@ -158,19 +158,19 @@ tape("ruleY(data, {y, x2}) specifies x1 = zero, x2 = x2", test => {
   test.strictEqual(x1.value, 0);
   test.strictEqual(x1.scale, "x");
   const x2 = rule.channels.find(c => c.name === "x2");
-  test.strictEqual(x2.value.label, "0");
+  test.strictEqual(x2.value, "0");
   test.strictEqual(x2.scale, "x");
 });
 
 tape("ruleY(data, {x1, x2, y}) specifies x1, x2, y", test => {
   const rule = Plot.ruleY(undefined, {x1: "0", x2: "1", y: "2"});
   const x1 = rule.channels.find(c => c.name === "x1");
-  test.strictEqual(x1.value.label, "0");
+  test.strictEqual(x1.value, "0");
   test.strictEqual(x1.scale, "x");
   const x2 = rule.channels.find(c => c.name === "x2");
-  test.strictEqual(x2.value.label, "1");
+  test.strictEqual(x2.value, "1");
   test.strictEqual(x2.scale, "x");
   const y = rule.channels.find(c => c.name === "y");
-  test.strictEqual(y.value.label, "2");
+  test.strictEqual(y.value, "2");
   test.strictEqual(y.scale, "y");
 });

--- a/test/marks/text-test.js
+++ b/test/marks/text-test.js
@@ -27,7 +27,7 @@ tape("text() has the expected defaults", test => {
 tape("text(data, {title}) specifies an optional title channel", test => {
   const text = Plot.text(undefined, {title: "x"});
   const title = text.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "x");
+  test.strictEqual(title.value, "x");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -45,6 +45,6 @@ tape("text(data, {fill}) allows fill to be a variable color", test => {
   const text = Plot.text(undefined, {fill: "x"});
   test.strictEqual(text.fill, undefined);
   const fill = text.channels.find(c => c.name === "fill");
-  test.strictEqual(fill.value.label, "x");
+  test.strictEqual(fill.value, "x");
   test.strictEqual(fill.scale, "color");
 });

--- a/test/marks/tick-test.js
+++ b/test/marks/tick-test.js
@@ -25,13 +25,13 @@ tape("tickX(data, {y}) uses a band scale", test => {
   test.deepEqual(tick.channels.map(c => c.name), ["x", "y"]);
   test.deepEqual(tick.channels.map(c => c.scale), ["x", "y"]);
   test.strictEqual(tick.channels.find(c => c.name === "y").type, "band");
-  test.strictEqual(tick.channels.find(c => c.name === "y").value.label, "x");
+  test.strictEqual(tick.channels.find(c => c.name === "y").value, "x");
 });
 
 tape("tickX(data, {title}) specifies an optional title channel", test => {
   const tick = Plot.tickX(undefined, {title: "x"});
   const title = tick.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "x");
+  test.strictEqual(title.value, "x");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -49,7 +49,7 @@ tape("tickX(data, {stroke}) allows stroke to be a variable color", test => {
   const tick = Plot.tickX(undefined, {stroke: "x"});
   test.strictEqual(tick.stroke, undefined);
   const stroke = tick.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });
 
@@ -77,13 +77,13 @@ tape("tickY(data, {x}) uses a band scale", test => {
   test.deepEqual(tick.channels.map(c => c.name), ["y", "x"]);
   test.deepEqual(tick.channels.map(c => c.scale), ["y", "x"]);
   test.strictEqual(tick.channels.find(c => c.name === "x").type, "band");
-  test.strictEqual(tick.channels.find(c => c.name === "x").value.label, "y");
+  test.strictEqual(tick.channels.find(c => c.name === "x").value, "y");
 });
 
 tape("tickY(data, {title}) specifies an optional title channel", test => {
   const tick = Plot.tickY(undefined, {title: "x"});
   const title = tick.channels.find(c => c.name === "title");
-  test.strictEqual(title.value.label, "x");
+  test.strictEqual(title.value, "x");
   test.strictEqual(title.scale, undefined);
 });
 
@@ -101,6 +101,6 @@ tape("tickY(data, {stroke}) allows stroke to be a variable color", test => {
   const tick = Plot.tickY(undefined, {stroke: "x"});
   test.strictEqual(tick.stroke, undefined);
   const stroke = tick.channels.find(c => c.name === "stroke");
-  test.strictEqual(stroke.value.label, "x");
+  test.strictEqual(stroke.value, "x");
   test.strictEqual(stroke.scale, "color");
 });


### PR DESCRIPTION
Instead, leave them as-is, and let valueof (and labelof) do the work. Broken out of #451.