### PR TITLE
symmetric diverging scales by domain extension

### DIFF
--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -393,18 +393,14 @@ it("plot(…).scale('color') can return an asymmetric diverging scale", async ()
 it("plot(…).scale('color') can return a symmetric diverging scale", async () => {
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging"}});
-  const {interpolate, ...color} = plot.scale("color");
-  assert.deepStrictEqual(color, {
+  assert.deepStrictEqual(plot.scale("color"), {
     type: "diverging",
-    domain: [-0.78, 1.35],
+    domain: [-1.35, 1.35],
+    interpolate: d3.interpolateRdBu,
     pivot: 0,
     clamp: false,
     label: "Anomaly"
   });
-  const k = 0.78 / 1.35;
-  for (const t of d3.ticks(0, 1, 100)) {
-    assert.strictEqual(interpolate(t), d3.interpolateRdBu(t < 0.5 ? t * k + (1 - k) / 2: t));
-  }
 });
 
 it("plot(…).scale('color') can return a diverging scale with an explicit range", async () => {
@@ -447,6 +443,21 @@ it("plot(…).scale('color') can return a transformed diverging scale", async ()
   assert.deepStrictEqual(plot.scale("color"), {
     type: "diverging",
     domain: [-78, 135],
+    pivot: 0,
+    transform,
+    interpolate: d3.interpolateRdBu,
+    clamp: false,
+    label: "Anomaly"
+  });
+});
+
+it("plot(…).scale('color') can return a transformed symmetric diverging scale", async () => {
+  const transform = d => d * 100;
+  const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
+  const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging", transform}});
+  assert.deepStrictEqual(plot.scale("color"), {
+    type: "diverging",
+    domain: [-135, 135],
     pivot: 0,
     transform,
     interpolate: d3.interpolateRdBu,


### PR DESCRIPTION
Rather than truncating the interpolator, this extends the domain so that it is symmetric around the pivot. While the effect is the same internally, this has two improvements.

First, it fixes #562 by returning a domain that is already symmetric, and hence applying the (default) symmetric transform again is idempotent and has no effect.

Second, it makes it easier to produce a good color legend for symmetric diverging scales. With the previous approach, you’d see something like this:

<img width="751" alt="Screen Shot 2021-09-26 at 8 08 24 PM" src="https://user-images.githubusercontent.com/230541/134839887-9c3af177-e61d-4b06-9afa-c621b01981e9.png">

While strictly accurate, it’s a bit visually unsettling and difficult to interpret. The lower half of the legend is given equal visual space to the upper half, but covers a smaller range of values ([-0.78, 0] vs. [0, 1.35]). Under the new approach in this PR, you’d instead get:

<img width="751" alt="Screen Shot 2021-09-26 at 8 10 05 PM" src="https://user-images.githubusercontent.com/230541/134839999-67eeca8a-68fa-43fe-ab0f-1d7a018fe45d.png">

The extended domain includes values that are not present in the chart, but the resulting interpolator no longer needs transformation, and the legend is much easier to interpret.

In retrospect, I now realize why you had symmetric = false when exposing diverging scales. 😅 But while returning symmetric = false would also fix #562, I think it’s likely to be confusing if people inspect the exposed diverging scale, and wonder why is says it’s asymmetric when you asked it to be symmetric. The approach here avoids that confusion, and makes it easier to produce a good color legend.