### PR TITLE
document *width* for swatches legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ Categorical and ordinal color legends are rendered as swatches, unless *options*
 * *options*.**columns** - the number of swatches per row
 * *options*.**marginLeft** - the legend’s left margin
 * *options*.**className** - a class name, that defaults to a randomly generated string scoping the styles
+* *options*.**width** - the legend’s width (in pixels)
 
 Continuous color legends are rendered as a ramp, and can be configured with the following options:
 


### PR DESCRIPTION
it's a bit unintuitive at first how this interacts with columns, but the plot-legends notebook helps to clarify