### PR TITLE
Nice error for null facet data

### DIFF
--- a/src/facet.js
+++ b/src/facet.js
@@ -10,7 +10,7 @@ export function facets(data, {x, y, ...options}, marks) {
 
 class Facet extends Mark {
   constructor(data, {x, y, ...options} = {}, marks = []) {
-    if (data === undefined) throw new Error("missing facet data");
+    if (data == null) throw new Error("missing facet data");
     super(
       data,
       [


### PR DESCRIPTION
There doesn’t seem any advantage to the more cryptic error if you specify facet: {data: null}, so might as well use the lax test here.

Note that facet: {data: false} does _not_ error, and is similar to facet: {data: []}. I think that’s appropriate.