### PR TITLE
don’t allow margins or insets to invert range

### DIFF
--- a/src/scales.js
+++ b/src/scales.js
@@ -74,7 +74,9 @@ function autoScaleRangeX(scale, dimensions) {
   if (scale.range === undefined) {
     const {insetLeft, insetRight} = scale;
     const {width, marginLeft = 0, marginRight = 0} = dimensions;
-    scale.range = [marginLeft + insetLeft, width - marginRight - insetRight];
+    const left = marginLeft + insetLeft;
+    const right = width - marginRight - insetRight;
+    scale.range = [left, Math.max(left, right)];
     if (!isOrdinalScale(scale)) scale.range = piecewiseRange(scale);
     scale.scale.range(scale.range);
   }
@@ -85,7 +87,9 @@ function autoScaleRangeY(scale, dimensions) {
   if (scale.range === undefined) {
     const {insetTop, insetBottom} = scale;
     const {height, marginTop = 0, marginBottom = 0} = dimensions;
-    scale.range = [height - marginBottom - insetBottom, marginTop + insetTop];
+    const top = marginTop + insetTop;
+    const bottom = height - marginBottom - insetBottom;
+    scale.range = [Math.max(top, bottom), top];
     if (!isOrdinalScale(scale)) scale.range = piecewiseRange(scale);
     else scale.range.reverse();
     scale.scale.range(scale.range);

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -1091,6 +1091,16 @@ it("plot(…).scale('opacity') respects the percent option, affecting domain and
   });
 });
 
+it("plot({inset, …}).scale('x') does not allow insets or margins to invert the range", () => {
+  assert.deepStrictEqual(Plot.plot({x: {inset: 60}, width: 100}).scale("x").range, [80, 80]);
+  assert.deepStrictEqual(Plot.plot({x: {inset: 30}, margin: 30, width: 100}).scale("x").range, [60, 60]);
+});
+
+it("plot({inset, …}).scale('y') does not allow insets or margins to invert the range", () => {
+  assert.deepStrictEqual(Plot.plot({y: {inset: 60}, height: 100}).scale("y").range, [80, 80]);
+  assert.deepStrictEqual(Plot.plot({y: {inset: 30}, margin: 30, height: 100}).scale("y").range, [60, 60]);
+});
+
 it("plot({inset, …}).scale('x').range respects the given top-level inset", () => {
   assert.deepStrictEqual(Plot.dot([1, 2, 3], {x: d => d}).plot({inset: 0}).scale("x").range, [20, 620]);
   assert.deepStrictEqual(Plot.dot([1, 2, 3], {x: d => d}).plot({inset: 7}).scale("x").range, [27, 613]);


### PR DESCRIPTION
Alternative to #618. Fixes #616. This behavior is more consistent with how rects treat insets, e.g.,

https://github.com/observablehq/plot/blob/72b2adbc28ed12a2fb2de800af8b57bd14a63154/src/marks/rect.js#L57-L60

I’d slightly prefer using the midpoint here, something like:

```js
if (right >= left) {
  scale.range = [left, right];
} else {
  const center = (right + left) / 2;
  scale.range = [center, center];
}
```

But then I’d want rects to behave similarly, and I don’t think it’s really worth the trouble for such a rare thing. Mostly I just want to avoid the surprising (to me) behavior of the scale’s range getting inverted when the insets or margins are too big, and I think a collapsed range is a sufficient indication of a misconfiguration and we don’t need to do more.