### PR TITLE
fix quantized ordinal color schemes

### DIFF
--- a/src/scales/schemes.js
+++ b/src/scales/schemes.js
@@ -158,7 +158,7 @@ function scheme11(scheme, interpolate) {
 
 function scheme11r(scheme, interpolate) {
   return ({length: n}) => {
-    if (n === 2) return [scheme[3][0], scheme[3][2]]; // favor diverging extrema
+    if (n === 2) return [scheme[3][2], scheme[3][0]]; // favor diverging extrema
     n = n > 3 ? Math.floor(n) : 3;
     return n > 11 ? quantize(t => interpolate(1 - t), n) : scheme[n].slice().reverse();
   };

--- a/src/scales/schemes.js
+++ b/src/scales/schemes.js
@@ -143,7 +143,7 @@ const ordinalSchemes = new Map([
 
 function scheme9(scheme, interpolate) {
   return ({length: n}) => {
-    n = n > 3 ? Math.floor(n) : 3;
+    n = Math.max(3, Math.floor(n));
     return n > 9 ? quantize(interpolate, n) : scheme[n];
   };
 }
@@ -151,7 +151,7 @@ function scheme9(scheme, interpolate) {
 function scheme11(scheme, interpolate) {
   return ({length: n}) => {
     if (n === 2) return [scheme[3][0], scheme[3][2]]; // favor diverging extrema
-    n = n > 3 ? Math.floor(n) : 3;
+    n = Math.max(3, Math.floor(n));
     return n > 11 ? quantize(interpolate, n) : scheme[n];
   };
 }
@@ -159,17 +159,17 @@ function scheme11(scheme, interpolate) {
 function scheme11r(scheme, interpolate) {
   return ({length: n}) => {
     if (n === 2) return [scheme[3][2], scheme[3][0]]; // favor diverging extrema
-    n = n > 3 ? Math.floor(n) : 3;
+    n = Math.max(3, Math.floor(n));
     return n > 11 ? quantize(t => interpolate(1 - t), n) : scheme[n].slice().reverse();
   };
 }
 
 function schemei(interpolate) {
-  return ({length: n}) => quantize(interpolate, n > 0 ? Math.floor(n) : 0);
+  return ({length: n}) => quantize(interpolate, Math.max(2, Math.floor(n)));
 }
 
 function schemeicyclical(interpolate) {
-  return ({length: n}) => quantize(interpolate, n > 0 ? Math.floor(n) + 1 : 1).slice(0, -1);
+  return ({length: n}) => quantize(interpolate, Math.floor(n) + 1).slice(0, -1);
 }
 
 export function ordinalScheme(scheme) {

--- a/test/output/colorSchemesOrdinal.html
+++ b/test/output/colorSchemesOrdinal.html
@@ -3295,7 +3295,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-97-swatch" style="--color: #ef8a62;">burd</span><span class="plot-97-swatch" style="--color: #67a9cf;">1</span>
+    </style><span class="plot-97-swatch" style="--color: #67a9cf;">burd</span><span class="plot-97-swatch" style="--color: #ef8a62;">1</span>
   </div>
   <div class="plot-98" style="
         --swatchWidth: 15px;
@@ -3465,7 +3465,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-102-swatch" style="--color: #fc8d59;">buylrd</span><span class="plot-102-swatch" style="--color: #91bfdb;">1</span>
+    </style><span class="plot-102-swatch" style="--color: #91bfdb;">buylrd</span><span class="plot-102-swatch" style="--color: #fc8d59;">1</span>
   </div>
   <div class="plot-103" style="
         --swatchWidth: 15px;

--- a/test/output/colorSchemesOrdinal.html
+++ b/test/output/colorSchemesOrdinal.html
@@ -4621,7 +4621,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-136-swatch" style="--color: rgb(NaN, NaN, NaN);">turbo</span>
+    </style><span class="plot-136-swatch" style="--color: rgb(35, 23, 27);">turbo</span>
   </div>
   <div class="plot-137" style="
         --swatchWidth: 15px;
@@ -4791,7 +4791,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-141-swatch">viridis</span>
+    </style><span class="plot-141-swatch" style="--color: #440154;">viridis</span>
   </div>
   <div class="plot-142" style="
         --swatchWidth: 15px;
@@ -4961,7 +4961,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-146-swatch">magma</span>
+    </style><span class="plot-146-swatch" style="--color: #000004;">magma</span>
   </div>
   <div class="plot-147" style="
         --swatchWidth: 15px;
@@ -5131,7 +5131,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-151-swatch">inferno</span>
+    </style><span class="plot-151-swatch" style="--color: #000004;">inferno</span>
   </div>
   <div class="plot-152" style="
         --swatchWidth: 15px;
@@ -5301,7 +5301,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-156-swatch">plasma</span>
+    </style><span class="plot-156-swatch" style="--color: #0d0887;">plasma</span>
   </div>
   <div class="plot-157" style="
         --swatchWidth: 15px;
@@ -5471,7 +5471,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-161-swatch" style="--color: rgb(NaN, NaN, NaN);">cividis</span>
+    </style><span class="plot-161-swatch" style="--color: rgb(0, 32, 81);">cividis</span>
   </div>
   <div class="plot-162" style="
         --swatchWidth: 15px;
@@ -5811,7 +5811,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-171-swatch" style="--color: rgb(0, 0, 0);">warm</span>
+    </style><span class="plot-171-swatch" style="--color: rgb(110, 64, 170);">warm</span>
   </div>
   <div class="plot-172" style="
         --swatchWidth: 15px;
@@ -5981,7 +5981,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-176-swatch" style="--color: rgb(0, 0, 0);">cool</span>
+    </style><span class="plot-176-swatch" style="--color: rgb(110, 64, 170);">cool</span>
   </div>
   <div class="plot-177" style="
         --swatchWidth: 15px;


### PR DESCRIPTION
Fixes burd and buylrd with n=2:
<img width="585" alt="Screen Shot 2021-12-30 at 4 47 57 PM" src="https://user-images.githubusercontent.com/230541/147796784-b1ccecae-33cf-4939-bdd3-93aecd00d76a.png">

Fixes turbo, virdis et al. with n=1:
<img width="588" alt="Screen Shot 2021-12-30 at 4 48 19 PM" src="https://user-images.githubusercontent.com/230541/147796795-073f3e21-552b-41e2-b65b-7f8367983545.png">

Fixes warm and cool with n=1:
<img width="576" alt="Screen Shot 2021-12-30 at 4 48 43 PM" src="https://user-images.githubusercontent.com/230541/147796806-21fb9fde-fc97-40e5-a96c-9bc37a1025df.png">

I decided to leave cubehelix as-is, since that’s how the scheme is designed.