### PR TITLE
Keep style.css in ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "files": [
     "dist/**/*.js",
-    "src/**/*.js"
+    "src/**/*.js",
+    "src/**/*.css"    
   ],
   "scripts": {
     "test": "mkdir -p test/output && mocha -r module-alias/register 'test/**/*-test.js' && mocha -r module-alias/register test/plot.js && eslint src test",


### PR DESCRIPTION
The `src/style.css` file is not kept in the distributed ES module. If I understand correctly, keeping it would allow to import it directly and keep it up to date when using Plot from a package manager.