### PR TITLE
stackR on x and y

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,5 +20,5 @@ export {normalizeX, normalizeY} from "./transforms/normalize.js";
 export {map, mapX, mapY} from "./transforms/map.js";
 export {windowX, windowY} from "./transforms/window.js";
 export {selectFirst, selectLast, selectMaxX, selectMaxY, selectMinX, selectMinY} from "./transforms/select.js";
-export {stackX, stackX1, stackX2, stackY, stackY1, stackY2} from "./transforms/stack.js";
+export {stackX, stackX1, stackX2, stackY, stackY1, stackY2, stackR} from "./transforms/stack.js";
 export {formatIsoDate, formatWeekday, formatMonth} from "./format.js";

--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -6,42 +6,42 @@ import {basic} from "./basic.js";
 export function stackX(stackOptions = {}, options = {}) {
   if (arguments.length === 1) options = mergeOptions(stackOptions);
   const {y1, y = y1, x, ...rest} = options; // note: consumes x!
-  const [transform, Y, x1, x2] = stack(y, x, "x", stackOptions, rest);
+  const [transform, Y,, x1, x2] = stack(y, undefined, x, "x", stackOptions, rest);
   return {...transform, y1, y: Y, x1, x2, x: mid(x1, x2)};
 }
 
 export function stackX1(stackOptions = {}, options = {}) {
   if (arguments.length === 1) options = mergeOptions(stackOptions);
   const {y1, y = y1, x} = options;
-  const [transform, Y, X] = stack(y, x, "x", stackOptions, options);
+  const [transform, Y,, X] = stack(y, undefined, x, "x", stackOptions, options);
   return {...transform, y1, y: Y, x: X};
 }
 
 export function stackX2(stackOptions = {}, options = {}) {
   if (arguments.length === 1) options = mergeOptions(stackOptions);
   const {y1, y = y1, x} = options;
-  const [transform, Y,, X] = stack(y, x, "x", stackOptions, options);
+  const [transform, Y,,, X] = stack(y, undefined, x, "x", stackOptions, options);
   return {...transform, y1, y: Y, x: X};
 }
 
 export function stackY(stackOptions = {}, options = {}) {
   if (arguments.length === 1) options = mergeOptions(stackOptions);
   const {x1, x = x1, y, ...rest} = options; // note: consumes y!
-  const [transform, X, y1, y2] = stack(x, y, "y", stackOptions, rest);
+  const [transform, X,, y1, y2] = stack(x, undefined, y, "y", stackOptions, rest);
   return {...transform, x1, x: X, y1, y2, y: mid(y1, y2)};
 }
 
 export function stackY1(stackOptions = {}, options = {}) {
   if (arguments.length === 1) options = mergeOptions(stackOptions);
   const {x1, x = x1, y} = options;
-  const [transform, X, Y] = stack(x, y, "y", stackOptions, options);
+  const [transform, X,, Y] = stack(x, undefined, y, "y", stackOptions, options);
   return {...transform, x1, x: X, y: Y};
 }
 
 export function stackY2(stackOptions = {}, options = {}) {
   if (arguments.length === 1) options = mergeOptions(stackOptions);
   const {x1, x = x1, y} = options;
-  const [transform, X,, Y] = stack(x, y, "y", stackOptions, options);
+  const [transform, X,,, Y] = stack(x, undefined, y, "y", stackOptions, options);
   return {...transform, x1, x: X, y: Y};
 }
 
@@ -63,6 +63,13 @@ export function maybeStackY({y, y1, y2, ...options} = {}) {
   return {...options, y1, y2};
 }
 
+export function stackR(stackOptions = {}, options = {}) {
+  if (arguments.length === 1) options = mergeOptions(stackOptions);
+  const {x, y, r, ...rest} = options; // note: consumes x,y!
+  const [transform, X, Y, R1, R2] = stack(x, y, r, "r", stackOptions, rest);
+  return {...transform, x: X, y: Y, r1: R1, r: R2};
+}
+
 // The reverse option is ambiguous: it is both a stack option and a basic
 // transform. If only one options object is specified, we interpret it as a
 // stack option, and therefore must remove it from the propagated options.
