### PR TITLE
handle collapsed domains

### DIFF
--- a/src/facet.js
+++ b/src/facet.js
@@ -72,7 +72,7 @@ class Facet extends Mark {
     }
     return {index, channels: [...channels, ...subchannels]};
   }
-  render(index, scales, channels, dimensions, axes) {
+  render(I, scales, channels, dimensions, axes) {
     const {marks, marksChannels, marksIndex, marksIndexByFacet} = this;
     const {fx, fy} = scales;
     const fyMargins = fy && {marginTop: 0, marginBottom: 0, height: fy.bandwidth()};

--- a/src/mark.js
+++ b/src/mark.js
@@ -326,18 +326,3 @@ export function isTemporal(values) {
     return value instanceof Date;
   }
 }
-
-// Certain marks have special behavior if a scale is collapsed, i.e. if the
-// domain is degenerate and represents only a single value such as [3, 3]; for
-// example, a rect will span the full extent of the chart along a collapsed
-// dimension (whereas a dot will simply be drawn in the center).
-export function isCollapsed(scale) {
-  const domain = scale.domain();
-  const value = scale(domain[0]);
-  for (let i = 1, n = domain.length; i < n; ++i) {
-    if (scale(domain[i]) - value) {
-      return false;
-    }
-  }
-  return true;
-}

--- a/src/mark.js
+++ b/src/mark.js
@@ -326,3 +326,18 @@ export function isTemporal(values) {
     return value instanceof Date;
   }
 }
