### PR TITLE
standalone scales with Plot.scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ const color = plot.scale("color"); // retrieve the color scale object
 console.log(color.range); // inspect the color scale’s range, ["red", "blue"]
 ```
 
+You can also create a standalone scale with Plot.**scale**(*options*):
+
+```js
+const color = Plot.scale({color: {type: "linear"}});
+```
+
 To reuse a scale across plots, pass the scale object into another plot specification:
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -23,4 +23,5 @@ export {window, windowX, windowY} from "./transforms/window.js";
 export {selectFirst, selectLast, selectMaxX, selectMaxY, selectMinX, selectMinY} from "./transforms/select.js";
 export {stackX, stackX1, stackX2, stackY, stackY1, stackY2} from "./transforms/stack.js";
 export {formatIsoDate, formatWeekday, formatMonth} from "./format.js";
+export {scale} from "./scales.js";
 export {legend} from "./legends.js";

--- a/src/scales.js
+++ b/src/scales.js
@@ -309,6 +309,17 @@ export function coerceDate(x) {
     : new Date(x);
 }
 
+export function scale(options = {}) {
+  let scale;
+  for (const key in options) {
+    if (!registry.has(key)) continue; // ignore unknown properties
+    if (scale !== undefined) throw new Error("ambiguous scale definition");
+    scale = exposeScale(normalizeScale(key, options[key]));
+  }
+  if (scale === undefined) throw new Error("invalid scale definition");
+  return scale;
+}
+
 export function exposeScales(scaleDescriptors) {
   return key => {
     if (!registry.has(key = `${key}`)) throw new Error(`unknown scale: ${key}`);

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -3,6 +3,17 @@ import * as d3 from "d3";
 import assert from "assert";
 import it from "../jsdom.js";
 
+it("Plot.scale(description) returns a standalone scale", () => {
+  const color = Plot.scale({color: {type: "linear"}});
+  scaleEqual(color, {
+    type: "linear",
+    domain: [0, 1],
+    range: [0, 1],
+    interpolate: d3.interpolateTurbo,
+    clamp: false
+  });
+});
+
 it("plot(…).scale(name) returns undefined for an unused scale", () => {
   const plot = Plot.dot([1, 2], {x: d => d, y: d => d}).plot();
   assert.deepStrictEqual(plot.scale("r"), undefined);


### PR DESCRIPTION
Alternative to #625. This lets you create the standalone scale directly, without requiring either a legend or a chart (but you can pass the scale to either as desired). Fixes #624.