@@ -71,16 +78,19 @@ function mergeOptions(options) {
   return reverse ? {...options, reverse: false} : options;
 }
 
-function stack(x, y = () => 1, ky, {offset, order, reverse}, options) {
+function stack(xa, xb, y = () => 1, ky, {offset, order, reverse}, options) {
   const z = maybeZ(options);
-  const [X, setX] = maybeLazyChannel(x);
+  const [Xa, setXa] = maybeLazyChannel(xa);
+  const [Xb, setXb] = maybeLazyChannel(xb);
   const [Y1, setY1] = lazyChannel(y);
   const [Y2, setY2] = lazyChannel(y);
   offset = maybeOffset(offset);
   order = maybeOrder(order, offset, ky);
   return [
     basic(options, (data, facets) => {
-      const X = x == null ? undefined : setX(valueof(data, x));
+      const Xa = xa == null ? undefined : setXa(valueof(data, xa));
+      const Xb = xb == null ? undefined : setXb(valueof(data, xb));
+      const X = xa == null ? Xb : xb == null ? Xa : Xa.map((a, i) => JSON.stringify([a, Xb[i]]));
       const Y = valueof(data, y, Float64Array);
       const Z = valueof(data, z);
       const O = order && order(data, X, Y, Z);
@@ -104,7 +114,8 @@ function stack(x, y = () => 1, ky, {offset, order, reverse}, options) {
       }
       return {data, facets};
     }),
-    X,
+    Xa,
+    Xb,
     Y1,
     Y2
   ];

--- a/test/output/carsMpg.svg
+++ b/test/output/carsMpg.svg
@@ -102,13 +102,13 @@
     <circle cx="110" cy="154.04255319148936" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="110" cy="139.14893617021278" r="5.196152422706632" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="110" cy="109.36170212765958" r="3" stroke="rgb(38, 188, 225)"></circle>
-    <circle cx="154" cy="228.51063829787233" r="3" stroke="rgb(38, 188, 225)"></circle>
+    <circle cx="154" cy="228.51063829787233" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="154" cy="213.61702127659575" r="5.196152422706632" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="154" cy="198.72340425531917" r="6" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="154" cy="183.82978723404256" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="154" cy="168.93617021276594" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="154" cy="154.04255319148936" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
-    <circle cx="198" cy="228.51063829787233" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
+    <circle cx="198" cy="228.51063829787233" r="5.196152422706632" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="198" cy="213.61702127659575" r="5.196152422706632" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="198" cy="198.72340425531917" r="3" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="198" cy="183.82978723404256" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
@@ -129,7 +129,7 @@
     <circle cx="330" cy="168.93617021276594" r="5.196152422706632" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="330" cy="154.04255319148936" r="6.708203932499369" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="330" cy="124.25531914893617" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
-    <circle cx="374" cy="213.61702127659575" r="3" stroke="rgb(38, 188, 225)"></circle>
+    <circle cx="374" cy="213.61702127659575" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="374" cy="183.82978723404256" r="5.196152422706632" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="374" cy="168.93617021276594" r="3" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="374" cy="154.04255319148936" r="3" stroke="rgb(38, 188, 225)"></circle>
@@ -153,7 +153,7 @@
     <circle cx="462" cy="124.25531914893617" r="3" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="462" cy="109.36170212765958" r="6" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="462" cy="94.46808510638297" r="3" stroke="rgb(38, 188, 225)"></circle>
-    <circle cx="506" cy="198.72340425531917" r="3" stroke="rgb(38, 188, 225)"></circle>
+    <circle cx="506" cy="198.72340425531917" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="506" cy="183.82978723404256" r="3" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="506" cy="168.93617021276594" r="4.242640687119286" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="506" cy="154.04255319148936" r="5.196152422706632" stroke="rgb(38, 188, 225)"></circle>
@@ -184,18 +184,18 @@
     <circle cx="594" cy="94.46808510638297" r="7.348469228349533" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="594" cy="79.57446808510639" r="5.196152422706632" stroke="rgb(38, 188, 225)"></circle>
     <circle cx="594" cy="34.89361702127658" r="3" stroke="rgb(38, 188, 225)"></circle>
-    <circle cx="418" cy="213.61702127659575" r="3" stroke="rgb(149, 251, 81)"></circle>
+    <circle cx="418" cy="213.61702127659575" r="5.196152422706632" stroke="rgb(149, 251, 81)"></circle>
     <circle cx="462" cy="183.82978723404256" r="3" stroke="rgb(149, 251, 81)"></circle>
-    <circle cx="506" cy="94.46808510638297" r="3" stroke="rgb(149, 251, 81)"></circle>
+    <circle cx="506" cy="94.46808510638297" r="5.196152422706632" stroke="rgb(149, 251, 81)"></circle>
     <circle cx="66" cy="228.51063829787233" r="3" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="66" cy="213.61702127659575" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="66" cy="198.72340425531917" r="3" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="110" cy="243.40425531914897" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="110" cy="228.51063829787233" r="7.348469228349533" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="198" cy="243.40425531914897" r="3" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="198" cy="228.51063829787233" r="6" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="198" cy="213.61702127659575" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="198" cy="198.72340425531917" r="3" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="198" cy="228.51063829787233" r="7.937253933193772" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="198" cy="213.61702127659575" r="6.708203932499369" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="198" cy="198.72340425531917" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="242" cy="258.29787234042556" r="3" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="242" cy="243.40425531914897" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="242" cy="228.51063829787233" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
@@ -205,36 +205,36 @@
     <circle cx="286" cy="228.51063829787233" r="6.708203932499369" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="286" cy="213.61702127659575" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="330" cy="243.40425531914897" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="330" cy="228.51063829787233" r="5.196152422706632" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="330" cy="213.61702127659575" r="3" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="330" cy="228.51063829787233" r="6" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="330" cy="213.61702127659575" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="330" cy="198.72340425531917" r="5.196152422706632" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="330" cy="183.82978723404256" r="3" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="330" cy="183.82978723404256" r="6" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="374" cy="243.40425531914897" r="3" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="374" cy="228.51063829787233" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="374" cy="213.61702127659575" r="3" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="374" cy="213.61702127659575" r="5.196152422706632" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="374" cy="198.72340425531917" r="3" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="418" cy="243.40425531914897" r="5.196152422706632" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="418" cy="228.51063829787233" r="6" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="418" cy="213.61702127659575" r="6.708203932499369" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="418" cy="213.61702127659575" r="8.485281374238571" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="462" cy="228.51063829787233" r="3" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="462" cy="213.61702127659575" r="5.196152422706632" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="462" cy="168.93617021276594" r="3" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="462" cy="154.04255319148936" r="3" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="462" cy="168.93617021276594" r="5.196152422706632" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="462" cy="154.04255319148936" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="506" cy="228.51063829787233" r="3" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="506" cy="124.25531914893617" r="3" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="506" cy="124.25531914893617" r="6.708203932499369" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="550" cy="243.40425531914897" r="3" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="550" cy="213.61702127659575" r="3" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="550" cy="198.72340425531917" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="550" cy="183.82978723404256" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="550" cy="139.14893617021278" r="3" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="594" cy="198.72340425531917" r="3" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="594" cy="183.82978723404256" r="3" stroke="rgb(255, 130, 29)"></circle>
-    <circle cx="594" cy="79.57446808510639" r="3" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="550" cy="183.82978723404256" r="5.196152422706632" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="550" cy="139.14893617021278" r="5.196152422706632" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="594" cy="198.72340425531917" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="594" cy="183.82978723404256" r="4.242640687119286" stroke="rgb(255, 130, 29)"></circle>
+    <circle cx="594" cy="79.57446808510639" r="6" stroke="rgb(255, 130, 29)"></circle>
     <circle cx="66" cy="302.97872340425533" r="3" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="66" cy="288.0851063829787" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="66" cy="258.29787234042556" r="9.486832980505138" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="66" cy="243.40425531914897" r="4.242640687119286" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="66" cy="228.51063829787233" r="4.242640687119286" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="66" cy="228.51063829787233" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="110" cy="273.19148936170205" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="110" cy="258.29787234042556" r="6" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="154" cy="288.0851063829787" r="3" stroke="rgb(144, 12, 0)"></circle>
@@ -244,26 +244,26 @@
     <circle cx="198" cy="288.0851063829787" r="4.242640687119286" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="198" cy="273.19148936170205" r="9.9498743710662" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="198" cy="258.29787234042556" r="7.348469228349533" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="198" cy="243.40425531914897" r="3" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="198" cy="243.40425531914897" r="4.242640687119286" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="242" cy="273.19148936170205" r="3" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="242" cy="258.29787234042556" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="242" cy="243.40425531914897" r="3" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="242" cy="258.29787234042556" r="6" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="242" cy="243.40425531914897" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="286" cy="273.19148936170205" r="3" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="286" cy="258.29787234042556" r="4.242640687119286" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="286" cy="243.40425531914897" r="4.242640687119286" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="286" cy="213.61702127659575" r="3" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="286" cy="258.29787234042556" r="6.708203932499369" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="286" cy="243.40425531914897" r="6" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="286" cy="213.61702127659575" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="330" cy="273.19148936170205" r="6" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="330" cy="258.29787234042556" r="4.242640687119286" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="330" cy="243.40425531914897" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="330" cy="243.40425531914897" r="6.708203932499369" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="374" cy="258.29787234042556" r="6" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="374" cy="243.40425531914897" r="6" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="418" cy="243.40425531914897" r="3" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="418" cy="228.51063829787233" r="6" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="418" cy="213.61702127659575" r="3" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="374" cy="243.40425531914897" r="6.708203932499369" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="418" cy="243.40425531914897" r="6" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="418" cy="228.51063829787233" r="8.485281374238571" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="418" cy="213.61702127659575" r="9" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="462" cy="258.29787234042556" r="3" stroke="rgb(144, 12, 0)"></circle>
     <circle cx="462" cy="243.40425531914897" r="6" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="462" cy="228.51063829787233" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="462" cy="198.72340425531917" r="4.242640687119286" stroke="rgb(144, 12, 0)"></circle>
-    <circle cx="550" cy="168.93617021276594" r="3" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="462" cy="228.51063829787233" r="6" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="462" cy="198.72340425531917" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
+    <circle cx="550" cy="168.93617021276594" r="5.196152422706632" stroke="rgb(144, 12, 0)"></circle>
   </g>
 </svg>

--- a/test/plots/cars-mpg.js
+++ b/test/plots/cars-mpg.js
@@ -21,12 +21,13 @@ export default async function() {
         stroke: "cylinders",
         curve: "basis"
       })),
-      Plot.dot(data, Plot.binY({r: "count"}, {
+      Plot.dot(data, Plot.reverse(Plot.sort("r", Plot.stackR(Plot.binY({r: "count"}, {
         x: "year",
         y: "economy (mpg)",
-        stroke: "cylinders",
-        thresholds: 20
-      }))
+        fill: "cylinders",
+        thresholds: 20,
+        order: "cylinders"
+      })))))
     ]
   });
 }


### PR DESCRIPTION
closes #197 

todo:
- [ ] this version returns channels r1 and r, which is not symmetric with stackX (x1 and x2). The dot mark knows only r for the moment, it has no notion of innerRadius/outerRadius.
- [ ] it would be nice to have an offset: r0 that would start the ring at innerRadius r0 (esp. for negative values)
- [ ] is it possible to rewrite (Xa, Xb) as a combined operation?