### PR TITLE
Shorthand for axis-aligned links

### DIFF
--- a/src/marks/link.js
+++ b/src/marks/link.js
@@ -30,8 +30,8 @@ export class Link extends Mark {
       [
         {name: "x1", value: x1, scale: "x"},
         {name: "y1", value: y1, scale: "y"},
-        {name: "x2", value: x2, scale: "x"},
-        {name: "y2", value: y2, scale: "y"},
+        {name: "x2", value: x2, scale: "x", optional: true},
+        {name: "y2", value: y2, scale: "y", optional: true},
         {name: "title", value: title, optional: true},
         {name: "fill", value: vfill, scale: "color", optional: true},
         {name: "fillOpacity", value: vfillOpacity, scale: "opacity", optional: true},
@@ -53,7 +53,7 @@ export class Link extends Mark {
   render(
     I,
     {x, y},
-    {x1: X1, y1: Y1, x2: X2, y2: Y2, title: L, stroke: S, strokeOpacity: SO}
+    {x1: X1, y1: Y1, x2: X2 = X1, y2: Y2 = Y1, title: L, stroke: S, strokeOpacity: SO}
   ) {
     const index = filter(I, X1, Y1, X2, Y2, S, SO);
     return create("svg:g")
@@ -79,6 +79,26 @@ export class Link extends Mark {
   }
 }
 
-export function link(data, options) {
-  return new Link(data, options);
+export function link(data, {x, x1, x2, y, y1, y2, ...options} = {}) {
+  ([x1, x2] = maybeSameValue(x, x1, x2));
+  ([y1, y2] = maybeSameValue(y, y1, y2));
+  return new Link(data, {...options, x1, x2, y1, y2});
+}
+
+// If x1 and x2 are specified, return them as {x1, x2}.
+// If x and x1 and specified, or x and x2 are specified, return them as {x1, x2}.
+// If only x, x1, or x2 are specified, return it as {x1}.
+function maybeSameValue(x, x1, x2) {
+  if (x === undefined) {
+    if (x1 === undefined) {
+      if (x2 !== undefined) return [x2];
+    } else {
+      if (x2 === undefined) return [x1];
+    }
+  } else if (x1 === undefined) {
+    return x2 === undefined ? [x] : [x, x2];
+  } else if (x2 === undefined) {
+    return [x, x1];
+  }
+  return [x1, x2];
 }


### PR DESCRIPTION
Fixes #428. I mirrored the approach from the area mark so that we don’t need to compute both channels when only one is needed.