+
+// Certain marks have special behavior if a scale is collapsed, i.e. if the
+// domain is degenerate and represents only a single value such as [3, 3]; for
+// example, a rect will span the full extent of the chart along a collapsed
+// dimension (whereas a dot will simply be drawn in the center).
+export function isCollapsed(scale) {
+  const domain = scale.domain();
+  const value = scale(domain[0]);
+  for (let i = 1, n = domain.length; i < n; ++i) {
+    if (scale(domain[i]) - value) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,6 +1,6 @@
 import {create} from "d3";
 import {filter} from "../defined.js";
-import {Mark, number} from "../mark.js";
+import {Mark, number, isCollapsed} from "../mark.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, impliedString, applyAttr, applyChannelStyles} from "../style.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
 
@@ -75,13 +75,13 @@ export class BarX extends AbstractBar {
   _positions({x1: X1, x2: X2, y: Y}) {
     return [X1, X2, Y];
   }
-  _x(scales, {x1: X1, x2: X2}) {
+  _x({x}, {x1: X1, x2: X2}, {marginLeft}) {
     const {insetLeft} = this;
-    return i => Math.min(X1[i], X2[i]) + insetLeft;
+    return isCollapsed(x) ? marginLeft + insetLeft : i => Math.min(X1[i], X2[i]) + insetLeft;
   }
-  _width(scales, {x1: X1, x2: X2}) {
+  _width({x}, {x1: X1, x2: X2}, {marginRight, marginLeft, width}) {
     const {insetLeft, insetRight} = this;
-    return i => Math.max(0, Math.abs(X2[i] - X1[i]) - insetLeft - insetRight);
+    return isCollapsed(x) ? width - marginRight - marginLeft - insetLeft - insetRight : i => Math.max(0, Math.abs(X2[i] - X1[i]) - insetLeft - insetRight);
   }
 }
 
@@ -104,13 +104,13 @@ export class BarY extends AbstractBar {
   _positions({y1: Y1, y2: Y2, x: X}) {
     return [Y1, Y2, X];
   }
-  _y(scales, {y1: Y1, y2: Y2}) {
+  _y({y}, {y1: Y1, y2: Y2}, {marginTop}) {
     const {insetTop} = this;
-    return i => Math.min(Y1[i], Y2[i]) + insetTop;
+    return isCollapsed(y) ? marginTop + insetTop : i => Math.min(Y1[i], Y2[i]) + insetTop;
   }
-  _height(scales, {y1: Y1, y2: Y2}) {
+  _height({y}, {y1: Y1, y2: Y2}, {marginTop, marginBottom, height}) {
     const {insetTop, insetBottom} = this;
-    return i => Math.max(0, Math.abs(Y2[i] - Y1[i]) - insetTop - insetBottom);
+    return isCollapsed(y) ? height - marginTop - marginBottom - insetTop - insetBottom : i => Math.max(0, Math.abs(Y2[i] - Y1[i]) - insetTop - insetBottom);
   }
 }
 

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,6 +1,7 @@
 import {create} from "d3";
 import {filter} from "../defined.js";
-import {Mark, number, isCollapsed} from "../mark.js";
+import {Mark, number} from "../mark.js";
+import {isCollapsed} from "../scales.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, impliedString, applyAttr, applyChannelStyles} from "../style.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
 

--- a/src/marks/frame.js
+++ b/src/marks/frame.js
@@ -22,20 +22,17 @@ export class Frame extends Mark {
     this.insetBottom = number(insetBottom);
     this.insetLeft = number(insetLeft);
   }
-  render(
-    index,
-    scales,
-    channels,
-    {marginTop, marginRight, marginBottom, marginLeft, width, height}
-  ) {
+  render(I, scales, channels, dimensions) {
+    const {marginTop, marginRight, marginBottom, marginLeft, width, height} = dimensions;
+    const {insetTop, insetRight, insetBottom, insetLeft} = this;
     return create("svg:rect")
         .call(applyIndirectStyles, this)
         .call(applyDirectStyles, this)
         .call(applyTransform, null, null, 0.5, 0.5)
-        .attr("x", marginLeft + this.insetLeft)
-        .attr("y", marginTop + this.insetTop)
-        .attr("width", width - marginLeft - marginRight - this.insetLeft - this.insetRight)
-        .attr("height", height - marginTop - marginBottom - this.insetTop - this.insetBottom)
+        .attr("x", marginLeft + insetLeft)
+        .attr("y", marginTop + insetTop)
+        .attr("width", width - marginLeft - marginRight - insetLeft - insetRight)
+        .attr("height", height - marginTop - marginBottom - insetTop - insetBottom)
       .node();
   }
 }

--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -1,6 +1,6 @@
 import {create} from "d3";
 import {filter} from "../defined.js";
-import {Mark, number} from "../mark.js";
+import {Mark, number, isCollapsed} from "../mark.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, impliedString, applyAttr, applyChannelStyles} from "../style.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
 
@@ -51,10 +51,10 @@ export class Rect extends Mark {
           .data(index)
           .join("rect")
             .call(applyDirectStyles, this)
-            .attr("x", X1 && X2 ? i => Math.min(X1[i], X2[i]) + insetLeft : marginLeft + insetLeft)
-            .attr("y", Y1 && Y2 ? i => Math.min(Y1[i], Y2[i]) + insetTop : marginTop + insetTop)
-            .attr("width", X1 && X2 ? i => Math.max(0, Math.abs(X2[i] - X1[i]) - insetLeft - insetRight) : width - marginRight - marginLeft - insetRight - insetLeft)
-            .attr("height", Y1 && Y2 ? i => Math.max(0, Math.abs(Y1[i] - Y2[i]) - insetTop - insetBottom) : height - marginTop - marginBottom - insetTop - insetBottom)
+            .attr("x", X1 && X2 && !isCollapsed(x) ? i => Math.min(X1[i], X2[i]) + insetLeft : marginLeft + insetLeft)
+            .attr("y", Y1 && Y2 && !isCollapsed(y) ? i => Math.min(Y1[i], Y2[i]) + insetTop : marginTop + insetTop)
+            .attr("width", X1 && X2 && !isCollapsed(x) ? i => Math.max(0, Math.abs(X2[i] - X1[i]) - insetLeft - insetRight) : width - marginRight - marginLeft - insetRight - insetLeft)
+            .attr("height", Y1 && Y2 && !isCollapsed(y) ? i => Math.max(0, Math.abs(Y1[i] - Y2[i]) - insetTop - insetBottom) : height - marginTop - marginBottom - insetTop - insetBottom)
             .call(applyAttr, "rx", rx)
             .call(applyAttr, "ry", ry)
             .call(applyChannelStyles, channels))

--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -1,6 +1,7 @@
 import {create} from "d3";
 import {filter} from "../defined.js";
-import {Mark, number, isCollapsed} from "../mark.js";
+import {Mark, number} from "../mark.js";
+import {isCollapsed} from "../scales.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, impliedString, applyAttr, applyChannelStyles} from "../style.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
 

--- a/src/marks/rule.js
+++ b/src/marks/rule.js
@@ -1,6 +1,6 @@
 import {create} from "d3";
 import {filter} from "../defined.js";
-import {Mark, identity, number} from "../mark.js";
+import {Mark, identity, number, isCollapsed} from "../mark.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyChannelStyles} from "../style.js";
 
 const defaults = {
@@ -31,13 +31,10 @@ export class RuleX extends Mark {
     this.insetTop = number(insetTop);
     this.insetBottom = number(insetBottom);
   }
-  render(
-    I,
-    {x, y},
-    channels,
-    {width, height, marginTop, marginRight, marginLeft, marginBottom}
-  ) {
+  render(I, {x, y}, channels, dimensions) {
     const {x: X, y1: Y1, y2: Y2} = channels;
+    const {width, height, marginTop, marginRight, marginLeft, marginBottom} = dimensions;
+    const {insetTop, insetBottom} = this;
     const index = filter(I, X, Y1, Y2);
     return create("svg:g")
         .call(applyIndirectStyles, this)
@@ -48,8 +45,8 @@ export class RuleX extends Mark {
             .call(applyDirectStyles, this)
             .attr("x1", X ? i => X[i] : (marginLeft + width - marginRight) / 2)
             .attr("x2", X ? i => X[i] : (marginLeft + width - marginRight) / 2)
-            .attr("y1", Y1 ? i => Y1[i] + this.insetTop : marginTop + this.insetTop)
-            .attr("y2", Y2 ? (y.bandwidth ? i => Y2[i] + y.bandwidth() - this.insetBottom : i => Y2[i] - this.insetBottom) : height - marginBottom - this.insetBottom)
+            .attr("y1", Y1 && !isCollapsed(y) ? i => Y1[i] + insetTop : marginTop + insetTop)
+            .attr("y2", Y2 && !isCollapsed(y) ? (y.bandwidth ? i => Y2[i] + y.bandwidth() - insetBottom : i => Y2[i] - insetBottom) : height - marginBottom - insetBottom)
             .call(applyChannelStyles, channels))
       .node();
   }
@@ -78,13 +75,10 @@ export class RuleY extends Mark {
     this.insetRight = number(insetRight);
     this.insetLeft = number(insetLeft);
   }
-  render(
-    I,
-    {x, y},
-    channels,
-    {width, height, marginTop, marginRight, marginLeft, marginBottom}
-  ) {
+  render(I, {x, y}, channels, dimensions) {
     const {y: Y, x1: X1, x2: X2} = channels;
+    const {width, height, marginTop, marginRight, marginLeft, marginBottom} = dimensions;
+    const {insetLeft, insetRight} = this;
     const index = filter(I, Y, X1, X2);
     return create("svg:g")
         .call(applyIndirectStyles, this)
@@ -93,8 +87,8 @@ export class RuleY extends Mark {
           .data(index)
           .join("line")
             .call(applyDirectStyles, this)
-            .attr("x1", X1 ? i => X1[i] + this.insetLeft : marginLeft + this.insetLeft)
-            .attr("x2", X2 ? (x.bandwidth ? i => X2[i] + x.bandwidth() - this.insetRight : i => X2[i] - this.insetRight) : width - marginRight - this.insetRight)
+            .attr("x1", X1 && !isCollapsed(x) ? i => X1[i] + insetLeft : marginLeft + insetLeft)
+            .attr("x2", X2 && !isCollapsed(x) ? (x.bandwidth ? i => X2[i] + x.bandwidth() - insetRight : i => X2[i] - insetRight) : width - marginRight - insetRight)
             .attr("y1", Y ? i => Y[i] : (marginTop + height - marginBottom) / 2)
             .attr("y2", Y ? i => Y[i] : (marginTop + height - marginBottom) / 2)
             .call(applyChannelStyles, channels))

--- a/src/marks/rule.js
+++ b/src/marks/rule.js
@@ -1,6 +1,7 @@
 import {create} from "d3";
 import {filter} from "../defined.js";
-import {Mark, identity, number, isCollapsed} from "../mark.js";
+import {Mark, identity, number} from "../mark.js";
+import {isCollapsed} from "../scales.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyChannelStyles} from "../style.js";
 
 const defaults = {

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -45,13 +45,9 @@ export class Text extends Mark {
     this.dx = string(dx);
     this.dy = string(dy);
   }
-  render(
-    I,
-    {x, y},
-    channels,
-    {width, height, marginTop, marginRight, marginBottom, marginLeft}
-  ) {
+  render(I, {x, y}, channels, dimensions) {
     const {x: X, y: Y, rotate: R, text: T, fontSize: FS} = channels;
+    const {width, height, marginTop, marginRight, marginBottom, marginLeft} = dimensions;
     const {rotate} = this;
     const index = filter(I, X, Y, R).filter(i => nonempty(T[i]));
     const cx = (marginLeft + width - marginRight) / 2;

--- a/src/scales.js
+++ b/src/scales.js
@@ -129,3 +129,18 @@ export function applyScales(channels = [], scales) {
   }
   return values;
 }
+
+// Certain marks have special behavior if a scale is collapsed, i.e. if the
+// domain is degenerate and represents only a single value such as [3, 3]; for
+// example, a rect will span the full extent of the chart along a collapsed
+// dimension (whereas a dot will simply be drawn in the center).
+export function isCollapsed(scale) {
+  const domain = scale.domain();
+  const value = scale(domain[0]);
+  for (let i = 1, n = domain.length; i < n; ++i) {
+    if (scale(domain[i]) - value) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/test/output/singleValueBar.svg
+++ b/test/output/singleValueBar.svg
@@ -1,0 +1,18 @@
+<svg class="plot" fill="currentColor" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g transform="translate(40,0)" fill="none" text-anchor="end">
+    <g class="tick" opacity="1" transform="translate(0,195.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g transform="translate(0,370)" fill="none" text-anchor="middle">
+    <g class="tick" opacity="1" transform="translate(330.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">foo</text>
+    </g>
+  </g>
+  <g>
+    <rect x="93" width="474" y="20" height="350"></rect>
+  </g>
+  <g stroke="red" transform="translate(237.5,0)">
+    <line x1="93" x2="93" y1="20" y2="370"></line>
+  </g>
+</svg>

--- a/test/output/singleValueBin.svg
+++ b/test/output/singleValueBin.svg
@@ -1,0 +1,45 @@
+<svg class="plot" fill="currentColor" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g transform="translate(40,0)" fill="none" text-anchor="end">
+    <g class="tick" opacity="1" transform="translate(0,370.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.0</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,335.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.1</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,300.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.2</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,265.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.3</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,230.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.4</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,195.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.5</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,160.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.6</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,125.50000000000001)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.7</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,90.49999999999999)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.8</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,55.49999999999999)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.9</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,20.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">1.0</text>
+    </g><text fill="currentColor" transform="translate(-40,20)" dy="-1em" text-anchor="start">↑ Frequency</text>
+  </g>
+  <g transform="translate(0,370)" fill="none" text-anchor="middle">
+    <g class="tick" opacity="1" transform="translate(330.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">3</text>
+    </g>
+  </g>
+  <g>
+    <rect x="41" y="20" width="579" height="350"></rect>
+  </g>
+</svg>

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -88,6 +88,8 @@ export {default as sfTemperatureBandArea} from "./sf-temperature-band-area.js";
 export {default as simpsonsRatings} from "./simpsons-ratings.js";
 export {default as simpsonsRatingsDots} from "./simpsons-ratings-dots.js";
 export {default as simpsonsViews} from "./simpsons-views.js";
+export {default as singleValueBar} from "./single-value-bar.js";
+export {default as singleValueBin} from "./single-value-bin.js";
 export {default as softwareVersions} from "./software-versions.js";
 export {default as stackedBar} from "./stacked-bar.js";
 export {default as stackedRect} from "./stacked-rect.js";

--- a/test/plots/single-value-bar.js
+++ b/test/plots/single-value-bar.js
@@ -1,0 +1,10 @@
+import * as Plot from "@observablehq/plot";
+
+export default async function() {
+  return Plot.plot({
+    marks: [
+      Plot.barY({length: 1}, {x: ["foo"], y1: [0], y2: [0]}),
+      Plot.ruleX(["foo"], {stroke: "red", y1: [0], y2: [0]})
+    ]
+  });
+}

--- a/test/plots/single-value-bin.js
+++ b/test/plots/single-value-bin.js
@@ -1,0 +1,5 @@
+import * as Plot from "@observablehq/plot";
+
+export default async function() {
+  return Plot.rectY([3], Plot.binX()).plot();
+}


### PR DESCRIPTION
Supersedes #438.
Ref. https://github.com/observablehq/plot/issues/417#issuecomment-849149359.

This adds special logic to marks with continuous position dimensions such that when the associated scale’s domain is collapsed (i.e., all values in the input domain map to the same value in the output range), the mark spans the full extent of the chart. For example, here is a plot with the collapsed _y_-domain [0, 0]; note that the bar and rule span the full _y_-extent of the chart. Previously this chart would be empty because the bar and rule would have zero height.

<img width="573" alt="Screen Shot 2021-07-31 at 9 35 21 AM" src="https://user-images.githubusercontent.com/230541/127746452-1405fb50-6364-4927-9f20-f8e4e16b1e3e.png">

```js
Plot.plot({
  marks: [
    Plot.barY({length: 1}, {x: ["foo"], y1: [0], y2: [0]}),
    Plot.ruleX(["foo"], {stroke: "red", y1: [0], y2: [0]})
  ]
})
```

In practice, this seems most likely to occur when binning values that all happen to be equal, but unlike #438 this does not change the semantics of the chart and thus is more robust and general.

The isCollapsed check could be memoized if performance is a concern in the future, given how rare it is for a scale to be collapsed. And also it’s slightly unfortunate that this logic must be applied by mark implementations rather than somehow generalizing to the scales. I think it might be possible to do this more generically, and faster, but this seems fine for now?