### PR TITLE
scale("x") builds scale.apply and (when applicable) scale.invert

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,11 @@ const plot1 = Plot.plot(…);
 const plot2 = Plot.plot({…, color: plot1.scale("color")});
 ```
 
-The returned scale object represents the actual (or “materialized”) values encountered in the plot, including the domain, range, interpolate function, *etc.* The scale’s label, if any, is also returned; however, note that other axis properties are not currently exposed. The scale object is undefined if the associated plot has no scale with the given *name*, and throws an error if the *name* is invalid (*i.e.*, not one of the known scale names: *x*, *y*, *fx*, *fy*, *r*, *color*, or *opacity*).
+The returned scale object represents the actual (or “materialized”) values encountered in the plot, including the domain, range, interpolate function, *etc.* The scale’s label, if any, is also returned; however, note that other axis properties are not currently exposed.
+
+For convenience, an apply method is exposed, which returns the scale’s output for any given input. When applicable, an invert method is exposed, which returns the corresponding input from the scale’s domain for any given output.
+
+The scale object is undefined if the associated plot has no scale with the given *name*, and throws an error if the *name* is invalid (*i.e.*, not one of the known scale names: *x*, *y*, *fx*, *fy*, *r*, *color*, or *opacity*).
 
 ### Position options
 

--- a/src/scales.js
+++ b/src/scales.js
@@ -353,6 +353,6 @@ function exposeScale({
 
     // utilities
     apply: t => scale(t),
-    ...scale.invert && {invert: t => scale.invert(t) }
+    ...scale.invert && {invert: t => scale.invert(t)}
   };
 }

--- a/src/scales.js
+++ b/src/scales.js
@@ -319,7 +319,7 @@ function exposeScale({
   transform,
   percent
 }) {
-  if (type === "identity") return {type: "identity"};
+  if (type === "identity") return {type: "identity", apply: d => d, invert: d => d};
   const domain = scale.domain();
   const unknown = scale.unknown ? scale.unknown() : undefined;
   return {
@@ -349,6 +349,10 @@ function exposeScale({
 
     // band, point
     ...scale.align && {align: scale.align(), round: scale.round()},
-    ...scale.padding && (scale.paddingInner ? {paddingInner: scale.paddingInner(), paddingOuter: scale.paddingOuter()} : {padding: scale.padding()})
+    ...scale.padding && (scale.paddingInner ? {paddingInner: scale.paddingInner(), paddingOuter: scale.paddingOuter()} : {padding: scale.padding()}),
+
+    // utilities
+    apply: t => scale(t),
+    ...scale.invert && {invert: t => scale.invert(t) }
   };
 }

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -5,7 +5,7 @@ import it from "../jsdom.js";
 
 it("plot(…).scale(name) returns undefined for an unused scale", () => {
   const plot = Plot.dot([1, 2], {x: d => d, y: d => d}).plot();
-  assert.strictEqual(plot.scale("r"), undefined);
+  assert.deepStrictEqual(plot.scale("r"), undefined);
 });
 
 it("plot(…).scale(name) throws an error if there is no such named scale", () => {
@@ -15,7 +15,7 @@ it("plot(…).scale(name) throws an error if there is no such named scale", () =
 
 it("plot(…).scale('x') can return a linear scale", () => {
   const plot = Plot.dot([1, 2], {x: d => d, y: d => d}).plot();
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "linear",
     domain: [1, 2],
     range: [40, 620],
@@ -27,7 +27,7 @@ it("plot(…).scale('x') can return a linear scale", () => {
 it("plot(…).scale('x') returns the expected linear scale for penguins", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dotX(penguins, {x: "body_mass_g"}).plot();
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "linear",
     domain: [2700, 6300],
     range: [20, 620],
@@ -47,7 +47,7 @@ it("plot(…).scale('x') returns the expected sqrt scale given explicit options"
       label: "Body mass"
     }
   });
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "pow",
     exponent: 0.5,
     domain: [3500, 4000],
@@ -61,7 +61,7 @@ it("plot(…).scale('x') returns the expected sqrt scale given explicit options"
 it("plot(…).scale('x') can return a utc scale", async () => {
   const aapl = await d3.csv("data/aapl.csv", d3.autoType);
   const plot = Plot.line(aapl, {x: "Date", y: "Close"}).plot();
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "utc",
     domain: [new Date("2013-05-13"), new Date("2018-05-11")],
     range: [40, 620],
@@ -73,7 +73,7 @@ it("plot(…).scale('x') can return a utc scale", async () => {
 it("plot(…).scale('x') can return an explicit time scale", async () => {
   const aapl = await d3.csv("data/aapl.csv", d3.autoType);
   const plot = Plot.line(aapl, {x: "Date", y: "Close"}).plot({x: {type: "time"}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "time",
     domain: [new Date("2013-05-13"), new Date("2018-05-11")],
     range: [40, 620],
@@ -84,7 +84,7 @@ it("plot(…).scale('x') can return an explicit time scale", async () => {
 
 it("plot(…).scale('x') can return a point scale", () => {
   const plot = Plot.dot(["A", "B"], {x: d => d}).plot();
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "point",
     domain: ["A", "B"],
     range: [20, 620],
@@ -96,7 +96,7 @@ it("plot(…).scale('x') can return a point scale", () => {
 
 it("plot(…).scale('x') can return a point scale, respecting the specified align and padding", () => {
   const plot = Plot.dot(["A", "B"], {x: d => d}).plot({x: {padding: -0.2, align: 1}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "point",
     domain: ["A", "B"],
     range: [20, 620],
@@ -108,7 +108,7 @@ it("plot(…).scale('x') can return a point scale, respecting the specified alig
 
 it("plot(…).scale('x') can promote a reversed point scale to a point scale with a reversed domain", () => {
   const plot = Plot.dot(["A", "B"], {x: d => d}).plot({x: {reverse: true}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "point",
     domain: ["B", "A"],
     range: [20, 620],
@@ -120,7 +120,7 @@ it("plot(…).scale('x') can promote a reversed point scale to a point scale wit
 
 it("plot(…).scale('x') can return a band scale", () => {
   const plot = Plot.cellX(["A", "B"]).plot();
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "band",
     domain: [0, 1],
     range: [20, 620],
@@ -133,7 +133,7 @@ it("plot(…).scale('x') can return a band scale", () => {
 
 it("plot(…).scale('x') can return an explicit band scale", () => {
   const plot = Plot.cell([0, 1], {x: d => d}).plot({x: {type: "band"}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "band",
     domain: [0, 1],
     range: [20, 620],
@@ -146,7 +146,7 @@ it("plot(…).scale('x') can return an explicit band scale", () => {
 
 it("plot(…).scale('x') can promote a reversed band scale to a band scale with a reversed domain", () => {
   const plot = Plot.cellX(["A", "B"]).plot({x: {reverse: true}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "band",
     domain: [1, 0],
     range: [20, 620],
@@ -159,7 +159,7 @@ it("plot(…).scale('x') can promote a reversed band scale to a band scale with 
 
 it("plot(…).scale('y') can return a linear scale", () => {
   const plot = Plot.dot([1, 2], {x: d => d, y: d => d}).plot();
-  assert.deepStrictEqual(plot.scale("y"), {
+  scaleEqual(plot.scale("y"), {
     type: "linear",
     domain: [1, 2],
     range: [370, 20],
@@ -170,7 +170,7 @@ it("plot(…).scale('y') can return a linear scale", () => {
 
 it("plot(…).scale('y') can return a band scale", () => {
   const plot = Plot.cellY(["A", "B"]).plot();
-  assert.deepStrictEqual(plot.scale("y"), {
+  scaleEqual(plot.scale("y"), {
     type: "band",
     domain: [0, 1],
     range: [20, 80],
@@ -183,7 +183,7 @@ it("plot(…).scale('y') can return a band scale", () => {
 
 it("plot(…).scale('y') can return a band scale, respecting the specified align and padding", () => {
   const plot = Plot.cellY(["A", "B"]).plot({y: {paddingOuter: -0.2, align: 1}});
-  assert.deepStrictEqual(plot.scale("y"), {
+  scaleEqual(plot.scale("y"), {
     type: "band",
     domain: [0, 1],
     range: [20, 80],
@@ -209,7 +209,7 @@ it("plot(…).scale('fy') can return undefined", () => {
 it("plot(…).scale('fx') can return a band scale", () => {
   const data = [1, 2];
   const plot = Plot.dot(data, {y: d => d}).plot({facet: {data, x: data}});
-  assert.deepStrictEqual(plot.scale("fx"), {
+  scaleEqual(plot.scale("fx"), {
     type: "band",
     domain: [1, 2],
     range: [40, 620],
@@ -223,7 +223,7 @@ it("plot(…).scale('fx') can return a band scale", () => {
 it("plot(…).scale('fy') can return a band scale", () => {
   const data = [1, 2];
   const plot = Plot.dot(data, {y: d => d}).plot({facet: {data, y: data}});
-  assert.deepStrictEqual(plot.scale("fy"), {
+  scaleEqual(plot.scale("fy"), {
     type: "band",
     domain: [1, 2],
     range: [20, 380],
@@ -237,7 +237,7 @@ it("plot(…).scale('fy') can return a band scale", () => {
 it("plot(…).scale(name).unknown reflects the given unknown option for an ordinal scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dotX(penguins, {x: "body_mass_g", fill: "island"}).plot({color: {domain: ["Dream"], unknown: "#ccc"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "ordinal",
     domain: ["Dream"],
     unknown: "#ccc",
@@ -249,7 +249,7 @@ it("plot(…).scale(name).unknown reflects the given unknown option for an ordin
 it("plot(…).scale(name).unknown reflects the given unknown option for a continuous scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dotX(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {unknown: "black"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [2700, 6300],
     range: [0, 1],
@@ -263,7 +263,7 @@ it("plot(…).scale(name).unknown reflects the given unknown option for a contin
 it("plot(…).scale(name).unknown reflects the given unknown option for a threshold scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dotX(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "threshold", domain: [3000], unknown: "black"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [3000],
     unknown: "black",
@@ -275,7 +275,7 @@ it("plot(…).scale(name).unknown reflects the given unknown option for a thresh
 it("plot(…).scale(name).unknown reflects the given unknown option for a diverging scale", async () => {
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dotX(gistemp, {x: "Date", fill: "Anomaly"}).plot({color: {type: "diverging", symmetric: false, unknown: "black"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging",
     domain: [-0.78, 1.35],
     pivot: 0,
@@ -289,7 +289,7 @@ it("plot(…).scale(name).unknown reflects the given unknown option for a diverg
 it("plot(…).scale(name) promotes the given zero option to the domain", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dotX(penguins, {x: "body_mass_g"}).plot({x: {zero: true}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "linear",
     domain: [0, 6300],
     range: [20, 620],
@@ -302,7 +302,7 @@ it("plot(…).scale(name) promotes the given zero option to the domain", async (
 it("plot(…).scale(name) handles the zero option correctly for descending domains", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dotX(penguins, {x: "body_mass_g"}).plot({x: {zero: true, domain: [4000, 2000]}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "linear",
     domain: [4000, 0],
     range: [20, 620],
@@ -315,7 +315,7 @@ it("plot(…).scale(name) handles the zero option correctly for descending domai
 it("plot(…).scale(name) handles the zero option correctly for polylinear domains", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dotX(penguins, {x: "body_mass_g"}).plot({x: {type: "linear", zero: true, domain: [1000, 2000, 4000]}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "linear",
     domain: [0, 2000, 4000],
     range: [20, 320, 620],
@@ -328,7 +328,7 @@ it("plot(…).scale(name) handles the zero option correctly for polylinear domai
 it("plot(…).scale(name) handles the zero option correctly for descending polylinear domains", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dotX(penguins, {x: "body_mass_g"}).plot({x: {type: "linear", zero: true, domain: [4000, 2000, 1000]}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "linear",
     domain: [4000, 2000, 0],
     range: [20, 320, 620],
@@ -345,7 +345,7 @@ it("plot(…).scale('color') can return undefined if no color scale is present",
 
 it("plot(…).scale('color') can return a linear scale", () => {
   const plot = Plot.dot([1, 2, 3, 4, 5], {y: d => d, fill: d => d}).plot();
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [1, 5],
     range: [0, 1],
@@ -356,7 +356,7 @@ it("plot(…).scale('color') can return a linear scale", () => {
 
 it("plot(…).scale('color') can return a linear scale with an explicit range and RGB interpolation", () => {
   const plot = Plot.ruleX([100, 200, 300, 400], {stroke: d => d}).plot({color: {range: ["yellow", "blue"]}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [100, 400],
     range: ["yellow", "blue"],
@@ -368,7 +368,7 @@ it("plot(…).scale('color') can return a linear scale with an explicit range an
 it("plot(…).scale('color') can return a utc scale", async () => {
   const aapl = await d3.csv("data/aapl.csv", d3.autoType);
   const plot = Plot.dot(aapl, {x: "Close", stroke: "Date"}).plot();
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "utc",
     domain: [new Date("2013-05-13"), new Date("2018-05-11")],
     range: [0, 1],
@@ -380,7 +380,7 @@ it("plot(…).scale('color') can return a utc scale", async () => {
 it("plot(…).scale('color') can return an asymmetric diverging scale", async () => {
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging", symmetric: false}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging",
     domain: [-0.78, 1.35],
     pivot: 0,
@@ -393,7 +393,7 @@ it("plot(…).scale('color') can return an asymmetric diverging scale", async ()
 it("plot(…).scale('color') can return a symmetric diverging scale", async () => {
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging",
     domain: [-1.35, 1.35],
     interpolate: d3.interpolateRdBu,
@@ -407,7 +407,7 @@ it("plot(…).scale('color') can return a diverging scale with an explicit range
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging", symmetric: false, range: ["red", "white", "blue"]}});
   const {interpolate, ...color} = plot.scale("color");
-  assert.deepStrictEqual(color, {
+  scaleEqual(color, {
     type: "diverging",
     domain: [-0.78, 1.35],
     pivot: 0,
@@ -424,7 +424,7 @@ it("plot(…).scale('color') can return a diverging scale with an explicit schem
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging", symmetric: false, range: [0, 0.5], scheme: "rdbu"}});
   const {interpolate, ...color} = plot.scale("color");
-  assert.deepStrictEqual(color, {
+  scaleEqual(color, {
     type: "diverging",
     domain: [-0.78, 1.35],
     pivot: 0,
@@ -440,7 +440,7 @@ it("plot(…).scale('color') can return a transformed diverging scale", async ()
   const transform = d => d * 100;
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging", transform, symmetric: false}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging",
     domain: [-78, 135],
     pivot: 0,
@@ -455,7 +455,7 @@ it("plot(…).scale('color') can return a transformed symmetric diverging scale"
   const transform = d => d * 100;
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging", transform}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging",
     domain: [-135, 135],
     pivot: 0,
@@ -469,7 +469,7 @@ it("plot(…).scale('color') can return a transformed symmetric diverging scale"
 it("plot(…).scale('color') can return an asymmetric diverging pow scale with an explicit scheme", async () => {
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging-sqrt", symmetric: false, scheme: "piyg"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging-pow",
     exponent: 0.5,
     domain: [-0.78, 1.35],
@@ -483,7 +483,7 @@ it("plot(…).scale('color') can return an asymmetric diverging pow scale with a
 it("plot(…).scale('color') can return an asymmetric diverging pow scale with an explicit exponent and scheme", async () => {
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging-pow", exponent: 2, symmetric: false, scheme: "piyg"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging-pow",
     exponent: 2,
     domain: [-0.78, 1.35],
@@ -497,7 +497,7 @@ it("plot(…).scale('color') can return an asymmetric diverging pow scale with a
 it("plot(…).scale('color') can return an asymmetric diverging symlog scale with an explicit constant", async () => {
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", stroke: "Anomaly"}).plot({color: {type: "diverging-symlog", constant: 2, symmetric: false, scheme: "piyg"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging-symlog",
     constant: 2,
     domain: [-0.78, 1.35],
@@ -511,7 +511,7 @@ it("plot(…).scale('color') can return an asymmetric diverging symlog scale wit
 it("plot(…).scale('color') can return an asymmetric diverging log scale with an explicit pivot and base", async () => {
   const aapl = await d3.csv("data/aapl.csv", d3.autoType);
   const plot = Plot.dot(aapl, {x: "Date", stroke: "Volume"}).plot({color: {type: "diverging-log", pivot: 1e8, base: 10, symmetric: false, scheme: "piyg"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging-log",
     base: 10,
     domain: [11475900, 266380800],
@@ -526,7 +526,7 @@ it("plot(…).scale('color') can return an asymmetric diverging log scale with a
   const transform = d => -d;
   const aapl = await d3.csv("data/aapl.csv", d3.autoType);
   const plot = Plot.dot(aapl, {x: "Date", stroke: "Volume"}).plot({color: {type: "diverging-log", transform, pivot: -1e8, base: 10, symmetric: false, scheme: "piyg"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "diverging-log",
     base: 10,
     domain: [-266380800, -11475900],
@@ -546,7 +546,7 @@ it("plot(…).scale('color') can return a “polylinear” piecewise linear scal
       range: ["yellow", "blue", "black"]
     }
   });
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [0, 150, 500],
     range: ["yellow", "blue", "black"],
@@ -563,7 +563,7 @@ it("plot(…).scale('color') can return a polylinear piecewise linear scale with
       scheme: "warm"
     }
   });
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [0, 150, 500],
     range: [0, 0.5, 1],
@@ -582,7 +582,7 @@ it("plot(…).scale('color') can return a reversed polylinear piecewise linear s
     }
   });
   const {interpolate, ...color} = plot.scale("color");
-  assert.deepStrictEqual(color, {
+  scaleEqual(color, {
     type: "linear",
     domain: [0, 150, 500],
     range: [0, 0.5, 1],
@@ -601,7 +601,7 @@ it("plot(…).scale('color') can return a polylinear piecewise sqrt scale with a
       scheme: "warm"
     }
   });
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "pow",
     exponent: 0.5,
     domain: [0, 150, 500],
@@ -620,7 +620,7 @@ it("plot(…).scale('color') can return a polylinear piecewise pow scale with an
       scheme: "warm"
     }
   });
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "pow",
     exponent: 0.3,
     domain: [0, 150, 500],
@@ -638,7 +638,7 @@ it("plot(…).scale('color') can return a polylinear piecewise log scale with an
       scheme: "warm"
     }
   });
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "log",
     base: 10,
     domain: [1, 10, 500],
@@ -656,7 +656,7 @@ it("plot(…).scale('color') can return a polylinear piecewise symlog scale with
       scheme: "warm"
     }
   });
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "symlog",
     constant: 1,
     domain: [1, 10, 500],
@@ -669,7 +669,7 @@ it("plot(…).scale('color') can return a polylinear piecewise symlog scale with
 it("plot(…).scale('color') can return a threshold scale with the default domain", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "threshold"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [0],
     range: [d3.schemeRdYlBu[3][0], d3.schemeRdYlBu[3][2]],
@@ -681,7 +681,7 @@ it("plot(…).scale('color') can return a threshold scale with an explicit domai
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const domain = d3.ticks(...d3.extent(penguins, d => d.body_mass_g), 5);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "threshold", domain}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [3000, 4000, 5000, 6000],
     range: d3.schemeRdYlBu[5],
@@ -692,7 +692,7 @@ it("plot(…).scale('color') can return a threshold scale with an explicit domai
 it("plot(…).scale('color') can return a threshold scale with an explicit scheme", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "threshold", scheme: "blues"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [0],
     range: [d3.schemeBlues[3][0], d3.schemeBlues[3][1]],
@@ -703,7 +703,7 @@ it("plot(…).scale('color') can return a threshold scale with an explicit schem
 it("plot(…).scale('color') can return a threshold scale with an explicit interpolator", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "threshold", interpolate: d3.interpolateReds}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [0],
     range: d3.quantize(d3.interpolateReds, 2),
@@ -714,7 +714,7 @@ it("plot(…).scale('color') can return a threshold scale with an explicit inter
 it("plot(…).scale('color') can promote a quantile scale to a threshold scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "quantile"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [3475, 3800, 4300, 4950],
     range: d3.schemeRdYlBu[5],
@@ -725,7 +725,7 @@ it("plot(…).scale('color') can promote a quantile scale to a threshold scale",
 it("plot(…).scale('color') can promote a quantile scale with an explicit discrete scheme to a threshold scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "quantile", scheme: "spectral"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [3475, 3800, 4300, 4950],
     range: d3.schemeSpectral[5],
@@ -736,7 +736,7 @@ it("plot(…).scale('color') can promote a quantile scale with an explicit discr
 it("plot(…).scale('color') can promote a quantile scale with an explicit continuous scheme to a threshold scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "quantile", scheme: "warm"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [3475, 3800, 4300, 4950],
     range: d3.quantize(d3.interpolateWarm, 5),
@@ -747,7 +747,7 @@ it("plot(…).scale('color') can promote a quantile scale with an explicit conti
 it("plot(…).scale('color') can promote a quantile scale with an explicit continuous interpolator to a threshold scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "quantile", interpolate: d3.interpolateRainbow}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [3475, 3800, 4300, 4950],
     range: d3.quantize(d3.interpolateRainbow, 5),
@@ -758,7 +758,7 @@ it("plot(…).scale('color') can promote a quantile scale with an explicit conti
 it("plot(…).scale('color') can promote a quantile scale with an explicit number of quantiles to a threshold scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "quantile", quantiles: 10}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [3300, 3475, 3650, 3800, 4050, 4300, 4650, 4950, 5400],
     range: d3.schemeRdYlBu[10],
@@ -770,7 +770,7 @@ it("plot(…).scale('color') can promote a quantile scale with an explicit range
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const range = ["red", "yellow", "blue", "green"]; // for quartiles
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "quantile", range}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [3550, 4050, 4750],
     range,
@@ -781,7 +781,7 @@ it("plot(…).scale('color') can promote a quantile scale with an explicit range
 it("plot(…).scale('color') can promote a reversed quantile scale to a threshold scale with a reversed range", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "body_mass_g"}).plot({color: {type: "quantile", reverse: true}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [3475, 3800, 4300, 4950],
     range: d3.reverse(d3.schemeRdYlBu[5]),
@@ -791,7 +791,7 @@ it("plot(…).scale('color') can promote a reversed quantile scale to a threshol
 
 it("plot(…).scale('color') promotes a cyclical scale to a linear scale", () => {
   const plot = Plot.dot([1, 2, 3, 4, 5], {y: d => d, fill: d => d}).plot({color: {type: "cyclical"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [1, 5],
     range: [0, 1],
@@ -802,7 +802,7 @@ it("plot(…).scale('color') promotes a cyclical scale to a linear scale", () =>
 
 it("plot(…).scale('color') ignores nonsensical options for cyclical scale", () => {
   const plot = Plot.dot([1, 2, 3, 4, 5], {y: d => d, fill: d => d}).plot({color: {type: "cyclical", pivot: 5000, symmetric: false}}); // Note: diverging options ignored here!
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [1, 5],
     range: [0, 1],
@@ -813,7 +813,7 @@ it("plot(…).scale('color') ignores nonsensical options for cyclical scale", ()
 
 it("plot(…).scale('color') promotes a cyclical scale to a linear scale, even when a scheme is specified", () => {
   const plot = Plot.dot([1, 2, 3, 4, 5], {y: d => d, fill: d => d}).plot({color: {type: "cyclical", scheme: "blues"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [1, 5],
     range: [0, 1],
@@ -824,7 +824,7 @@ it("plot(…).scale('color') promotes a cyclical scale to a linear scale, even w
 
 it("plot(…).scale('color') promotes a cyclical scale to a linear scale and ignores the scheme when an interpolator is specified", () => {
   const plot = Plot.dot([1, 2, 3, 4, 5], {y: d => d, fill: d => d}).plot({color: {type: "cyclical", scheme: "blues", interpolate: d3.interpolateWarm}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [1, 5],
     range: [0, 1],
@@ -835,7 +835,7 @@ it("plot(…).scale('color') promotes a cyclical scale to a linear scale and ign
 
 it("plot(…).scale('color') promotes a sequential scale to a linear scale, even when a scheme is specified", () => {
   const plot = Plot.dot([1, 2, 3, 4, 5], {y: d => d, fill: d => d}).plot({color: {type: "sequential", scheme: "blues"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [1, 5],
     range: [0, 1],
@@ -846,7 +846,7 @@ it("plot(…).scale('color') promotes a sequential scale to a linear scale, even
 
 it("plot(…).scale('color') promotes a sequential scale to a linear scale and ignores the scheme when an interpolator is specified", () => {
   const plot = Plot.dot([1, 2, 3, 4, 5], {y: d => d, fill: d => d}).plot({color: {type: "sequential", scheme: "blues", interpolate: d3.interpolateWarm}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [1, 5],
     range: [0, 1],
@@ -857,7 +857,7 @@ it("plot(…).scale('color') promotes a sequential scale to a linear scale and i
 
 it("plot(…).scale('color') promotes a sequential scale to a linear scale", () => {
   const plot = Plot.dot([1, 2, 3, 4, 5], {y: d => d, fill: d => d}).plot({color: {type: "sequential"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [1, 5],
     range: [0, 1],
@@ -869,7 +869,7 @@ it("plot(…).scale('color') promotes a sequential scale to a linear scale", () 
 it("plot(…).scale('color') promotes a reversed sequential scale to a linear scale with a flipped interpolator", () => {
   const plot = Plot.dot([1, 2, 3, 4, 5], {y: d => d, fill: d => d}).plot({color: {type: "sequential", reverse: true}});
   const {interpolate, ...color} = plot.scale("color");
-  assert.deepStrictEqual(color, {
+  scaleEqual(color, {
     type: "linear",
     domain: [1, 5],
     range: [0, 1],
@@ -883,7 +883,7 @@ it("plot(…).scale('color') promotes a reversed sequential scale to a linear sc
 it("plot(…).scale('color') can return an ordinal scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "island"}).plot();
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "ordinal",
     domain: ["Biscoe", "Dream", "Torgersen"],
     range: d3.schemeTableau10,
@@ -895,7 +895,7 @@ it("plot(…).scale('color') can return an ordinal scale with a transform", asyn
   const transform = d => d.toUpperCase();
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "island"}).plot({color: {transform}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "ordinal",
     domain: ["BISCOE", "DREAM", "TORGERSEN"],
     transform,
@@ -907,7 +907,7 @@ it("plot(…).scale('color') can return an ordinal scale with a transform", asyn
 it("plot(…).scale('color') can promote a reversed categorical scale to an ordinal scale with a reversed domain", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "island"}).plot({color: {reverse: true}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "ordinal",
     domain: ["Torgersen", "Dream", "Biscoe"],
     range: d3.schemeTableau10,
@@ -918,7 +918,7 @@ it("plot(…).scale('color') can promote a reversed categorical scale to an ordi
 it("plot(…).scale('color') can promotes an explicitly categorical scale to an ordinal scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "island"}).plot({color: {type: "categorical"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "ordinal",
     domain: ["Biscoe", "Dream", "Torgersen"],
     range: d3.schemeTableau10,
@@ -929,7 +929,7 @@ it("plot(…).scale('color') can promotes an explicitly categorical scale to an 
 it("plot(…).scale('color') can return an explicitly ordinal scale", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "island"}).plot({color: {type: "ordinal"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "ordinal",
     domain: ["Biscoe", "Dream", "Torgersen"],
     range: d3.quantize(d3.interpolateTurbo, 3),
@@ -940,7 +940,7 @@ it("plot(…).scale('color') can return an explicitly ordinal scale", async () =
 it("plot(…).scale('color') promotes a reversed ordinal scale to an ordinal scale with a reversed domain", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "island"}).plot({color: {type: "ordinal", reverse: true}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "ordinal",
     domain: ["Torgersen", "Dream", "Biscoe"],
     range: d3.quantize(d3.interpolateTurbo, 3),
@@ -952,7 +952,7 @@ it("plot(…).scale('color') can return a ordinal scale with an explicit range",
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const range = ["yellow", "lime", "black", "red"];
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "island"}).plot({color: {range}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "ordinal",
     domain: ["Biscoe", "Dream", "Torgersen"],
     range,
@@ -964,7 +964,7 @@ it("plot(…).scale('color') can return an ordinal scale with an explicit range"
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const range = ["yellow", "lime", "black", "red"];
   const plot = Plot.dot(penguins, {x: "body_mass_g", fill: "island"}).plot({color: {type: "ordinal", range}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "ordinal",
     domain: ["Biscoe", "Dream", "Torgersen"],
     range,
@@ -979,7 +979,7 @@ it("plot(…).scale('r') can return undefined", () => {
 
 it("plot(…).scale('r') can return an implicit pow scale", () => {
   const plot = Plot.dot([1, 2, 3, 4, 9], {r: d => d}).plot();
-  assert.deepStrictEqual(plot.scale("r"), {
+  scaleEqual(plot.scale("r"), {
     type: "pow",
     exponent: 0.5,
     domain: [0, 9],
@@ -991,7 +991,7 @@ it("plot(…).scale('r') can return an implicit pow scale", () => {
 
 it("plot(…).scale('r') can return a pow scale for sqrt", () => {
   const plot = Plot.dot([1, 2, 3, 4, 9], {r: d => d}).plot({r: {type: "sqrt"}});
-  assert.deepStrictEqual(plot.scale("r"), {
+  scaleEqual(plot.scale("r"), {
     type: "pow",
     exponent: 0.5,
     domain: [0, 9],
@@ -1003,7 +1003,7 @@ it("plot(…).scale('r') can return a pow scale for sqrt", () => {
 
 it("plot(…).scale('r') can return an explicit pow scale", () => {
   const plot = Plot.dot([1, 2, 3, 4, 9], {r: d => d}).plot({r: {type: "pow", exponent: 0.3}});
-  assert.deepStrictEqual(plot.scale("r"), {
+  scaleEqual(plot.scale("r"), {
     type: "pow",
     exponent: 0.3,
     domain: [0, 9],
@@ -1015,7 +1015,7 @@ it("plot(…).scale('r') can return an explicit pow scale", () => {
 
 it("plot(…).scale('r') can return an implicit pow scale with an explicit range", () => {
   const plot = Plot.dot([1, 2, 3, 4, 9], {r: d => d}).plot({r: {range: [2, 13]}}); // Note: range should normally start at zero!
-  assert.deepStrictEqual(plot.scale("r"), {
+  scaleEqual(plot.scale("r"), {
     type: "pow",
     exponent: 0.5,
     domain: [0, 9],
@@ -1032,7 +1032,7 @@ it("plot(…).scale('opacity') can return undefined", () => {
 
 it("plot(…).scale('opacity') can return a linear scale", () => {
   const plot = Plot.dot([1, 2, 3, 4, 9], {fillOpacity: d => d}).plot();
-  assert.deepStrictEqual(plot.scale("opacity"), {
+  scaleEqual(plot.scale("opacity"), {
     type: "linear",
     domain: [0, 9],
     range: [0, 1],
@@ -1044,7 +1044,7 @@ it("plot(…).scale('opacity') can return a linear scale", () => {
 it("plot(…).scale('opacity') can return a linear scale for penguins", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.rectX(penguins, Plot.binX({fillOpacity: "count"}, {x: "body_mass_g", thresholds: 20})).plot();
-  assert.deepStrictEqual(plot.scale("opacity"), {
+  scaleEqual(plot.scale("opacity"), {
     type: "linear",
     domain: [0, 40],
     range: [0, 1],
@@ -1057,7 +1057,7 @@ it("plot(…).scale('opacity') can return a linear scale for penguins", async ()
 it("plot(…).scale('opacity') respects the percent option, affecting domain and label", async () => {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.rectX(penguins, Plot.binX({fillOpacity: "proportion"}, {x: "body_mass_g", thresholds: 20})).plot({opacity: {percent: true}});
-  assert.deepStrictEqual(plot.scale("opacity"), {
+  scaleEqual(plot.scale("opacity"), {
     type: "linear",
     domain: [0, 11.627906976744185],
     range: [0, 1],
@@ -1188,7 +1188,7 @@ it("plot(…).scale(name).exponent returns the expected exponent for pow and sqr
 
 it("plot(…).scale('y') can return a log scale", () => {
   const plot = Plot.dotY([1, 2, 3, 4]).plot({y: {type: "log"}});
-  assert.deepStrictEqual(plot.scale("y"), {
+  scaleEqual(plot.scale("y"), {
     type: "log",
     domain: [1, 4],
     range: [380, 20],
@@ -1206,7 +1206,7 @@ it("plot(…).scale(name).base returns the expected base for log scales", () => 
 
 it("plot(…).scale('y') can return a symlog scale", () => {
   const plot = Plot.dotY([1, 2, 3, 4]).plot({y: {type: "symlog"}});
-  assert.deepStrictEqual(plot.scale("y"), {
+  scaleEqual(plot.scale("y"), {
     type: "symlog",
     domain: [1, 4],
     range: [380, 20],
@@ -1266,7 +1266,7 @@ it("plot(…).scale(name) reflects the given custom interpolator", async () => {
   const interpolate = (a, b) => t => +(t * (b - a) + a).toFixed(1);
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dotX(penguins, {x: "body_mass_g"}).plot({x: {interpolate}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "linear",
     domain: [2700, 6300],
     range: [20, 620],
@@ -1279,7 +1279,7 @@ it("plot(…).scale(name) reflects the given custom interpolator", async () => {
 it("plot(…).scale('color') allows a range to be specified in conjunction with a scheme", async () => {
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", fill: "Anomaly"}).plot({color: {range: [0, 0.5], scheme: "cool"}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [-0.78, 1.35],
     range: [0, 0.5],
@@ -1292,7 +1292,7 @@ it("plot(…).scale('color') allows a range to be specified in conjunction with 
 it("plot(…).scale('color') allows a range to be specified in conjunction with a single-argument interpolator", async () => {
   const gistemp = await d3.csv("data/gistemp.csv", d3.autoType);
   const plot = Plot.dot(gistemp, {x: "Date", fill: "Anomaly"}).plot({color: {range: [0, 0.5], interpolate: d3.interpolateCool}});
-  assert.deepStrictEqual(plot.scale("color"), {
+  scaleEqual(plot.scale("color"), {
     type: "linear",
     domain: [-0.78, 1.35],
     range: [0, 0.5],
@@ -1322,7 +1322,7 @@ it("plot(…).scale(name) reflects the given transform", async () => {
   const transform = d => 1 / d;
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
   const plot = Plot.dot(penguins, {x: "body_mass_g"}).plot({x: {transform}});
-  assert.deepStrictEqual(plot.scale("x"), {
+  scaleEqual(plot.scale("x"), {
     type: "linear",
     domain: [1 / 6300, 1 / 2700],
     range: [20, 620],
@@ -1335,8 +1335,16 @@ it("plot(…).scale(name) reflects the given transform", async () => {
 
 it("plot(…).scale(name) can return an identity scale, ignoring all other options", () => {
   const plot = Plot.dot([1, 2], {x: d => d, fill: d => d}).plot({x: {type: "identity"}, color: {type: "identity"}});
-  assert.deepStrictEqual(plot.scale("x"), {type: "identity"});
-  assert.deepStrictEqual(plot.scale("color"), {type: "identity"});
+  scaleEqual(plot.scale("x"), {type: "identity"});
+  scaleEqual(plot.scale("color"), {type: "identity"});
+});
+
+it("plot(…).scale(name).apply and invert return the expected functions", () => {
+  scaleApply({domain: [0, 1], range: [0, -1]}, [[2, -2]]);
+  scaleApply({domain: [0, 1], range: [0, -1], type: "sqrt"}, [[4, -2]]);
+  scaleApply({domain: [1, 1000], range: [0, 3], type: "log"}, [[10, 1], [100, 2]]);
+  scaleApply({domain: [0, 100], type: "symlog"}, [[100, 620], [0, 20], [-100, -580]]);
+  scaleApply({type: "identity"}, [[10, 10], [100, 100]]);
 });
 
 // Given a plot specification (or, as shorthand, an array of marks or a single
@@ -1353,3 +1361,25 @@ it("plot(…).scale(name) can return an identity scale, ignoring all other optio
 //   assert.deepStrictEqual(scales1, scales2);
 //   assert.strictEqual(plot1.outerHTML, plot2.outerHTML);
 // }
+
+function scaleEqual({...scale}, spec) {
+  if (typeof scale.apply !== "function") {
+    scale.apply = typeof scale.apply; // allows visual debugging
+  } else {
+    delete scale.apply;
+  }
+  if (typeof scale.invert !== "function" && !(["band", "point", "threshold", "ordinal", "diverging", "diverging-log", "diverging-symlog", "diverging-pow" ].includes(scale.type))) {
+    scale.invert = typeof scale.invert;
+  } else {
+    delete scale.invert;
+  }
+  return assert.deepStrictEqual(scale, spec);
+}
+
+function scaleApply(x, pairs) {
+  x = Plot.plot({x}).scale("x");
+  for (const [input, output] of pairs) {
+    assert.strictEqual(+x.apply(input).toFixed(10), output);
+    assert.strictEqual(+x.invert(output).toFixed(10), input);
+  }
+}


### PR DESCRIPTION
(Note that diverging scales do not expose invert, as per d3-scale.)