### PR TITLE
reinstate the "save changed figure" functionality of tests

### DIFF
--- a/test/plot.js
+++ b/test/plot.js
@@ -37,12 +37,12 @@ import * as plots from "./plots/index.js";
           }
         }
 
-        assert(actual === expected, `${name} must match snapshot`);
         if (actual !== expected) {
           const outfile = path.resolve("./test/output", path.basename(name, ".js") + "-changed." + ext);
           console.warn(`! generating ${outfile}`);
           await fs.writeFile(outfile, actual, "utf8");
         }
+        assert(actual === expected, `${name} must match snapshot`);
       } finally {
         delete global.document;
         delete global.Node;


### PR DESCRIPTION
(I think it disappeared after 13052a87 when assert replaced test.ok)