### PR TITLE
handle no ticks when rotating

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -220,23 +220,24 @@ function createAxis(axis, scale, {ticks, tickSize, tickPadding, tickFormat}) {
     .tickValues(Array.isArray(ticks) ? ticks : null);
 }
 
+const radians = Math.PI / 180;
+
 function maybeTickRotate(g, rotate) {
   if (!(rotate = +rotate)) return;
-  const radians = Math.PI / 180;
-  const labels = g.selectAll("text").attr("dy", "0.32em");
-  const y = +labels.attr("y");
-  if (y) {
-    const s = Math.sign(y);
-    labels
-      .attr("y", null)
-      .attr("transform", `translate(0, ${y + s * 4 * Math.cos(rotate * radians)}) rotate(${rotate})`)
-      .attr("text-anchor", Math.abs(rotate) < 10 ? "middle" : (rotate < 0) ^ (s > 0) ? "start" : "end");
-  } else {
-    const x = +labels.attr("x");
-    const s = Math.sign(x);
-    labels
-      .attr("x", null)
-      .attr("transform", `translate(${x + s * 4 * Math.abs(Math.sin(rotate * radians))}, 0) rotate(${rotate})`)
-      .attr("text-anchor", Math.abs(rotate) > 60 ? "middle" : s > 0 ? "start" : "end");
+  for (const text of g.selectAll("text")) {
+    const x = +text.getAttribute("x");
+    const y = +text.getAttribute("y");
+    if (Math.abs(y) > Math.abs(x)) {
+      const s = Math.sign(y);
+      text.setAttribute("transform", `translate(0, ${y + s * 4 * Math.cos(rotate * radians)}) rotate(${rotate})`);
+      text.setAttribute("text-anchor", Math.abs(rotate) < 10 ? "middle" : (rotate < 0) ^ (s > 0) ? "start" : "end");
+    } else {
+      const s = Math.sign(x);
+      text.setAttribute("transform", `translate(${x + s * 4 * Math.abs(Math.sin(rotate * radians))}, 0) rotate(${rotate})`);
+      text.setAttribute("text-anchor", Math.abs(rotate) > 60 ? "middle" : s > 0 ? "start" : "end");
+    }
+    text.removeAttribute("x");
+    text.removeAttribute("y");
+    text.setAttribute("dy", "0.32em");
   }
 }


### PR DESCRIPTION
Fixes #544.

Since I was there, I also took a moment to rewrite the code so to make slightly fewer assumptions about the structure of the axis: namely, rather than only looking at the first element’s attributes, look at each element individually. I don’t seeing this having any immediate practical effect, but it does seem slightly cleaner.

There aren’t any tests for the tickRotate option. Any chance you’d be willing to add some to make sure I haven’t broken anything here, @Fil?

(I tested it in [this notebook](https://observablehq.com/d/d3feddc757b564e2) and it seemed to still work…)