### PR TITLE
throw an error if there is not enough space for the x or y scales

### DIFF
--- a/src/scales.js
+++ b/src/scales.js
@@ -72,7 +72,10 @@ function autoScaleRangeX(scale, dimensions) {
   if (scale.range === undefined) {
     const {insetLeft, insetRight} = scale;
     const {width, marginLeft = 0, marginRight = 0} = dimensions;
-    scale.range = [marginLeft + insetLeft, width - marginRight - insetRight];
+    const left = marginLeft + insetLeft;
+    const right = width - marginRight - insetRight;
+    if (right < left) throw new Error("Not enough space left for x");
+    scale.range = [left, right];
     if (!isOrdinalScale(scale)) scale.range = piecewiseRange(scale);
     scale.scale.range(scale.range);
   }
@@ -83,7 +86,10 @@ function autoScaleRangeY(scale, dimensions) {
   if (scale.range === undefined) {
     const {insetTop, insetBottom} = scale;
     const {height, marginTop = 0, marginBottom = 0} = dimensions;
-    scale.range = [height - marginBottom - insetBottom, marginTop + insetTop];
+    const top = height - marginBottom - insetBottom;
+    const bottom = marginTop + insetTop;
+    if (top < bottom) throw new Error("Not enough space left for y");
+    scale.range = [top, bottom];
     if (!isOrdinalScale(scale)) scale.range = piecewiseRange(scale);
     else scale.range.reverse();
     scale.scale.range(scale.range);

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -1090,6 +1090,16 @@ it("plot({inset, …}).scale('x').range respects the given scale-level inset", (
   assert.deepStrictEqual(Plot.dot([1, 2, 3], {x: d => d}).plot({x: {inset: 7}}).scale("x").range, [27, 613]);
 });
 
+it("plot({inset, …}).scale('x') throws if there is not enough space", () => {
+  assert.throws(() => Plot.plot({x: {inset: 60}, width: 100}));
+  assert.throws(() => Plot.plot({x: {inset: 30}, margin: 30, width: 100}));
+});
+
+it("plot({inset, …}).scale('y') throws if there is not enough space", () => {
+  assert.throws(() => Plot.plot({y: {inset: 60}, height: 100}));
+  assert.throws(() => Plot.plot({y: {inset: 30}, margin: 30, height: 100}));
+});
+
 it("plot({clamp, …}).scale('x').clamp reflects the given clamp option", () => {
   assert.strictEqual(Plot.dot([1, 2, 3], {x: d => d}).plot({x: {clamp: false}}).scale("x").clamp, false);
   assert.strictEqual(Plot.dot([1, 2, 3], {x: d => d}).plot({x: {clamp: true}}).scale("x").clamp, true);


### PR DESCRIPTION
demo: https://observablehq.com/@observablehq/collapsing-ranges-618

the most difficult part was to come up with a somehow relevant error message

closes #616