### PR TITLE
allow quantile or threshold position scales

### DIFF
--- a/src/scales.js
+++ b/src/scales.js
@@ -84,8 +84,8 @@ function autoScaleRangeY(scale, dimensions) {
     const {insetTop, insetBottom} = scale;
     const {height, marginTop = 0, marginBottom = 0} = dimensions;
     scale.range = [height - marginBottom - insetBottom, marginTop + insetTop];
-    if (isOrdinalScale(scale)) scale.range.reverse();
-    else scale.range = piecewiseRange(scale);
+    if (!isOrdinalScale(scale)) scale.range = piecewiseRange(scale);
+    else scale.range.reverse();
     scale.scale.range(scale.range);
   }
   autoScaleRound(scale);
@@ -111,10 +111,10 @@ function roundError({scale}) {
   return (step - Math.floor(step)) * m;
 }
 
-function piecewiseRange({scale, range}) {
-  const length = scale.domain().length;
-  if (!(length > 2)) return range;
-  const [start, end] = range;
+function piecewiseRange(scale) {
+  const length = scale.scale.domain().length + isThresholdScale(scale);
+  if (!(length > 2)) return scale.range;
+  const [start, end] = scale.range;
   return Array.from({length}, (_, i) => start + i / (length - 1) * (end - start));
 }
 
@@ -215,6 +215,10 @@ export function isTemporalScale({type}) {
 
 export function isOrdinalScale({type}) {
   return type === "ordinal" || type === "point" || type === "band";
+}
+
+function isThresholdScale({type}) {
+  return type === "threshold";
 }
 
 function isBandScale({type}) {

--- a/src/scales/quantitative.js
+++ b/src/scales/quantitative.js
@@ -132,7 +132,7 @@ export function ScaleQuantile(key, channels, {
   reverse
 }) {
   return ScaleThreshold(key, channels, {
-    domain: scaleQuantile(domain, range).quantiles(),
+    domain: scaleQuantile(domain, range === undefined ? {length: quantiles} : range).quantiles(),
     range,
     reverse
   });
@@ -152,7 +152,7 @@ export function ScaleThreshold(key, channels, {
 }) {
   if (!pairs(domain).every(([a, b]) => ascending(a, b) <= 0)) throw new Error("non-ascending domain");
   if (reverse) range = reverseof(range); // domain ascending, so reverse range
-  return {type: "threshold", scale: scaleThreshold(domain, range).unknown(unknown), domain, range};
+  return {type: "threshold", scale: scaleThreshold(domain, range === undefined ? [] : range).unknown(unknown), domain, range};
 }
 
 export function ScaleIdentity() {


### PR DESCRIPTION
Fixes a crash where we tried to pass an undefined *range* to the scaleQuantile and scaleThreshold constructors, and then fixes an off-by-one in autoScaleRange for threshold scales, which require a range of length domain.length + 1.