### PR TITLE
map option for map[XY]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1239,21 +1239,21 @@ Plot.map({y: "cumsum"}, {y: d3.randomNormal()})
 
 Groups on the first channel of *z*, *fill*, or *stroke*, if any, and then for each channel declared in the specified *outputs* object, applies the corresponding map method. Each channel in *outputs* must have a corresponding input channel in *options*.
 
-#### Plot.mapX(*map*, *options*)
+#### Plot.mapX(*options*)
 
 ```js
-Plot.mapX("cumsum", {x: d3.randomNormal()})
+Plot.mapX({map: "cumsum", x: d3.randomNormal()})
 ```
 
-Equivalent to Plot.map({x: *map*, x1: *map*, x2: *map*}, *options*), but ignores any of **x**, **x1**, and **x2** not present in *options*.
+Equivalent to Plot.map({x: *map*, x1: *map*, x2: *map*}, *options*), but ignores any of **x**, **x1**, and **x2** not present in *options*. The **map** option is required.
 
-#### Plot.mapY(*map*, *options*)
+#### Plot.mapY(*options*)
 
 ```js
-Plot.mapY("cumsum", {y: d3.randomNormal()})
+Plot.mapY({map: "cumsum", y: d3.randomNormal()})
 ```
 
-Equivalent to Plot.map({y: *map*, y1: *map*, y2: *map*}, *options*), but ignores any of **y**, **y1**, and **y2** not present in *options*.
+Equivalent to Plot.map({y: *map*, y1: *map*, y2: *map*}, *options*), but ignores any of **y**, **y1**, and **y2** not present in *options*. The **map** option is required.
 
 #### Plot.normalizeX(*options*)
 
@@ -1261,7 +1261,7 @@ Equivalent to Plot.map({y: *map*, y1: *map*, y2: *map*}, *options*), but ignores
 Plot.normalizeX({y: "Date", x: "Close", stroke: "Symbol"})
 ```
 
-Like [Plot.mapX](#plotmapxmap-options), but applies the normalize map method with the given *options*.
+Like [Plot.mapX](#plotmapxmap-options), but applies the normalize map method with the given *options*. If the **basiss** option is not specified, it defaults to *first*.
 
 #### Plot.normalizeY(*options*)
 
@@ -1269,7 +1269,7 @@ Like [Plot.mapX](#plotmapxmap-options), but applies the normalize map method wit
 Plot.normalizeY({x: "Date", y: "Close", stroke: "Symbol"})
 ```
 
-Like [Plot.mapY](#plotmapymap-options), but applies the normalize map method with the given *options*.
+Like [Plot.mapY](#plotmapymap-options), but applies the normalize map method with the given *options*. If the **basiss** option is not specified, it defaults to *first*.
 
 #### Plot.windowX(*options*)
 
@@ -1277,7 +1277,7 @@ Like [Plot.mapY](#plotmapymap-options), but applies the normalize map method wit
 Plot.windowX({y: "Date", x: "Anomaly", k: 24})
 ```
 
-Like [Plot.mapX](#plotmapxmap-options), but applies the window map method with the given *options*.
+Like [Plot.mapX](#plotmapxmap-options), but applies the window map method with the given *options*. The **k** option is required to define the window size, while the **reduce** and **shift** options default to *mean* and *centered* respectively.
 
 #### Plot.windowY(*options*)
 
@@ -1285,7 +1285,7 @@ Like [Plot.mapX](#plotmapxmap-options), but applies the window map method with t
 Plot.windowY({x: "Date", y: "Anomaly", k: 24})
 ```
 
-Like [Plot.mapY](#plotmapymap-options), but applies the window map method with the given *options*.
+Like [Plot.mapY](#plotmapymap-options), but applies the window map method with the given *options*. The **k** option is required to define the window size, while the **reduce** and **shift** options default to *mean* and *centered* respectively.
 
 ### Select
 

--- a/README.md
+++ b/README.md
@@ -1261,7 +1261,7 @@ Equivalent to Plot.map({y: *map*, y1: *map*, y2: *map*}, *options*), but ignores
 Plot.normalizeX({y: "Date", x: "Close", stroke: "Symbol"})
 ```
 
-Like [Plot.mapX](#plotmapxmap-options), but applies the normalize map method with the given *options*. If the **basiss** option is not specified, it defaults to *first*.
+Like [Plot.mapX](#plotmapxmap-options), but applies the normalize map method with the given *options*. If the **basis** option is not specified, it defaults to *first*.
 
 #### Plot.normalizeY(*options*)
 
@@ -1269,7 +1269,7 @@ Like [Plot.mapX](#plotmapxmap-options), but applies the normalize map method wit
 Plot.normalizeY({x: "Date", y: "Close", stroke: "Symbol"})
 ```
 
-Like [Plot.mapY](#plotmapymap-options), but applies the normalize map method with the given *options*. If the **basiss** option is not specified, it defaults to *first*.
+Like [Plot.mapY](#plotmapymap-options), but applies the normalize map method with the given *options*. If the **basis** option is not specified, it defaults to *first*.
 
 #### Plot.windowX(*options*)
 

--- a/src/transforms/map.js
+++ b/src/transforms/map.js
@@ -1,13 +1,15 @@
 import {group} from "d3";
 import {maybeTransform, maybeZ, take, valueof, maybeInput, lazyChannel} from "../mark.js";
 
-export function mapX(m, options = {}) {
+export function mapX(m = {}, options = {}) {
+  if (arguments.length === 1) ({map: m, ...options} = m);
   return map(Object.fromEntries(["x", "x1", "x2"]
     .filter(key => options[key] != null)
     .map(key => [key, m])), options);
 }
 
-export function mapY(m, options = {}) {
+export function mapY(m = {}, options = {}) {
+  if (arguments.length === 1) ({map: m, ...options} = m);
   return map(Object.fromEntries(["y", "y1", "y2"]
     .filter(key => options[key] != null)
     .map(key => [key, m])), options);

--- a/test/plots/random-walk.js
+++ b/test/plots/random-walk.js
@@ -6,7 +6,7 @@ export default async function() {
   return Plot.plot({
     marks: [
       Plot.lineY(d3.cumsum({length: 500}, randomNormal), {stroke: "red"}),
-      Plot.lineY({length: 500}, Plot.mapY("cumsum", {y: randomNormal, stroke: "blue"}))
+      Plot.lineY({length: 500}, Plot.mapY({map: "cumsum", y: randomNormal, stroke: "blue"}))
     ]
   });
 }


### PR DESCRIPTION
Fixes #479.

My first take was to support Plot.normalizeX(*basis*, *options*) and Plot.normalizeY(*basis*, *options*). While that’s more consistent with Plot.mapX(*map*, *options*) and Plot.mapY(*map*, *options*), it’s not consistent with Plot.windowX(*options*) and Plot.windowY(*options*). So, I then decided it would be better to standardize on Plot.mapX(*options*) and Plot.mapY(*options*), and only use the two-argument form when you want to declare the output channels explicitly (e.g., Plot.map, Plot.group, and Plot.bin).

For backwards-compatibility we can continue to support the old form of Plot.mapX and Plot.mapY, but I consider it deprecated and removed it from the documentation.