### PR TITLE
warn about ignored indices

### DIFF
--- a/src/defined.js
+++ b/src/defined.js
@@ -17,8 +17,15 @@ export function nonempty(x) {
 }
 
 export function filter(index, ...channels) {
+  const ignored = [];
   for (const c of channels) {
-    if (c) index = index.filter(i => defined(c[i]));
+    if (c) {
+      const test = typeof c === "function" ? c : i => defined(c[i]);
+      index = index.filter(i => test(i) || (ignored.push(i), false));
+    }
+  }
+  if (ignored.length > 0) {
+    console.warn(`ignored indices:`, ignored);
   }
   return index;
 }

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -33,8 +33,7 @@ export class Dot extends Mark {
   ) {
     const {x: X, y: Y, r: R} = channels;
     const {dx, dy} = this;
-    let index = filter(I, X, Y);
-    if (R) index = index.filter(i => positive(R[i]));
+    const index = filter(I, X, Y, R && (i => positive(R[i])));
     return create("svg:g")
         .call(applyIndirectStyles, this)
         .call(applyTransform, x, y, offset + dx, offset + dy)

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -51,7 +51,7 @@ export class Text extends Mark {
     const {x: X, y: Y, rotate: R, text: T, fontSize: FS} = channels;
     const {width, height, marginTop, marginRight, marginBottom, marginLeft} = dimensions;
     const {rotate} = this;
-    const index = filter(I, X, Y, R).filter(i => nonempty(T[i]));
+    const index = filter(I, X, Y, R, i => nonempty(T[i]));
     const cx = (marginLeft + width - marginRight) / 2;
     const cy = (marginTop + height - marginBottom) / 2;
     return create("svg:g")


### PR DESCRIPTION
for #493 #536

example with the wordcloud, in which all words which appear once are ignored:
<img width="780" alt="Capture d’écran 2021-11-23 à 12 44 29" src="https://user-images.githubusercontent.com/7001/143018462-95b66f3e-4c4a-4b34-ad3e-56f1e2ced669.png">

