### PR TITLE
alternative to bin{filter} : bin {transform}

### DIFF
--- a/test/plots/athletes-height-weight-bin-stroke.js
+++ b/test/plots/athletes-height-weight-bin-stroke.js
@@ -15,7 +15,7 @@ export default async function() {
     },
     marks: [
       Plot.rect(athletes, Plot.bin({fill: "count"}, {x: "weight", y: "height", thresholds: 50})),
-      Plot.rect(athletes, Plot.bin({filter: d => d.length > 20}, {x: "weight", y: "height", stroke: "grey", inset: 0, thresholds: 50}))
+      Plot.rect(athletes, Plot.bin({transform: bin => bin.length > 20 ? bin : null}, {x: "weight", y: "height", stroke: "grey", inset: 0, thresholds: 50}))
     ]
   });
 }

--- a/test/plots/availability.js
+++ b/test/plots/availability.js
@@ -9,7 +9,7 @@ export default async function() {
         data,
         Plot.binX(
           {
-            filter: null,
+            transform: bin => bin,
             y: "sum"
           },
           {
@@ -27,7 +27,7 @@ export default async function() {
         data,
         Plot.binX(
           {
-            filter: null,
+            transform: bin => bin,
             y: d => d.length ? d3.sum(d) : null
           },
           {


### PR DESCRIPTION
what if we did something totally different and passed the actual bin to a _transform_ option?
* the default might be `transform: bin => bin.length ? bin : null` which would remove empty bins.
* using `transform: bin => bin` or `transform: "identity" ("keep-empty")`, would keep empty bins
* using `transform: bin => bin.length < 20 ? null : bin` would do for athletesHeightWeightBinStroke

Ref https://github.com/observablehq/plot/pull/495#issuecomment-896738585