### PR TITLE
“mid” interval transform

### DIFF
--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -1,6 +1,6 @@
 import {create} from "d3";
 import {filter, positive} from "../defined.js";
-import {maybeIntervalX, maybeIntervalY} from "../transforms/interval.js";
+import {maybeIntervalMidX, maybeIntervalMidY} from "../transforms/interval.js";
 import {Mark, identity, maybeNumber, maybeTuple} from "../mark.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransform, offset} from "../style.js";
 
@@ -53,13 +53,13 @@ export class Dot extends Mark {
 
 export function dot(data, {x, y, ...options} = {}) {
   ([x, y] = maybeTuple(x, y));
-  return new Dot(data, maybeIntervalY(maybeIntervalX({...options, x, y})));
+  return new Dot(data, maybeIntervalMidY(maybeIntervalMidX({...options, x, y})));
 }
 
 export function dotX(data, {x = identity, ...options} = {}) {
-  return new Dot(data, maybeIntervalY({...options, x}));
+  return new Dot(data, maybeIntervalMidY({...options, x}));
 }
 
 export function dotY(data, {y = identity, ...options} = {}) {
-  return new Dot(data, maybeIntervalX({...options, y}));
+  return new Dot(data, maybeIntervalMidX({...options, y}));
 }

--- a/src/marks/image.js
+++ b/src/marks/image.js
@@ -1,6 +1,6 @@
 import {create} from "d3";
 import {filter, positive} from "../defined.js";
-import {maybeIntervalX, maybeIntervalY} from "../transforms/interval.js";
+import {maybeIntervalMidX, maybeIntervalMidY} from "../transforms/interval.js";
 import {Mark, maybeNumber, maybeTuple, string} from "../mark.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransform, applyAttr, offset, impliedString} from "../style.js";
 
@@ -90,5 +90,5 @@ export class Image extends Mark {
 
 export function image(data, {x, y, ...options} = {}) {
   ([x, y] = maybeTuple(x, y));
-  return new Image(data, maybeIntervalY(maybeIntervalX({...options, x, y})));
+  return new Image(data, maybeIntervalMidY(maybeIntervalMidX({...options, x, y})));
 }

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -2,7 +2,7 @@ import {create} from "d3";
 import {filter, nonempty} from "../defined.js";
 import {Mark, indexOf, identity, string, maybeNumber, maybeTuple, numberChannel} from "../mark.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyAttr, applyTransform, offset} from "../style.js";
-import {maybeIntervalX, maybeIntervalY} from "../transforms/interval.js";
+import {maybeIntervalMidX, maybeIntervalMidY} from "../transforms/interval.js";
 
 const defaults = {
   strokeLinejoin: "round"
@@ -80,15 +80,15 @@ export class Text extends Mark {
 
 export function text(data, {x, y, ...options} = {}) {
   ([x, y] = maybeTuple(x, y));
-  return new Text(data, maybeIntervalY(maybeIntervalX({...options, x, y})));
+  return new Text(data, maybeIntervalMidY(maybeIntervalMidX({...options, x, y})));
 }
 
 export function textX(data, {x = identity, ...options} = {}) {
-  return new Text(data, maybeIntervalY({...options, x}));
+  return new Text(data, maybeIntervalMidY({...options, x}));
 }
 
 export function textY(data, {y = identity, ...options} = {}) {
-  return new Text(data, maybeIntervalX({...options, y}));
+  return new Text(data, maybeIntervalMidX({...options, y}));
 }
 
 function applyIndirectTextStyles(selection, mark) {

--- a/src/transforms/interval.js
+++ b/src/transforms/interval.js
@@ -9,9 +9,19 @@ function maybeInterval(interval) {
   if (typeof interval === "number") {
     const n = interval;
     // Note: this offset doesn’t support the optional step argument for simplicity.
-    interval = {floor: d => n * Math.floor(d / n), offset: d => d + n};
+    interval = {
+      floor: d => n * Math.floor(d / n),
+      mid: d => n * (Math.floor(d / n) + 0.5),
+      offset: d => d + n
+    };
   }
   if (typeof interval.floor !== "function" || typeof interval.offset !== "function") throw new Error("invalid interval");
+  if (typeof interval.mid !== "function") {
+    interval = {
+      ...interval,
+      mid: x => (x = interval.floor(x), new Date((+x + +interval.offset(x)) / 2))
+    };
+  }
   return interval;
 }
 
@@ -49,11 +59,7 @@ function maybeIntervalMidK(k, maybeInsetK, options) {
     ...options,
     [k]: {
       label: labelof(v),
-      transform: data => valueof(data, value).map(v => {
-        const a = interval.floor(v);
-        const b = interval.offset(a);
-        return a instanceof Date ? new Date((+a + +b) / 2) : (a + b) / 2;
-      })
+      transform: data => valueof(data, value).map(interval.mid)
     }
   });
 }


### PR DESCRIPTION
I prefer to keep the two transforms distinct: we’ll compute the midpoint of the interval for dot, text, and image, and the extent of the interval for other marks. This also allows the “mid” interval transform to avoid memoization.

In addition to your fix to pass *data* to the interval’s transform function in case x2 in computed before x1, I’ve also fixed the memoization to be bypassed if the *data* changes. This isn’t currently possible in Plot, but I could imagine us wanting to support data changing in the future, so fixing while I’m here.