### PR TITLE
a few changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,6 @@ When drawing a single mark, you can call *mark*.**plot**(*options*) as shorthand
 ```js
 Plot.barY(alphabet, {x: "letter", y: "frequency"}).plot()
 ```
-#### Sorting *y* by *x*
-
-If the mark accepts an ordinal dimension for *y*, a common task is to sort the *y* domain according to the descending value of the opposite dimension *x*. Although this can be done by setting *y.domain*, you can specify a reducer in *mark.sortY*—the default *y* domain will then be sorted according to the corresponding *x* (or *x2*) reduced over all the elements sharing the same *y*. Baked-in reducers are "count", "max" (default when setting *sortY = true*), "min", "mean", "median", and "sum", the latter being useful when summing across facets.
-
-Symmetrically, set *mark.sortX = true* to sort an ordinal *x* by the *y* (or *y2*) channel.
-
 ### Layout options
 
 These options determine the overall layout of the plot; all are specified as numbers in pixels:
@@ -177,7 +171,7 @@ A scale’s domain (the extent of its inputs, abstract values) and range (the ex
 * *scale*.**range** - typically [*min*, *max*], or an array of ordinal or categorical values
 * *scale*.**reverse** - reverses the domain, say to flip the chart along *x* or *y*
 
-For most quantitative scales, the default domain is the [*min*, *max*] of all values associated with the scale. For the *radius* and *opacity* scales, the default domain is [0, *max*] to ensure a meaningful value encoding. For ordinal scales, the default domain is the set of all distinct values associated with the scale in natural ascending order; for a different order, set the domain explicitly or add a sortX or sortY option to a mark. For threshold scales, the default domain is [0] to separate negative and non-negative values. For quantile scales, the default domain is the set of all defined values associated with the scale. If a scale is reversed, it is equivalent to setting the domain as [*max*, *min*] instead of [*min*, *max*].
+For most quantitative scales, the default domain is the [*min*, *max*] of all values associated with the scale. For the *radius* and *opacity* scales, the default domain is [0, *max*] to ensure a meaningful value encoding. For ordinal scales, the default domain is the set of all distinct values associated with the scale in natural ascending order; for a different order, set the domain explicitly or add a [sort option](#sort-options) to a mark. For threshold scales, the default domain is [0] to separate negative and non-negative values. For quantile scales, the default domain is the set of all defined values associated with the scale. If a scale is reversed, it is equivalent to setting the domain as [*max*, *min*] instead of [*min*, *max*].
 
 The default range depends on the scale: for [position scales](#position-options) (*x*, *y*, *fx*, and *fy*), the default range depends on the plot’s [size and margins](#layout-options). For [color scales](#color-options), there are default color schemes for quantitative, ordinal, and categorical data. For opacity, the default range is [0, 1]. And for radius, the default range is designed to produce dots of “reasonable” size assuming a *sqrt* scale type for accurate area representation: zero maps to zero, the first quartile maps to a radius of three pixels, and other values are extrapolated. This convention for radius ensures that if the scale’s data values are all equal, dots have the default constant radius of three pixels, while if the data varies, dots will tend to be larger.
 
@@ -201,6 +195,32 @@ Plot.plot({
   marks: …
 })
 ```
+
+### Sort options
+
+If the mark accepts an ordinal dimension for *y*, a common task is to sort *y*’s domain according to the value of the opposite dimension *x*. Although this can be done by setting *y.domain* with d3.groupSort, you can pass a sort option to achieve a similar effect. The sort option is an object that specifies, for each scale, a channel *value* and a group *reduce*, and the sorting direction *reverse*.
+
+For example, the following sorts the domain of the *y* scale by the descending length *x* of horizontal bars:
+
+```js   
+Plot.barX(alphabet, {x: "frequency", y: "letter", sort: {
+  y: {value: "x", reverse: true, reduce: "max"}
+}})
+```
+
+Only the mark’s channels (such as *x*, *y*, *y2*, *fill*, etc.) can be used for sorting. When stacking on dimension Y, *y* is aliased to *y2* for convenience; similarly when stacking on X, *x* is aliased to *x2*.
+
+The default *reduce* is "max". All of the [group](#group) aggregation methods are available. In the barX example given above, the *reduce* function is applied to each bar’s *x* channel, and most aggregation methods ("mean", "max", "min", "sum"…) would result in the same ordering. For dot marks, however, the "count" reducer is usually more appropriate.
+
+The default for *reverse* is false. The shorthand notation "-x" is equivalent to setting {value: "x", reverse: true}. The example above can be simplified:
+
+```js   
+Plot.barX(alphabet, {x: "frequency", y: "letter", sort: {y: "-x"} })
+```
+
+An additional *limit: n* option allows to restrict the domain to the *n* first values after sorting. It defaults to Infinity, showing all the values.
+
+Note: when passed as a string or a function, *options.sort* is a shorthand for the [sort transform](#transforms). To use both sort options and a sort transform, use Plot.sort explicitly.
 
 ### Position options
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The default for *reverse* is false. The shorthand notation "-x" is equivalent to
 Plot.barX(alphabet, {x: "frequency", y: "letter", sort: {y: "-x"} })
 ```
 
-An additional *limit: n* option allows to restrict the domain to the *n* first values after sorting. It defaults to Infinity, showing all the values.
+An additional *limit: n* option allows to restrict the domain to the *n* first values after sorting. It defaults to Infinity, showing all the values. If *limit* is an array [*lo*, *hi*], the *i*th values with *lo* ≤ *i* < *hi* will be selected.
 
 Note: when passed as a string or a function, *options.sort* is a shorthand for the [sort transform](#transforms). To use both sort options and a sort transform, use Plot.sort explicitly.
 

--- a/src/mark.js
+++ b/src/mark.js
@@ -72,7 +72,7 @@ function Channel(data, {scale, type, value}) {
 
 function channelSort(channels, x, y) {
   let reverse, reduce, limit;
-  ({value: y, reverse = /^[-]/.test(y), reduce = true, limit = Infinity} = maybeValue(y));
+  ({value: y, reverse = /^[-]/.test(y), reduce = true, limit} = maybeValue(y));
   if (/^[-+]/.test(y)) y = y.slice(1);
   if (reduce == null || reduce === false) return;
   const X = channels.find(([, {scale}]) => scale === x);
@@ -85,7 +85,9 @@ function channelSort(channels, x, y) {
   X[1].domain = () => {
     let domain = rollup(range(XV), I => reduce.reduce(I, YV), i => XV[i]);
     domain = sort(domain, reverse ? descendingGroup : ascendingGroup);
-    if (limit < Infinity) domain = domain.slice(0, limit);
+    if (limit !== undefined) {
+      domain = domain.slice(...typeof limit === "object" ? [limit[0], limit[1]] : [0, limit]);
+    }
     return domain.map(first);
   };
 }

--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -70,7 +70,7 @@ function aliasSort(options, name) {
   if (!isOptions(sort)) return options;
   for (const x in sort) {
     const {value: y, ...rest} = maybeValue(sort[x]);
-    if (y.replace(/^[-+]/, "") === name) {
+    if (String(y).replace(/^[-+]/, "") === name) {
       sort = {...sort, [x]: {value: y + "2", ...rest}};
     }
   }

--- a/test/data/first-ladies.csv
+++ b/test/data/first-ladies.csv
@@ -1,0 +1,55 @@
+president_number,name,birth,death,tenure_start,tenure_end,president,president_relationship
+1,Martha Washington,1731-06-13,1802-05-22,1789-04-30,1797-03-04,George Washington,Husband
+2,Abigail Adams,1744-11-22,1818-10-28,1797-03-04,1801-03-04,John Adams,Husband
+3,Martha Jefferson,1772-09-27,1836-10-10,1801-03-04,1809-03-04,Thomas Jefferson,Father
+4,Dolly Madison,1768-05-20,1849-07-12,1809-03-04,1817-03-04,James Madison,Husband
+5,Elizabeth Monroe,1768-06-30,1830-09-23,1817-03-04,1825-03-04,James Monroe,Husband
+6,Louisa Adams,1775-02-12,1852-05-15,1825-03-04,1829-03-04,John Quincy Adams,Husband
+7,Emily Donelson,1807-06-01,1836-12-19,1829-03-04,1834-11-26,Andrew Jackson,Uncle
+7,Sarah Jackson,1803-07-16,1887-08-23,1834-11-26,1837-03-04,Andrew Jackson,Father-in-law
+8,Sarah Van Buren,1818-02-13,1877-12-29,1838-11-27,1841-03-04,Martin Van Buren,Father-in-law
+9,Anna Harrison,1775-07-25,1864-02-25,1841-03-04,1841-04-04,William Henry Harrison,Husband
+9,Jane Harrison,1804-07-23,1846-05-11,1841-03-04,1841-04-04,William Henry Harrison,Father-in-law
+10,Letitia Tyler,1790-11-12,1842-09-10,1841-04-04,1842-09-10,John Tyler,Husband
+10,Elizabeth Priscilla Tyler,1816-06-14,1889-12-29,1842-09-10,1844-06-26,John Tyler,Father-in-law
+10,Julia Tyler,1820-07-29,1889-07-10,1844-06-26,1845-03-04,John Tyler,Husband
+11,Sarah Polk,1803-09-04,1891-08-14,1845-03-04,1849-03-04,James K. Polk,Husband
+12,"Margaret ""Peggy"" Taylor",1788-09-21,1852-08-14,1849-03-04,1850-07-09,Zachary Taylor,Husband
+13,Abigail Fillmore,1798-03-13,1853-03-30,1850-07-09,1853-03-04,Millard Fillmore,Husband
+14,Jane Pierce,1806-03-12,1863-12-02,1853-03-04,1857-03-04,Franklin Pierce,Husband
+15,Harriet Lane,1830-05-09,1903-07-03,1857-03-04,1861-03-04,James Buchanan,Uncle
+16,Mary Lincoln,1818-12-13,1882-07-16,1861-03-04,1865-04-15,Abraham Lincoln,Husband
+17,Eliza Johnson,1810-10-04,1876-01-15,1865-04-15,1869-03-04,Andrew Johnson,Husband
+18,Julia Grant,1826-01-26,1902-12-14,1869-03-04,1877-03-04,Ulysses S. Grant,Husband
+19,Lucy Hayes,1831-08-28,1889-06-25,1877-03-04,1881-03-04,Rutherford B. Hayes,Husband
+20,Lucretia Garfield,1832-04-19,1918-03-14,1881-03-04,1881-09-19,James A. Garfield,Husband
+21,Mary McElroy,1841-07-05,1917-01-08,1881-09-19,1885-03-04,Chester A. Arthur,Brother
+22,Rose Cleveland,1846-06-13,1918-11-22,1885-03-04,1886-06-02,Grover Cleveland,Brother
+22,Frances Cleveland,1864-07-21,1947-10-29,1886-06-02,1889-03-04,Grover Cleveland,Husband
+23,Caroline Harrison,1832-10-01,1892-10-25,1889-03-04,1892-10-25,Benjamin Harrison,Husband
+23,Mary Harrison McKee,1858-04-03,1930-10-28,1892-10-25,1893-03-04,Benjamin Harrison,Father
+24,Frances Cleveland,1864-07-21,1947-10-29,1893-03-04,1897-03-04,Grover Cleveland,Husband
+25,Ida McKinley,1847-06-08,1907-05-26,1897-03-04,1901-09-14,William McKinley,Husband
+26,Edith Roosevelt,1861-08-06,1948-09-30,1901-09-14,1909-03-04,Theodore Roosevelt,Husband
+27,"Helen ""Nellie"" Taft",1861-06-02,1943-05-22,1909-03-04,1913-03-04,William H. Taft,Husband
+28,Ellen Wilson,1860-05-15,1914-08-06,1913-03-04,1914-08-06,Woodrow Wilson,Husband
+28,Margaret Wilson,1886-04-16,1944-02-12,1914-08-06,1915-12-18,Woodrow Wilson,Father
+28,Edith Wilson,1872-10-15,1961-12-28,1915-12-18,1921-03-04,Woodrow Wilson,Husband
+29,Florence Harding,1860-08-15,1924-11-21,1921-03-04,1923-08-02,Warren G. Harding,Husband
+30,Grace Coolidge,1879-01-03,1957-07-08,1923-08-02,1929-03-04,Calvin Coolidge,Husband
+31,Lou Hoover,1874-03-29,1944-01-07,1929-03-04,1933-03-04,Herbert Hoover,Husband
+32,Anna Eleanor Roosevelt,1884-10-11,1962-11-07,1933-03-04,1945-04-12,Franklin D. Roosevelt,Husband
+33,"Elizabeth ""Bess"" Truman",1885-02-13,1982-10-18,1945-04-12,1953-01-20,Harry S. Truman,Husband
+34,Mamie Eisenhower,1896-11-14,1979-11-01,1953-01-20,1961-01-20,Dwight D. Eisenhower,Husband
+35,"Jacqueline ""Jackie"" Kennedy",1929-07-28,1994-05-19,1961-01-20,1963-11-22,John F. Kennedy,Husband
+36,"Claudia ""Lady Bird"" Johnson",1912-12-22,2007-07-11,1963-11-22,1969-01-20,Lyndon B. Johnson,Husband
+37,"Thelma ""Pat"" Nixon",1912-03-16,1993-06-22,1969-01-20,1974-08-09,Richard Nixon,Husband
+38,"Elizabeth ""Betty"" Ford",1918-04-08,2011-07-08,1974-08-09,1977-01-20,Gerald Ford,Husband
+39,Eleanor Rosalynn Carter,1927-08-18,,1977-01-20,1981-01-20,Jimmy Carter,Husband
+40,Nancy Reagan,1921-07-06,2016-03-06,1981-01-20,1989-01-20,Ronald Reagan,Husband
+41,Barbara Bush,1925-06-08,2018-04-17,1989-01-20,1993-01-20,George H. W. Bush,Husband
+42,Hillary Clinton,1947-10-26,,1993-01-20,2001-01-20,Bill Clinton,Husband
+43,Laura Bush,1946-11-04,,2001-01-20,2009-01-20,George W. Bush,Husband
+44,Michelle Obama,1964-01-17,,2009-01-20,2017-01-20,Barack Obama,Husband
+45,Melania Trump,1970-04-26,,2017-01-20,2021-01-20,Donald Trump,Husband
+46,Jill Biden,1951-06-03,,2021-01-20,,Joe Biden,Husband

--- a/test/output/firstLadies.svg
+++ b/test/output/firstLadies.svg
@@ -1,0 +1,162 @@
+<svg class="plot" fill="currentColor" text-anchor="middle" width="940" height="1120" viewBox="0 0 940 1120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g transform="translate(0,1090)" fill="none" text-anchor="middle">
+    <g class="tick" opacity="1" transform="translate(44.080027927689926,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1740</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(99.21834547307243,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1760</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(154.35666301845492,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1780</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(209.4949805638374,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1800</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(264.62575008491524,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1820</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(319.7640676302978,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1840</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(374.90238517568025,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1860</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(430.04070272106276,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1880</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(485.17902026644526,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1900</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(540.3097897875231,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1920</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(595.4481073329056,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1940</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(650.5864248782882,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1960</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(705.7247424236707,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1980</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(760.8630599690531,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">2000</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(816.0013775144356,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">2020</text>
+    </g>
+  </g>
+  <g fill="#ccc">
+    <rect x="20" width="195.56930973317733" y="16" height="18"></rect>
+    <rect x="57.068347360078505" width="203.81175227384233" y="36" height="18"></rect>
+    <rect x="133.83930256255425" width="176.53319243687966" y="56" height="18"></rect>
+    <rect x="121.83039589387477" width="223.70079631656415" y="76" height="18"></rect>
+    <rect x="122.13986489036495" width="171.55904442012303" y="96" height="18"></rect>
+    <rect x="140.39098765898026" width="212.97505377967317" y="116" height="18"></rect>
+    <rect x="229.4274823564932" width="81.47337434426535" y="136" height="18"></rect>
+    <rect x="218.7394799411254" width="231.86775861418272" y="156" height="18"></rect>
+    <rect x="258.9402573876288" width="165.06774351813414" y="176" height="18"></rect>
+    <rect x="141.6213156206363" width="244.2238744008756" y="196" height="18"></rect>
+    <rect x="221.5548930067555" width="115.23568705891233" y="216" height="18"></rect>
+    <rect x="183.80722345925952" width="142.8765520624976" y="236" height="18"></rect>
+    <rect x="254.34351058610406" width="202.74748084688832" y="256" height="18"></rect>
+    <rect x="265.7108351888893" width="190.08189606370536" y="276" height="18"></rect>
+    <rect x="219.11688115635735" width="242.45008868928556" y="296" height="18"></rect>
+    <rect x="177.9046684530324" width="176.1482431973431" y="316" height="18"></rect>
+    <rect x="204.0208325470808" width="151.75302864475228" y="336" height="18"></rect>
+    <rect x="226.06106351662456" width="159.14254443899304" y="356" height="18"></rect>
+    <rect x="292.6648299807526" width="201.6605653470204" y="376" height="18"></rect>
+    <rect x="261.2273087519342" width="175.31041249952824" y="396" height="18"></rect>
+    <rect x="238.64362003245648" width="179.97509151979474" y="416" height="18"></rect>
+    <rect x="280.8597199682983" width="211.94852247424234" y="436" height="18"></rect>
+    <rect x="296.2576895497603" width="159.42182133826475" y="456" height="18"></rect>
+    <rect x="298.03147526135035" width="236.81171453372087" y="476" height="18"></rect>
+    <rect x="323.42302902215346" width="208.17451032192326" y="496" height="18"></rect>
+    <rect x="337.0396648677209" width="199.71317507642374" y="516" height="18"></rect>
+    <rect x="386.9547495942937" width="229.56561120126804" y="536" height="18"></rect>
+    <rect x="299.27689927161566" width="165.59610521945882" y="556" height="18"></rect>
+    <rect x="369.58674566932103" width="200.06038419443718" y="576" height="18"></rect>
+    <rect x="386.9547495942937" width="229.56561120126804" y="536" height="18"></rect>
+    <rect x="339.7569536173906" width="165.30928029588262" y="596" height="18"></rect>
+    <rect x="378.8028833452844" width="240.2611616409405" y="616" height="18"></rect>
+    <rect x="378.31226176548284" width="225.97275163226027" y="636" height="18"></rect>
+    <rect x="375.4213684568064" width="149.48862135336077" y="656" height="18"></rect>
+    <rect x="446.87851454881684" width="159.41427331396005" y="676" height="18"></rect>
+    <rect x="409.65920670264563" width="245.9146318451145" y="696" height="18"></rect>
+    <rect x="376.1157866928331" width="177.17477450277397" y="716" height="18"></rect>
+    <rect x="426.8007698984791" width="216.4395969355021" y="736" height="18"></rect>
+    <rect x="413.65965958410385" width="192.36139940370612" y="756" height="18"></rect>
+    <rect x="442.71200513265654" width="215.23191304675998" y="776" height="18"></rect>
+    <rect x="443.65550817073625" width="269.27576706797" y="796" height="18"></rect>
+    <rect x="476.05162848624377" width="228.71268445484384" y="816" height="18"></rect>
+    <rect x="566.1976827565385" width="178.66928331509234" y="836" height="18"></rect>
+    <rect x="520.4415594218214" width="260.6634713363777" y="856" height="18"></rect>
+    <rect x="518.320564592218" width="224.04800543457736" y="876" height="18"></rect>
+    <rect x="535.031890402687" width="257.0781597916746" y="896" height="18"></rect>
+    <rect x="560.8385855002452" width="259.16141449975476" y="916" height="18"></rect>
+    <rect x="543.9762992036835" width="260.98803638147706" y="936" height="18"></rect>
+    <rect x="554.79261803223" width="255.99879231611123" y="956" height="18"></rect>
+    <rect x="616.4977167226479" width="203.50228327735215" y="976" height="18"></rect>
+    <rect x="613.8106200701966" width="206.1893799298034" y="996" height="18"></rect>
+    <rect x="661.2348567762388" width="158.76514322376124" y="1016" height="18"></rect>
+    <rect x="678.5273804581651" width="141.4726195418349" y="1036" height="18"></rect>
+    <rect x="626.4309167075518" width="193.56908329244823" y="1056" height="18"></rect>
+  </g>
+  <g>
+    <rect x="179.5727818243575" width="21.625089632788615" y="16" height="18"></rect>
+    <rect x="201.1978714571461" width="11.02011548477185" y="36" height="18"></rect>
+    <rect x="212.21798694191796" width="22.055327018153008" y="56" height="18"></rect>
+    <rect x="234.27331396007096" width="22.055327018153008" y="76" height="18"></rect>
+    <rect x="256.328640978224" width="22.05532701815298" y="96" height="18"></rect>
+    <rect x="278.38396799637695" width="11.02766350907649" y="116" height="18"></rect>
+    <rect x="289.41163150545344" width="15.798014869607925" y="136" height="18"></rect>
+    <rect x="305.20964637506137" width="6.257312148545111" y="156" height="18"></rect>
+    <rect x="316.24485790844244" width="6.249764124240528" y="176" height="18"></rect>
+    <rect x="322.49462203268297" width="0.23398875344378212" y="196" height="18"></rect>
+    <rect x="322.49462203268297" width="0.23398875344378212" y="216" height="18"></rect>
+    <rect x="322.72861078612675" width="3.955164735630376" y="236" height="18"></rect>
+    <rect x="326.6837755217571" width="4.943955919538098" y="256" height="18"></rect>
+    <rect x="331.6277314412952" width="1.8945541004641768" y="276" height="18"></rect>
+    <rect x="333.5222855417594" width="11.027663509076547" y="296" height="18"></rect>
+    <rect x="344.54994905083595" width="3.713627957882011" y="316" height="18"></rect>
+    <rect x="348.26357700871796" width="7.314035551194536" y="336" height="18"></rect>
+    <rect x="355.5776125599125" width="11.027663509076376" y="356" height="18"></rect>
+    <rect x="366.60527606898887" width="11.027663509076547" y="376" height="18"></rect>
+    <rect x="377.6329395780654" width="11.344680529871312" y="396" height="18"></rect>
+    <rect x="388.97762010793673" width="10.710646488281725" y="416" height="18"></rect>
+    <rect x="399.68826659621845" width="22.05532701815298" y="436" height="18"></rect>
+    <rect x="421.74359361437143" width="11.02766350907649" y="456" height="18"></rect>
+    <rect x="432.7712571234479" width="1.5020568366230123" y="476" height="18"></rect>
+    <rect x="434.27331396007094" width="9.525606672453478" y="496" height="18"></rect>
+    <rect x="443.7989206325244" width="3.4343510586104458" y="516" height="18"></rect>
+    <rect x="447.23327169113486" width="7.593312450466044" y="536" height="18"></rect>
+    <rect x="454.8265841416009" width="10.046420349473578" y="556" height="18"></rect>
+    <rect x="464.8730044910745" width="0.9812431596029114" y="576" height="18"></rect>
+    <rect x="465.8542476506774" width="11.027663509076604" y="536" height="18"></rect>
+    <rect x="476.881911159754" width="12.484432199871662" y="596" height="18"></rect>
+    <rect x="489.36634335962566" width="20.59101030305311" y="616" height="18"></rect>
+    <rect x="509.95735366267877" width="11.027663509076547" y="636" height="18"></rect>
+    <rect x="520.9850171717553" width="3.924972638411873" y="656" height="18"></rect>
+    <rect x="524.9099898101672" width="3.7664641280144906" y="676" height="18"></rect>
+    <rect x="528.6764539381817" width="14.363890251726616" y="696" height="18"></rect>
+    <rect x="543.0403441899083" width="6.649809412386276" y="716" height="18"></rect>
+    <rect x="549.6901536022946" width="15.405517605766704" y="736" height="18"></rect>
+    <rect x="565.0956712080613" width="11.027663509076547" y="756" height="18"></rect>
+    <rect x="576.1233347171378" width="33.37736347511043" y="776" height="18"></rect>
+    <rect x="609.5006981922483" width="21.436389025172616" y="796" height="18"></rect>
+    <rect x="630.9370872174209" width="22.05532701815298" y="816" height="18"></rect>
+    <rect x="652.9924142355738" width="7.819753179605186" y="836" height="18"></rect>
+    <rect x="660.812167415179" width="14.235573838547793" y="856" height="18"></rect>
+    <rect x="675.0477412537268" width="15.299845265501745" y="876" height="18"></rect>
+    <rect x="690.3475865192286" width="6.755481752651235" y="896" height="18"></rect>
+    <rect x="697.1030682718798" width="11.027663509076547" y="916" height="18"></rect>
+    <rect x="708.1307317809564" width="22.05532701815298" y="936" height="18"></rect>
+    <rect x="730.1860587991093" width="11.027663509076547" y="956" height="18"></rect>
+    <rect x="741.2137223081859" width="22.055327018152866" y="976" height="18"></rect>
+    <rect x="763.2690493263387" width="22.055327018153093" y="996" height="18"></rect>
+    <rect x="785.3243763444918" width="22.05532701815298" y="1016" height="18"></rect>
+    <rect x="807.3797033626448" width="11.027663509076547" y="1036" height="18"></rect>
+    <rect x="818.4073668717214" width="1.592633128278635" y="1056" height="18"></rect>
+  </g>
+  <g text-anchor="start" transform="translate(0.5,9.5)"><text dx="5" dy="0.32em" x="215.56930973317733" y="16">Martha Washington</text><text dx="5" dy="0.32em" x="260.88009963392085" y="36">Abigail Adams</text><text dx="5" dy="0.32em" x="310.3724949994339" y="56">Martha Jefferson</text><text dx="5" dy="0.32em" x="345.5311922104389" y="76">Dolly Madison</text><text dx="5" dy="0.32em" x="293.698909310488" y="96">Elizabeth Monroe</text><text dx="5" dy="0.32em" x="353.36604143865344" y="116">Louisa Adams</text><text dx="5" dy="0.32em" x="310.90085670075854" y="136">Emily Donelson</text><text dx="5" dy="0.32em" x="450.60723855530813" y="156">Sarah Jackson</text><text dx="5" dy="0.32em" x="424.0080009057629" y="176">Sarah Van Buren</text><text dx="5" dy="0.32em" x="385.8451900215119" y="196">Anna Harrison</text><text dx="5" dy="0.32em" x="336.7905800656678" y="216">Jane Harrison</text><text dx="5" dy="0.32em" x="326.6837755217571" y="236">Letitia Tyler</text><text dx="5" dy="0.32em" x="457.0909914329924" y="256">Elizabeth Priscilla Tyler</text><text dx="5" dy="0.32em" x="455.79273125259465" y="276">Julia Tyler</text><text dx="5" dy="0.32em" x="461.5669698456429" y="296">Sarah Polk</text><text dx="5" dy="0.32em" x="354.0529116503755" y="316">Margaret "Peggy" Taylor</text><text dx="5" dy="0.32em" x="355.7738611918331" y="336">Abigail Fillmore</text><text dx="5" dy="0.32em" x="385.2036079556176" y="356">Jane Pierce</text><text dx="5" dy="0.32em" x="494.325395327773" y="376">Harriet Lane</text><text dx="5" dy="0.32em" x="436.5377212514624" y="396">Mary Lincoln</text><text dx="5" dy="0.32em" x="418.6187115522512" y="416">Eliza Johnson</text><text dx="5" dy="0.32em" x="492.80824244254063" y="436">Julia Grant</text><text dx="5" dy="0.32em" x="455.67951088802505" y="456">Lucy Hayes</text><text dx="5" dy="0.32em" x="534.8431897950712" y="476">Lucretia Garfield</text><text dx="5" dy="0.32em" x="531.5975393440767" y="496">Mary McElroy</text><text dx="5" dy="0.32em" x="536.7528399441446" y="516">Rose Cleveland</text><text dx="5" dy="0.32em" x="616.5203607955617" y="536">Frances Cleveland</text><text dx="5" dy="0.32em" x="464.8730044910745" y="556">Caroline Harrison</text><text dx="5" dy="0.32em" x="569.6471298637582" y="576">Mary Harrison McKee</text><text dx="5" dy="0.32em" x="616.5203607955617" y="536">Frances Cleveland</text><text dx="5" dy="0.32em" x="505.0662339132732" y="596">Ida McKinley</text><text dx="5" dy="0.32em" x="619.0640449862249" y="616">Edith Roosevelt</text><text dx="5" dy="0.32em" x="604.2850133977431" y="636">Helen "Nellie" Taft</text><text dx="5" dy="0.32em" x="524.9099898101672" y="656">Ellen Wilson</text><text dx="5" dy="0.32em" x="606.2927878627769" y="676">Margaret Wilson</text><text dx="5" dy="0.32em" x="655.5738385477601" y="696">Edith Wilson</text><text dx="5" dy="0.32em" x="553.2905611956071" y="716">Florence Harding</text><text dx="5" dy="0.32em" x="643.2403668339812" y="736">Grace Coolidge</text><text dx="5" dy="0.32em" x="606.02105898781" y="756">Lou Hoover</text><text dx="5" dy="0.32em" x="657.9439181794165" y="776">Anna Eleanor Roosevelt</text><text dx="5" dy="0.32em" x="712.9312752387062" y="796">Elizabeth "Bess" Truman</text><text dx="5" dy="0.32em" x="704.7643129410876" y="816">Mamie Eisenhower</text><text dx="5" dy="0.32em" x="744.8669660716308" y="836">Jacqueline "Jackie" Kennedy</text><text dx="5" dy="0.32em" x="781.1050307581991" y="856">Claudia "Lady Bird" Johnson</text><text dx="5" dy="0.32em" x="742.3685700267954" y="876">Thelma "Pat" Nixon</text><text dx="5" dy="0.32em" x="792.1100501943616" y="896">Elizabeth "Betty" Ford</text><text dx="5" dy="0.32em" x="820" y="916">Eleanor Rosalynn Carter</text><text dx="5" dy="0.32em" x="804.9643355851606" y="936">Nancy Reagan</text><text dx="5" dy="0.32em" x="810.7914103483413" y="956">Barbara Bush</text><text dx="5" dy="0.32em" x="820" y="976">Hillary Clinton</text><text dx="5" dy="0.32em" x="820" y="996">Laura Bush</text><text dx="5" dy="0.32em" x="820" y="1016">Michelle Obama</text><text dx="5" dy="0.32em" x="820" y="1036">Melania Trump</text><text dx="5" dy="0.32em" x="820" y="1056">Jill Biden</text></g>
+</svg>

--- a/test/plots/first-ladies.js
+++ b/test/plots/first-ladies.js
@@ -1,0 +1,33 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export default async function() {
+  const data = await d3.csv("data/first-ladies.csv", d3.autoType);
+  const now = Date.UTC(2021, 7, 19);
+  return Plot.plot({
+    width: 940,
+    marginRight: 120,
+    y: { axis: null },
+    marks: [
+      Plot.barX(data, {
+        x1: "birth",
+        x2: d => d.death || now,
+        y: "name",
+        fill: "#ccc"
+      }),
+      Plot.barX(data, {
+        x1: "tenure_start",
+        x2: d => d.tenure_end || now,
+        y: "name",
+        sort: { y: { value: "x1", reduce: "min" } }
+      }),
+      Plot.text(data, {
+        x: d => d.death || now,
+        y: "name",
+        text: "name",
+        textAnchor: "start",
+        dx: 5
+      })
+    ]
+  });
+}

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -31,6 +31,7 @@ export {default as empty} from "./empty.js";
 export {default as emptyX} from "./empty-x.js";
 export {default as figcaption} from "./figcaption.js";
 export {default as figcaptionHtml} from "./figcaption-html.js";
+export {default as firstLadies} from "./first-ladies.js";
 export {default as fruitSales} from "./fruit-sales.js";
 export {default as fruitSalesDate} from "./fruit-sales-date.js";
 export {default as gistempAnomaly} from "./gistemp-anomaly.js";


### PR DESCRIPTION
* README document sort x by y
* first ladies example plot (by @tophtucker )
* add limit: [lo, hi]
* throw the correct error if a mistaken sort option is given as {x: "-y", limit: 10} 
