### PR TITLE
automatic color identity range

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -25,9 +25,6 @@ export const first = d => d[0];
 export const second = d => d[1];
 export const constant = x => () => x;
 
-// A few extra color keywords not known to d3-color.
-const colors = new Set(["currentColor", "none"]);
-
 // Some channels may allow a string constant to be specified; to differentiate
 // string constants (e.g., "red") from named fields (e.g., "date"), this
 // function tests whether the given value is a CSS color string and returns a
@@ -37,7 +34,7 @@ const colors = new Set(["currentColor", "none"]);
 export function maybeColorChannel(value, defaultValue) {
   if (value === undefined) value = defaultValue;
   return value === null ? [undefined, "none"]
-    : typeof value === "string" && (colors.has(value) || color(value)) ? [undefined, value]
+    : isColor(value) ? [undefined, value]
     : [value, undefined];
 }
 
@@ -208,6 +205,20 @@ export function isNumeric(values) {
     if (value == null) continue;
     return typeof value === "number";
   }
+}
+
+// A few extra color keywords not known to d3-color.
+function isColor(value) {
+  value = `${value}`.toLowerCase();
+  return value === "currentcolor" || value === "none" || color(value);
+}
+
+export function isAllColors(values) {
+  for (const value of values) {
+    if (value == null) continue;
+    if (!isColor(value)) return false;
+  }
+  return true;
 }
 
 export function order(values) {

--- a/test/output/usCongressAgeColorExplicit.svg
+++ b/test/output/usCongressAgeColorExplicit.svg
@@ -1,0 +1,2737 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text {
+      white-space: pre;
+    }
+  </style>
+  <g transform="translate(40,0)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,270.5)">
+      <line stroke="currentColor" x2="-6"></line>
+      <line stroke="currentColor" x2="580" stroke-opacity="0.1"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,230.17741935483872)">
+      <line stroke="currentColor" x2="-6"></line>
+      <line stroke="currentColor" x2="580" stroke-opacity="0.1"></line><text fill="currentColor" x="-9" dy="0.32em">5</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,189.85483870967744)">
+      <line stroke="currentColor" x2="-6"></line>
+      <line stroke="currentColor" x2="580" stroke-opacity="0.1"></line><text fill="currentColor" x="-9" dy="0.32em">10</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,149.53225806451613)">
+      <line stroke="currentColor" x2="-6"></line>
+      <line stroke="currentColor" x2="580" stroke-opacity="0.1"></line><text fill="currentColor" x="-9" dy="0.32em">15</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,109.20967741935485)">
+      <line stroke="currentColor" x2="-6"></line>
+      <line stroke="currentColor" x2="580" stroke-opacity="0.1"></line><text fill="currentColor" x="-9" dy="0.32em">20</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,68.88709677419357)">
+      <line stroke="currentColor" x2="-6"></line>
+      <line stroke="currentColor" x2="580" stroke-opacity="0.1"></line><text fill="currentColor" x="-9" dy="0.32em">25</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,28.56451612903225)">
+      <line stroke="currentColor" x2="-6"></line>
+      <line stroke="currentColor" x2="580" stroke-opacity="0.1"></line><text fill="currentColor" x="-9" dy="0.32em">30</text>
+    </g><text fill="currentColor" transform="translate(-40,20)" dy="-1em" text-anchor="start">↑ Frequency</text>
+  </g>
+  <g transform="translate(0,270)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(40.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">30</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(123.35714285714286,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">40</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(206.21428571428572,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">50</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(289.07142857142856,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">60</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(371.92857142857144,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">70</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(454.78571428571433,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">80</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(537.6428571428571,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">90</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(620.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">100</text>
+    </g><text fill="currentColor" transform="translate(640,30)" dy="-0.32em" text-anchor="end">Age →</text>
+  </g>
+  <g transform="translate(0.5,0.5)">
+    <circle cx="56.57142857142857" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Alexandria Ocasio-Cortez</title>
+    </circle>
+    <circle cx="64.85714285714286" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Abby Finkenauer</title>
+    </circle>
+    <circle cx="73.14285714285714" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Katie Hill</title>
+    </circle>
+    <circle cx="81.42857142857143" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Josh Harder</title>
+    </circle>
+    <circle cx="81.42857142857143" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Lauren Underwood</title>
+    </circle>
+    <circle cx="81.42857142857143" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Max Rose</title>
+    </circle>
+    <circle cx="98" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Elise M. Stefanik</title>
+    </circle>
+    <circle cx="98" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Mike Gallagher</title>
+    </circle>
+    <circle cx="98" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Conor Lamb</title>
+    </circle>
+    <circle cx="98" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Joe Neguse</title>
+    </circle>
+    <circle cx="98" cy="229.67741935483872" r="3" fill="rgb(132, 165, 157)">
+      <title>Xochitl Torres Small</title>
+    </circle>
+    <circle cx="98" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Anthony Gonzalez</title>
+    </circle>
+    <circle cx="98" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>William R. Timmons IV</title>
+    </circle>
+    <circle cx="98" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Dan Crenshaw</title>
+    </circle>
+    <circle cx="106.28571428571429" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Patrick Murphy</title>
+    </circle>
+    <circle cx="106.28571428571429" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Trey Hollingsworth</title>
+    </circle>
+    <circle cx="106.28571428571429" cy="245.80645161290323" r="3" fill="rgb(132, 165, 157)">
+      <title>Haley M. Stevens</title>
+    </circle>
+    <circle cx="106.28571428571429" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Guy Reschenthaler</title>
+    </circle>
+    <circle cx="106.28571428571429" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Colin Z. Allred</title>
+    </circle>
+    <circle cx="114.57142857142857" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Matt Gaetz</title>
+    </circle>
+    <circle cx="114.57142857142857" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Andy Kim</title>
+    </circle>
+    <circle cx="114.57142857142857" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Joe Cunningham</title>
+    </circle>
+    <circle cx="114.57142857142857" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Lance Gooden</title>
+    </circle>
+    <circle cx="114.57142857142857" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Jared F. Golden</title>
+    </circle>
+    <circle cx="122.85714285714286" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Aaron Schock</title>
+    </circle>
+    <circle cx="122.85714285714286" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Tulsi Gabbard</title>
+    </circle>
+    <circle cx="122.85714285714286" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Michael F. Q. San Nicolas</title>
+    </circle>
+    <circle cx="122.85714285714286" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Ilhan Omar</title>
+    </circle>
+    <circle cx="122.85714285714286" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Bryan Steil</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Carlos Curbelo</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Ruben J. Kihuen</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Justin Amash</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Eric Swalwell</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Joseph P. Kennedy III</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Jason Smith</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Lee M. Zeldin</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Brian J. Mast</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="197.4193548387097" r="3" fill="rgb(132, 165, 157)">
+      <title>Sharice Davids</title>
+    </circle>
+    <circle cx="131.14285714285714" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Chris Pappas</title>
+    </circle>
+    <circle cx="139.42857142857144" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Scott Taylor</title>
+    </circle>
+    <circle cx="139.42857142857144" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Ruben Gallego</title>
+    </circle>
+    <circle cx="139.42857142857144" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Pete Aguilar</title>
+    </circle>
+    <circle cx="139.42857142857144" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Jim Banks</title>
+    </circle>
+    <circle cx="139.42857142857144" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Jason Crow</title>
+    </circle>
+    <circle cx="139.42857142857144" cy="221.61290322580643" r="3" fill="rgb(132, 165, 157)">
+      <title>Abigail Davis Spanberger</title>
+    </circle>
+    <circle cx="139.42857142857144" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Josh Hawley</title>
+    </circle>
+    <circle cx="147.71428571428572" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Ron DeSantis</title>
+    </circle>
+    <circle cx="147.71428571428572" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Jaime Herrera Beutler</title>
+    </circle>
+    <circle cx="147.71428571428572" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Adam Kinzinger</title>
+    </circle>
+    <circle cx="147.71428571428572" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Seth Moulton</title>
+    </circle>
+    <circle cx="147.71428571428572" cy="229.67741935483872" r="3" fill="rgb(132, 165, 157)">
+      <title>Stephanie N. Murphy</title>
+    </circle>
+    <circle cx="147.71428571428572" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Darren Soto</title>
+    </circle>
+    <circle cx="147.71428571428572" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Mike Levin</title>
+    </circle>
+    <circle cx="147.71428571428572" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>W. Gregory Steube</title>
+    </circle>
+    <circle cx="147.71428571428572" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Anthony Brindisi</title>
+    </circle>
+    <circle cx="156" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>David G. Valadao</title>
+    </circle>
+    <circle cx="156" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Tom Cotton</title>
+    </circle>
+    <circle cx="156" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Markwayne Mullin</title>
+    </circle>
+    <circle cx="156" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Brendan F. Boyle</title>
+    </circle>
+    <circle cx="156" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Will Hurd</title>
+    </circle>
+    <circle cx="156" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Antonio Delgado</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Benjamin Quayle</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Trey Radel</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Marlin A. Stutzman</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Kevin Yoder</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Ryan A. Costello</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Duncan Hunter</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="213.5483870967742" r="3" fill="rgb(132, 165, 157)">
+      <title>Martha Roby</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="205.48387096774192" r="3" fill="rgb(132, 165, 157)">
+      <title>Kyrsten Sinema</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Ro Khanna</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="189.35483870967744" r="3" fill="rgb(132, 165, 157)">
+      <title>Nanette Diaz Barragán</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="181.29032258064515" r="3" fill="rgb(132, 165, 157)">
+      <title>Jenniffer González-Colón</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Steve Watkins</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="165.1612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Elissa Slotkin</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Rashida Tlaib</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Kelly Armstrong</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="140.96774193548387" r="3" fill="rgb(132, 165, 157)">
+      <title>Kendra S. Horn</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Dusty Johnson</title>
+    </circle>
+    <circle cx="164.28571428571428" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Mike Garcia</title>
+    </circle>
+    <circle cx="172.57142857142858" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Jim Bridenstine</title>
+    </circle>
+    <circle cx="172.57142857142858" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Jared Polis</title>
+    </circle>
+    <circle cx="172.57142857142858" cy="245.80645161290323" r="3" fill="rgb(132, 165, 157)">
+      <title>Mia B. Love</title>
+    </circle>
+    <circle cx="172.57142857142858" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Patrick T. McHenry</title>
+    </circle>
+    <circle cx="172.57142857142858" cy="229.67741935483872" r="3" fill="rgb(132, 165, 157)">
+      <title>Grace Meng</title>
+    </circle>
+    <circle cx="172.57142857142858" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Josh Gottheimer</title>
+    </circle>
+    <circle cx="172.57142857142858" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Michael Cloud</title>
+    </circle>
+    <circle cx="172.57142857142858" cy="205.48387096774192" r="3" fill="rgb(132, 165, 157)">
+      <title>Lizzie Fletcher</title>
+    </circle>
+    <circle cx="172.57142857142858" cy="197.4193548387097" r="3" fill="rgb(132, 165, 157)">
+      <title>Elaine G. Luria</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Vance M. McAllister</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>André Carson</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Cory Gardner</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Joaquin Castro</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Derek Kilmer</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Jimmy Gomez</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="213.5483870967742" r="3" fill="rgb(132, 165, 157)">
+      <title>Katie Porter</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Michael Waltz</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="197.4193548387097" r="3" fill="rgb(132, 165, 157)">
+      <title>Ayanna Pressley</title>
+    </circle>
+    <circle cx="180.85714285714286" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Ben McAdams</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Dan Boren</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Jon Runyan</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Stephen Lee Fincher</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Christopher Murphy</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Devin Nunes</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Cedric L. Richmond</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Tim Ryan</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Andy Barr</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Raja Krishnamoorthi</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Brian K. Fitzpatrick</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Steven Horsford</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Jahana Hayes</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Russ Fulcher</title>
+    </circle>
+    <circle cx="189.14285714285714" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Lori Trahan</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>David W. Jolly</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Beto O’Rourke</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Thomas A. Garrett, Jr.</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Ben Ray Luján</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Todd Young</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Brian Schatz</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Raul Ruiz</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Garret Graves</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>David Rouzer</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Ben Sasse</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>James Comer</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Mike Johnson</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Jodey C. Arrington</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Angie Craig</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="149.03225806451613" r="3" fill="rgb(132, 165, 157)">
+      <title>Mikie Sherrill</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Van Taylor</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Chip Roy</title>
+    </circle>
+    <circle cx="197.42857142857142" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Ben Cline</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Heath Shuler</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Kristi L. Noem</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Sean P. Duffy</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Martin Heinrich</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Mike Lee</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Tom Reed</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Marco Rubio</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Thomas Massie</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Richard Hudson</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Marc A. Veasey</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Alexander X. Mooney</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Ted Budd</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Gilbert Ray Cisneros, Jr.</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Debbie Mucarsel-Powell</title>
+    </circle>
+    <circle cx="205.71428571428572" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Sean Casten</title>
+    </circle>
+    <circle cx="214" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Jeffrey M. Landry</title>
+    </circle>
+    <circle cx="214" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Michael G. Grimm</title>
+    </circle>
+    <circle cx="214" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Frank C. Guinta</title>
+    </circle>
+    <circle cx="214" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Todd Rokita</title>
+    </circle>
+    <circle cx="214" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Thomas J. Rooney</title>
+    </circle>
+    <circle cx="214" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Paul D. Ryan</title>
+    </circle>
+    <circle cx="214" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Tom Graves</title>
+    </circle>
+    <circle cx="214" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Steven M. Palazzo</title>
+    </circle>
+    <circle cx="214" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Adrian Smith</title>
+    </circle>
+    <circle cx="214" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Rob Woodall</title>
+    </circle>
+    <circle cx="214" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Rodney Davis</title>
+    </circle>
+    <circle cx="214" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Hakeem S. Jeffries</title>
+    </circle>
+    <circle cx="214" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Ted Cruz</title>
+    </circle>
+    <circle cx="214" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Joni Ernst</title>
+    </circle>
+    <circle cx="214" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Warren Davidson</title>
+    </circle>
+    <circle cx="214" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Greg Stanton</title>
+    </circle>
+    <circle cx="214" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Michael Guest</title>
+    </circle>
+    <circle cx="214" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Denver Riggleman</title>
+    </circle>
+    <circle cx="214" cy="116.7741935483871" r="3" fill="rgb(132, 165, 157)">
+      <title>Kelly Loeffler</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>William M. Cowan</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Robert Hurt</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Robert J. Dold</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Luke Messer</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Bill Huizenga</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="221.61290322580643" r="3" fill="rgb(132, 165, 157)">
+      <title>Cathy McMorris Rodgers</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Austin Scott</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="205.48387096774192" r="3" fill="rgb(132, 165, 157)">
+      <title>Linda T. Sánchez</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Cory A. Booker</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Ted Lieu</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Mark Walker</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Jimmy Panetta</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Dean Phillips</title>
+    </circle>
+    <circle cx="222.28571428571428" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Veronica Escobar</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Jason Altmire</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Tim Griffin</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Daniel B. Maffei</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Kelly Ayotte</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Tim Huelskamp</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>David Young</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>James Lankford</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="205.48387096774192" r="3" fill="rgb(132, 165, 157)">
+      <title>Tammy Duckworth</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>George Holding</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Darin LaHood</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="181.29032258064515" r="3" fill="rgb(132, 165, 157)">
+      <title>Jennifer Wexton</title>
+    </circle>
+    <circle cx="230.57142857142858" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Kim Schrier</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Connie Mack</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Mark Takai</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Mick Mulvaney</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Jason Chaffetz</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Jeff Denham</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Raúl R. Labrador</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Mike Bishop</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Bruce Westerman</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Vicente Gonzalez</title>
+    </circle>
+    <circle cx="238.85714285714286" cy="189.35483870967744" r="3" fill="rgb(132, 165, 157)">
+      <title>Chrissy Houlahan</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Randy Hultgren</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Stephen Knight</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="245.80645161290323" r="3" fill="rgb(132, 165, 157)">
+      <title>Kirsten E. Gillibrand</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Kathy Castor</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Eric A. "Rick" Crawford</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Theodore E. Deutch</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Jeff Duncan</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>James A. Himes</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Daniel Lipinski</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="189.35483870967744" r="3" fill="rgb(132, 165, 157)">
+      <title>Debbie Wasserman Schultz</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Doug Collins</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Sean Patrick Maloney</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="165.1612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Stacey E. Plaskett</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Trent Kelly</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>A. Drew Ferguson IV</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>David Kustoff</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="132.90322580645162" r="3" fill="rgb(132, 165, 157)">
+      <title>Liz Cheney</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Ross Spano</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Pete Stauber</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="108.70967741935485" r="3" fill="rgb(132, 165, 157)">
+      <title>Susie Lee</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="100.64516129032259" r="3" fill="rgb(132, 165, 157)">
+      <title>Martha McSally</title>
+    </circle>
+    <circle cx="247.14285714285717" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Chris Jacobs</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Jesse L. Jackson Jr.</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>David Rivera</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>John Sullivan</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Jeff Chiesa</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Steve Southerland II</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Erik Paulsen</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>John Ratcliffe</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Robert B. Aderholt</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Rick Larsen</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Kevin McCarthy</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Steve Scalise</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Tim Scott</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="165.1612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Terri A. Sewell</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Adam Smith</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Steve Stivers</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Ami Bera</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="132.90322580645162" r="3" fill="rgb(132, 165, 157)">
+      <title>Norma J. Torres</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="124.83870967741935" r="3" fill="rgb(132, 165, 157)">
+      <title>Kathleen M. Rice</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="116.7741935483871" r="3" fill="rgb(132, 165, 157)">
+      <title>Pramila Jayapal</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="108.70967741935485" r="3" fill="rgb(132, 165, 157)">
+      <title>Cynthia Axne</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Tom Malinowski</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>John W. Rose</title>
+    </circle>
+    <circle cx="255.42857142857144" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Fred Keller</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Robert T. Schilling</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Renee L. Ellmers</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Christopher P. Gibson</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Trey Gowdy</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Timothy J. Walz</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Dave Brat</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Michael F. Bennet</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="205.48387096774192" r="3" fill="rgb(132, 165, 157)">
+      <title>Yvette D. Clarke</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Scott DesJarlais</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Brett Guthrie</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Jim Jordan</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>James R. Langevin</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Jared Huffman</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Mark Pocan</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Dan Sullivan</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="140.96774193548387" r="3" fill="rgb(132, 165, 157)">
+      <title>Kamala D. Harris</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="132.90322580645162" r="3" fill="rgb(132, 165, 157)">
+      <title>Catherine Cortez Masto</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Salud O. Carbajal</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Lloyd Smucker</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Daniel Meuser</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Tim Burchett</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Mark E. Green</title>
+    </circle>
+    <circle cx="263.7142857142857" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Dan Bishop</title>
+    </circle>
+    <circle cx="272" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Betty Sutton</title>
+    </circle>
+    <circle cx="272" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Eric Cantor</title>
+    </circle>
+    <circle cx="272" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Mark L. Pryor</title>
+    </circle>
+    <circle cx="272" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Mike Rogers</title>
+    </circle>
+    <circle cx="272" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Joe Garcia</title>
+    </circle>
+    <circle cx="272" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Michael G. Fitzpatrick</title>
+    </circle>
+    <circle cx="272" cy="213.5483870967742" r="3" fill="rgb(132, 165, 157)">
+      <title>Gwen Graham</title>
+    </circle>
+    <circle cx="272" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Mike Pompeo</title>
+    </circle>
+    <circle cx="272" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Keith Ellison</title>
+    </circle>
+    <circle cx="272" cy="189.35483870967744" r="3" fill="rgb(132, 165, 157)">
+      <title>Lynn Jenkins</title>
+    </circle>
+    <circle cx="272" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>John K. Delaney</title>
+    </circle>
+    <circle cx="272" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Steve Russell</title>
+    </circle>
+    <circle cx="272" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Christopher A. Coons</title>
+    </circle>
+    <circle cx="272" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Gus M. Bilirakis</title>
+    </circle>
+    <circle cx="272" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Sam Graves</title>
+    </circle>
+    <circle cx="272" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Ron Kind</title>
+    </circle>
+    <circle cx="272" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Rand Paul</title>
+    </circle>
+    <circle cx="272" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Tony Cárdenas</title>
+    </circle>
+    <circle cx="272" cy="116.7741935483871" r="3" fill="rgb(132, 165, 157)">
+      <title>Jackie Walorski</title>
+    </circle>
+    <circle cx="272" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Filemon Vela</title>
+    </circle>
+    <circle cx="272" cy="100.64516129032259" r="3" fill="rgb(132, 165, 157)">
+      <title>Katherine M. Clark</title>
+    </circle>
+    <circle cx="272" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Barry Loudermilk</title>
+    </circle>
+    <circle cx="272" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Don Bacon</title>
+    </circle>
+    <circle cx="272" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>TJ Cox</title>
+    </circle>
+    <circle cx="272" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Gregory F. Murphy</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Mark S. Critz</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Todd Russell Platts</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="245.80645161290323" r="3" fill="rgb(132, 165, 157)">
+      <title>Laura Richardson</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Mark Begich</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Lee Terry</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Patrick J. Tiberi</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Joseph Crowley</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Jeff Flake</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Keith J. Rothfus</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="189.35483870967744" r="3" fill="rgb(132, 165, 157)">
+      <title>Mimi Walters</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="181.29032258064515" r="3" fill="rgb(132, 165, 157)">
+      <title>Karen C. Handel</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Tammy Baldwin</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Larry Bucshon</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Charles J. "Chuck" Fleischmann</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Michael T. McCaul</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Pete Olson</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>John P. Sarbanes</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>David Schweikert</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="116.7741935483871" r="3" fill="rgb(132, 165, 157)">
+      <title>Suzan K. DelBene</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="108.70967741935485" r="3" fill="rgb(132, 165, 157)">
+      <title>Ann Wagner</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Steve Daines</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Scott Perry</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>John Katko</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="76.45161290322582" r="3" fill="rgb(132, 165, 157)">
+      <title>Lisa Blunt Rochester</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Jamie Raskin</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="60.32258064516128" r="3" fill="#f6bd60">
+      <title>Thomas R. Suozzi</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="52.258064516129025" r="3" fill="#f6bd60">
+      <title>Troy Balderson</title>
+    </circle>
+    <circle cx="280.28571428571433" cy="44.19354838709678" r="3" fill="#f6bd60">
+      <title>Jim Hagedorn</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Mary Bono Mack</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Mike Ross</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Joe Walsh</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Allen B. West</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Pete P. Gallego</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>David Vitter</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Joseph J. Heck</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Ryan K. Zinke</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Blake Farenthold</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Peter J. Roskam</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Bill Shuster</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Claudia Tenney</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>David N. Cicilline</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Mario Diaz-Balart</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>John Thune</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Patrick J. Toomey</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Juan Vargas</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="124.83870967741935" r="3" fill="rgb(132, 165, 157)">
+      <title>Cheri Bustos</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Kevin Cramer</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Matt Cartwright</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>John R. Moolenaar</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Tom Emmer</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Bradley Scott Schneider</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Clay Higgins</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Anthony G. Brown</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="60.32258064516128" r="3" fill="#f6bd60">
+      <title>Paul Mitchell</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="52.258064516129025" r="3" fill="#f6bd60">
+      <title>A. Donald McEachin</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="44.19354838709678" r="3" fill="#f6bd60">
+      <title>Greg Gianforte</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="36.12903225806453" r="3" fill="#f6bd60">
+      <title>Kevin Hern</title>
+    </circle>
+    <circle cx="288.57142857142856" cy="28.06451612903225" r="3" fill="#f6bd60">
+      <title>Harley Rouda</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Jim Matheson</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>John E. Walsh</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>E. Scott Rigell</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Loretta Sanchez</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Charles W. Dent</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Evan H. Jenkins</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Dean Heller</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Mark Sanford</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>David A. Trott</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Thomas MacArthur</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Robert P. Casey, Jr.</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Amy Klobuchar</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Jeff Fortenberry</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Vicky Hartzler</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Frank D. Lucas</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Adam B. Schiff</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Michael R. Turner</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Doug LaMalfa</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Mark Takano</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="108.70967741935485" r="3" fill="rgb(132, 165, 157)">
+      <title>Susan W. Brooks</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Chris Stewart</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Jody B. Hice</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Mike Bost</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Thom Tillis</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Roger W. Marshall</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="60.32258064516128" r="3" fill="#f6bd60">
+      <title>John R. Curtis</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="52.258064516129025" r="3" fill="rgb(132, 165, 157)">
+      <title>Lucy McBath</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="44.19354838709678" r="3" fill="#f6bd60">
+      <title>Andy Levin</title>
+    </circle>
+    <circle cx="296.85714285714283" cy="36.12903225806453" r="3" fill="rgb(132, 165, 157)">
+      <title>Debra A. Haaland</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Scott P. Brown</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Rick Berg</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Ben Chandler</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Chip Cravaack</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="229.67741935483872" r="3" fill="rgb(132, 165, 157)">
+      <title>Nan A. S. Hayworth</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Mike Pence</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Jo Bonner</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Mark Kirk</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Scott Garrett</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Jeff Miller</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Pedro R. Pierluisi</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Curt Clawson</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="165.1612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Michelle Lujan Grisham</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Dennis A. Ross</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="149.03225806451613" r="3" fill="rgb(132, 165, 157)">
+      <title>Elizabeth H. Esty</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="140.96774193548387" r="3" fill="rgb(132, 165, 157)">
+      <title>Barbara Comstock</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="132.90322580645162" r="3" fill="rgb(132, 165, 157)">
+      <title>Brenda Jones</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Mark Meadows</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Brian Higgins</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>James P. McGovern</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Glenn Thompson</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Chris Van Hollen</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Robert J. Wittman</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Ken Buck</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="68.38709677419357" r="3" fill="rgb(132, 165, 157)">
+      <title>Cindy Hyde-Smith</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="60.32258064516128" r="3" fill="rgb(132, 165, 157)">
+      <title>Mary Gay Scanlon</title>
+    </circle>
+    <circle cx="305.14285714285717" cy="52.258064516129025" r="3" fill="rgb(132, 165, 157)">
+      <title>Madeleine Dean</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Enid Greene Waldholtz</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Steve Austria</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Russ Carnahan</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Kathleen C. Hochul</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Alan Nunnelee</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="221.61290322580643" r="3" fill="rgb(132, 165, 157)">
+      <title>Donna F. Edwards</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Steve Israel</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Matt Salmon</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Alan Grayson</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Xavier Becerra</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>James B. Renacci</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Maria Cantwell</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Paul A. Gosar</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>H. Morgan Griffith</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Gary C. Peters</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Mike Quigley</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Mike Rogers</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>John Shimkus</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Mac Thornberry</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Mark E. Amodei</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Donald M. Payne, Jr.</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Scott H. Peters</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Daniel T. Kildee</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Brad R. Wenstrup</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Tim Kaine</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="60.32258064516128" r="3" fill="#f6bd60">
+      <title>Donald Norcross</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="52.258064516129025" r="3" fill="rgb(132, 165, 157)">
+      <title>Margaret Wood Hassan</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="44.19354838709678" r="3" fill="#f6bd60">
+      <title>Andy Biggs</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="36.12903225806453" r="3" fill="#f6bd60">
+      <title>J. Luis Correa</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="28.06451612903225" r="3" fill="rgb(132, 165, 157)">
+      <title>Tina Smith</title>
+    </circle>
+    <circle cx="313.42857142857144" cy="20" r="3" fill="rgb(132, 165, 157)">
+      <title>Debbie Lesko</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Hansen Clarke</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Tim Holden</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Robert E. Andrews</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Bruce L. Braley</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Cresent Hardy</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Trent Franks</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Jeb Hensarling</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Bill Cassidy</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="197.4193548387097" r="3" fill="rgb(132, 165, 157)">
+      <title>Diana DeGette</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Andy Harris</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>John Hoeven</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Lisa Murkowski</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Greg Walden</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Steve Womack</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>David P. Joyce</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Tom Rice</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Earl L. "Buddy" Carter</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="124.83870967741935" r="3" fill="rgb(132, 165, 157)">
+      <title>Val Butler Demings</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="116.7741935483871" r="3" fill="rgb(132, 165, 157)">
+      <title>Jacky Rosen</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Joseph D. Morelle</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="100.64516129032259" r="3" fill="rgb(132, 165, 157)">
+      <title>Susan Wild</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>John Joyce</title>
+    </circle>
+    <circle cx="321.7142857142857" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Thomas P. Tiffany</title>
+    </circle>
+    <circle cx="330" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Sandy Adams</title>
+    </circle>
+    <circle cx="330" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Michele Bachmann</title>
+    </circle>
+    <circle cx="330" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Mike McIntyre</title>
+    </circle>
+    <circle cx="330" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Steve Stockman</title>
+    </circle>
+    <circle cx="330" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Chaka Fattah</title>
+    </circle>
+    <circle cx="330" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Charles W. Boustany Jr.</title>
+    </circle>
+    <circle cx="330" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>John C. Carney Jr.</title>
+    </circle>
+    <circle cx="330" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Reid J. Ribble</title>
+    </circle>
+    <circle cx="330" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Lou Barletta</title>
+    </circle>
+    <circle cx="330" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>John Abney Culberson</title>
+    </circle>
+    <circle cx="330" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Gregg Harper</title>
+    </circle>
+    <circle cx="330" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Daniel M. Donovan, Jr.</title>
+    </circle>
+    <circle cx="330" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Jon Tester</title>
+    </circle>
+    <circle cx="330" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Jeff Merkley</title>
+    </circle>
+    <circle cx="330" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Wm. Lacy Clay</title>
+    </circle>
+    <circle cx="330" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Robert E. Latta</title>
+    </circle>
+    <circle cx="330" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Tom McClintock</title>
+    </circle>
+    <circle cx="330" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Scott R. Tipton</title>
+    </circle>
+    <circle cx="330" cy="116.7741935483871" r="3" fill="rgb(132, 165, 157)">
+      <title>Ann M. Kuster</title>
+    </circle>
+    <circle cx="330" cy="108.70967741935485" r="3" fill="rgb(132, 165, 157)">
+      <title>Robin L. Kelly</title>
+    </circle>
+    <circle cx="330" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>J. French Hill</title>
+    </circle>
+    <circle cx="330" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Charlie Crist</title>
+    </circle>
+    <circle cx="330" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Ron Estes</title>
+    </circle>
+    <circle cx="330" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Jesús G. "Chuy" García</title>
+    </circle>
+    <circle cx="330" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Greg Pence</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Denny Rehberg</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Mary L. Landrieu</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>John Barrow</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>John Campbell</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Jim Gerlach</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Jack Kingston</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Michael H. Michaud</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Patrick Meehan</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Mike Coffman</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Joe Donnelly</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Pete Sessions</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Heidi Heitkamp</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Rod Blum</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Jason Lewis</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Sheldon Whitehouse</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Lindsey Graham</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Kevin Brady</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Richard Burr</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Henry Cuellar</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Ron Johnson</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Billy Long</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Stephen F. Lynch</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="84.51612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Chellie Pingree</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Rob Portman</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Gregorio Kilili Camacho Sablan</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="60.32258064516128" r="3" fill="#f6bd60">
+      <title>Bill Foster</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="52.258064516129025" r="3" fill="#f6bd60">
+      <title>Ted S. Yoho</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="44.19354838709678" r="3" fill="#f6bd60">
+      <title>Bradley Byrne</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="36.12903225806453" r="3" fill="#f6bd60">
+      <title>Dan Newhouse</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="28.06451612903225" r="3" fill="#f6bd60">
+      <title>Glenn Grothman</title>
+    </circle>
+    <circle cx="338.2857142857143" cy="20" r="3" fill="#f6bd60">
+      <title>David J. Trone</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Steven C. LaTourette</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Candice S. Miller</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="245.80645161290323" r="3" fill="rgb(132, 165, 157)">
+      <title>Cynthia M. Lummis</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Tom Price</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Robert Menendez</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Mark R. Warner</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Mo Brooks</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Jim Cooper</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Bill Flores</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Bob Gibbs</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Bill Johnson</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Henry C. "Hank" Johnson, Jr.</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Doug Lamborn</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Betty McCollum</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Jerry Moran</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Brad Sherman</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="132.90322580645162" r="3" fill="rgb(132, 165, 157)">
+      <title>Suzanne Bonamici</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Gary J. Palmer</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Ralph Lee Abraham</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="108.70967741935485" r="3" fill="rgb(132, 165, 157)">
+      <title>Brenda L. Lawrence</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Mike Rounds</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Dwight Evans</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Adriano Espaillat</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Doug Jones</title>
+    </circle>
+    <circle cx="346.57142857142856" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Mike Braun</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Brad Miller</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Kay R. Hagan</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Dave Camp</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Luther Strange</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="229.67741935483872" r="3" fill="rgb(132, 165, 157)">
+      <title>Claire McCaskill</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Luis V. Gutiérrez</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Darrell E. Issa</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Bruce Poliquin</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="197.4193548387097" r="3" fill="rgb(132, 165, 157)">
+      <title>Karen Bass</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Ken Calvert</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="181.29032258064515" r="3" fill="rgb(132, 165, 157)">
+      <title>Shelley Moore Capito</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Steve Chabot</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="165.1612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Judy Chu</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Joe Courtney</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Michael F. Doyle</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Louie Gohmert</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Gregory W. Meeks</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Ed Perlmutter</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Christopher H. Smith</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Fred Upton</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="100.64516129032259" r="3" fill="rgb(132, 165, 157)">
+      <title>Nydia M. Velázquez</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Randy K. Weber, Sr.</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="84.51612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Debbie Dingell</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Neal P. Dunn</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Francis Rooney</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="60.32258064516128" r="3" fill="#f6bd60">
+      <title>Ralph Norman</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="52.258064516129025" r="3" fill="#f6bd60">
+      <title>Jefferson Van Drew</title>
+    </circle>
+    <circle cx="354.85714285714283" cy="44.19354838709678" r="3" fill="#f6bd60">
+      <title>Ron Wright</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Charles F. Bass</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>David Dreier</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Steven R. Rothman</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Janice Hahn</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Dan Benishek</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>J. Randy Forbes</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Tim Murphy</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Bob Corker</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Michael E. Capuano</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Bob Goodlatte</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Leonard Lance</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Ileana Ros-Lehtinen</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="165.1612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Carol Shea-Porter</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>John J. Faso</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Tom Marino</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Sherrod Brown</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>John Barrasso</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="124.83870967741935" r="3" fill="rgb(132, 165, 157)">
+      <title>Susan M. Collins</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>John Cornyn</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="108.70967741935485" r="3" fill="rgb(132, 165, 157)">
+      <title>Marsha Blackburn</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Jim Costa</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="92.5806451612903" r="3" fill="rgb(132, 165, 157)">
+      <title>Marcia L. Fudge</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>William R. Keating</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>David Loebsack</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Blaine Luetkemeyer</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="60.32258064516128" r="3" fill="rgb(132, 165, 157)">
+      <title>Julia Brownley</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="52.258064516129025" r="3" fill="#f6bd60">
+      <title>Denny Heck</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="44.19354838709678" r="3" fill="#f6bd60">
+      <title>Mark DeSaulnier</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="36.12903225806453" r="3" fill="#f6bd60">
+      <title>John H. Rutherford</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="28.06451612903225" r="3" fill="#f6bd60">
+      <title>Ed Case</title>
+    </circle>
+    <circle cx="363.14285714285717" cy="20" r="3" fill="#f6bd60">
+      <title>Rick Scott</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Shelley Berkley</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Brian P. Bilbray</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="245.80645161290323" r="3" fill="rgb(132, 165, 157)">
+      <title>Ann Marie Buerkle</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Larry Kissell</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="229.67741935483872" r="3" fill="rgb(132, 165, 157)">
+      <title>Jean Schmidt</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Jim DeMint</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>John F. Tierney</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Kerry L. Bentivolio</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>John Fleming</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Richard L. Hanna</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Richard B. Nugent</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Al Franken</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="165.1612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Diane Black</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Edward R. Royce</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="149.03225806451613" r="3" fill="rgb(132, 165, 157)">
+      <title>Colleen Hanabusa</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Elijah E. Cummings</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Roger F. Wicker</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Rob Bishop</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Vern Buchanan</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Mike Crapo</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>Kenny Marchant</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Jerry McNerney</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="84.51612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Gwen Moore</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Frank Pallone, Jr.</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Kurt Schrader</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="60.32258064516128" r="3" fill="#f6bd60">
+      <title>Albio Sires</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="52.258064516129025" r="3" fill="#f6bd60">
+      <title>Mike Thompson</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="44.19354838709678" r="3" fill="#f6bd60">
+      <title>Tim Walberg</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="36.12903225806453" r="3" fill="rgb(132, 165, 157)">
+      <title>Deb Fischer</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="28.06451612903225" r="3" fill="#f6bd60">
+      <title>Rick W. Allen</title>
+    </circle>
+    <circle cx="371.42857142857144" cy="20" r="3" fill="#f6bd60">
+      <title>John Kennedy</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Jo Ann Emerson</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Mark Udall</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Timothy H. Bishop</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Mike Johanns</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Lynn A. Westmoreland</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>David G. Reichert</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Chris Collins</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="205.48387096774192" r="3" fill="rgb(132, 165, 157)">
+      <title>Debbie Stabenow</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Roy Blunt</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>John Boozman</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Michael C. Burgess</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Gerald E. Connolly</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="165.1612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Sheila Jackson Lee</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Patty Murray</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Charles E. Schumer</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Michael K. Simpson</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="132.90322580645162" r="3" fill="rgb(132, 165, 157)">
+      <title>Jackie Speier</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="124.83870967741935" r="3" fill="rgb(132, 165, 157)">
+      <title>Dina Titus</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="116.7741935483871" r="3" fill="rgb(132, 165, 157)">
+      <title>Joyce Beatty</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Donald S. Beyer, Jr.</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="100.64516129032259" r="3" fill="rgb(132, 165, 157)">
+      <title>Ann Kirkpatrick</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="92.5806451612903" r="3" fill="rgb(132, 165, 157)">
+      <title>Sylvia R. Garcia</title>
+    </circle>
+    <circle cx="379.7142857142857" cy="84.51612903225806" r="3" fill="rgb(132, 165, 157)">
+      <title>Carol D. Miller</title>
+    </circle>
+    <circle cx="388" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Francisco "Quico" Canseco</title>
+    </circle>
+    <circle cx="388" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Jerry F. Costello</title>
+    </circle>
+    <circle cx="388" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>William L. Owens</title>
+    </circle>
+    <circle cx="388" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Nick J. Rahall II</title>
+    </circle>
+    <circle cx="388" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>William L. Enyart</title>
+    </circle>
+    <circle cx="388" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>John A. Boehner</title>
+    </circle>
+    <circle cx="388" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Randy Neugebauer</title>
+    </circle>
+    <circle cx="388" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Brad Ashford</title>
+    </circle>
+    <circle cx="388" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Joe Barton</title>
+    </circle>
+    <circle cx="388" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Jack Reed</title>
+    </circle>
+    <circle cx="388" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Steve Cohen</title>
+    </circle>
+    <circle cx="388" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Tom Cole</title>
+    </circle>
+    <circle cx="388" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Steve King</title>
+    </circle>
+    <circle cx="388" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Richard E. Neal</title>
+    </circle>
+    <circle cx="388" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Paul Tonko</title>
+    </circle>
+    <circle cx="388" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Peter J. Visclosky</title>
+    </circle>
+    <circle cx="388" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Daniel Webster</title>
+    </circle>
+    <circle cx="388" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Ron Wyden</title>
+    </circle>
+    <circle cx="388" cy="116.7741935483871" r="3" fill="rgb(132, 165, 157)">
+      <title>Elizabeth Warren</title>
+    </circle>
+    <circle cx="388" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Roger Williams</title>
+    </circle>
+    <circle cx="388" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>David Perdue</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Kent Conrad</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>David Alan Curson</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Tom Coburn</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Rush Holt</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Tom Latham</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Gary G. Miller</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="213.5483870967742" r="3" fill="rgb(132, 165, 157)">
+      <title>Allyson Y. Schwartz</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Ted Poe</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Robert Pittenger</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Tom Udall</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Earl Blumenauer</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>K. Michael Conaway</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Raúl M. Grijalva</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Mike Kelly</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>John B. Larson</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Bennie G. Thompson</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="132.90322580645162" r="3" fill="rgb(132, 165, 157)">
+      <title>Lois Frankel</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Brian Babin</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Al Lawson, Jr.</title>
+    </circle>
+    <circle cx="396.28571428571433" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Kweisi Mfume</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Olympia J. Snowe</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>W. Todd Akin</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Joe Baca</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Spencer Bachus</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>John Kline</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>John J. Duncan, Jr.</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Gene Green</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Stevan Pearce</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Dana Rohrabacher</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Lamar Smith</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Thomas R. Carper</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Jeanne Shaheen</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Joe Manchin, III</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Sanford D. Bishop, Jr.</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>G. K. Butterfield</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="140.96774193548387" r="3" fill="#f6bd60">
+      <title>Peter A. DeFazio</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>Eliot L. Engel</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Al Green</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="116.7741935483871" r="3" fill="rgb(132, 165, 157)">
+      <title>Mazie K. Hirono</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="108.70967741935485" r="3" fill="rgb(132, 165, 157)">
+      <title>Zoe Lofgren</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="100.64516129032259" r="3" fill="#f6bd60">
+      <title>David B. McKinley</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Jerrold Nadler</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="84.51612903225806" r="3" fill="#f6bd60">
+      <title>Bill Posey</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="76.45161290322582" r="3" fill="#f6bd60">
+      <title>Robert C. "Bobby" Scott</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="68.38709677419357" r="3" fill="#f6bd60">
+      <title>Peter Welch</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="60.32258064516128" r="3" fill="#f6bd60">
+      <title>Joe Wilson</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="52.258064516129025" r="3" fill="#f6bd60">
+      <title>John A. Yarmuth</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="44.19354838709678" r="3" fill="rgb(132, 165, 157)">
+      <title>Aumua Amata Coleman Radewagen</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="36.12903225806453" r="3" fill="#f6bd60">
+      <title>Jack Bergman</title>
+    </circle>
+    <circle cx="404.57142857142856" cy="28.06451612903225" r="3" fill="#f6bd60">
+      <title>Mitt Romney</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Jim Webb</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Timothy V. Johnson</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Dennis J. Kucinich</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Daniel E. Lungren</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Rodney Alexander</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Tim Johnson</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Paul C. Broun</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="205.48387096774192" r="3" fill="rgb(132, 165, 157)">
+      <title>Corrine Brown</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Jeff Sessions</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Rodney P. Frelinghuysen</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Frank A. LoBiondo</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Niki Tsongas</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Richard Blumenthal</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="157.09677419354838" r="3" fill="#f6bd60">
+      <title>Lloyd Doggett</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="149.03225806451613" r="3" fill="rgb(132, 165, 157)">
+      <title>Marcy Kaptur</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="140.96774193548387" r="3" fill="rgb(132, 165, 157)">
+      <title>Barbara Lee</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="132.90322580645162" r="3" fill="rgb(132, 165, 157)">
+      <title>Carolyn B. Maloney</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>Edward J. Markey</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>C. A. Dutch Ruppersberger</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="108.70967741935485" r="3" fill="#f6bd60">
+      <title>Bobby L. Rush</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="100.64516129032259" r="3" fill="rgb(132, 165, 157)">
+      <title>Alma S. Adams</title>
+    </circle>
+    <circle cx="412.8571428571429" cy="92.5806451612903" r="3" fill="#f6bd60">
+      <title>Tom O’Halleran</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Charles A. Gonzalez</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Wally Herger</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Melvin L. Watt</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Donna M. Christensen</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>George Miller</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>James P. Moran</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Ron Barber</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Robert A. Brady</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>John Garamendi</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>David P. Roe</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>David Scott</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Bonnie Watson Coleman</title>
+    </circle>
+    <circle cx="421.14285714285717" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>James R. Baird</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Elton Gallegly</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Donald A. Manzullo</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Silvestre Reyes</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Carolyn McCarthy</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Ander Crenshaw</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Johnny Isakson</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Richard J. Durbin</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Michael B. Enzi</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Emanuel Cleaver</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="189.35483870967744" r="3" fill="rgb(132, 165, 157)">
+      <title>Susan A. Davis</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Peter T. King</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="173.22580645161293" r="3" fill="rgb(132, 165, 157)">
+      <title>Doris O. Matsui</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Collin C. Peterson</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Janice D. Schakowsky</title>
+    </circle>
+    <circle cx="429.42857142857144" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Angus S. King, Jr.</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Jeff Bingaman</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Kay Bailey Hutchison</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>John F. Kerry</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Saxby Chambliss</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Eni F. H. Faleomavaega</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Ed Pastor</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Ed Whitfield</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Daniel Coats</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>John L. Mica</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Richard M. Nolan</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Walter B. Jones</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>Benjamin L. Cardin</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>James E. Risch</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Rosa L. DeLauro</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="149.03225806451613" r="3" fill="rgb(132, 165, 157)">
+      <title>Virginia Foxx</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="140.96774193548387" r="3" fill="rgb(132, 165, 157)">
+      <title>Kay Granger</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="132.90322580645162" r="3" fill="#f6bd60">
+      <title>F. James Sensenbrenner, Jr.</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="124.83870967741935" r="3" fill="#f6bd60">
+      <title>José E. Serrano</title>
+    </circle>
+    <circle cx="437.7142857142857" cy="116.7741935483871" r="3" fill="#f6bd60">
+      <title>Paul Cook</title>
+    </circle>
+    <circle cx="446" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Bob Filner</title>
+    </circle>
+    <circle cx="446" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Joseph I. Lieberman</title>
+    </circle>
+    <circle cx="446" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Gary L. Ackerman</title>
+    </circle>
+    <circle cx="446" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Phil Gingrey</title>
+    </circle>
+    <circle cx="446" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Jon Kyl</title>
+    </circle>
+    <circle cx="446" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Bill Nelson</title>
+    </circle>
+    <circle cx="446" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Mitch McConnell</title>
+    </circle>
+    <circle cx="446" cy="205.48387096774192" r="3" fill="rgb(132, 165, 157)">
+      <title>Anna G. Eshoo</title>
+    </circle>
+    <circle cx="446" cy="197.4193548387097" r="3" fill="rgb(132, 165, 157)">
+      <title>Frederica S. Wilson</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Ben Nelson</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Howard L. Berman</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="245.80645161290323" r="3" fill="rgb(132, 165, 157)">
+      <title>Sue Wilkins Myrick</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Cliff Stearns</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Robert L. Turner</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Max Baucus</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Doc Hastings</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="205.48387096774192" r="3" fill="rgb(132, 165, 157)">
+      <title>Gloria Negrete McLeod</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Sam Farr</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="189.35483870967744" r="3" fill="#f6bd60">
+      <title>Michael M. Honda</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>Bernard Sanders</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="173.22580645161293" r="3" fill="#f6bd60">
+      <title>John R. Carter</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="165.1612903225806" r="3" fill="#f6bd60">
+      <title>Danny K. Davis</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="157.09677419354838" r="3" fill="rgb(132, 165, 157)">
+      <title>Lucille Roybal-Allard</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="149.03225806451613" r="3" fill="#f6bd60">
+      <title>Alan S. Lowenthal</title>
+    </circle>
+    <circle cx="454.28571428571433" cy="140.96774193548387" r="3" fill="rgb(132, 165, 157)">
+      <title>Donna E. Shalala</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Norman D. Dicks</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Barney Frank</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Thomas E. Petri</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Barbara Boxer</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Rubén Hinojosa</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>John Lewis</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Lamar Alexander</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>James E. Clyburn</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="197.4193548387097" r="3" fill="#f6bd60">
+      <title>Patrick J. Leahy</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="189.35483870967744" r="3" fill="rgb(132, 165, 157)">
+      <title>Nancy Pelosi</title>
+    </circle>
+    <circle cx="462.5714285714285" cy="181.29032258064515" r="3" fill="#f6bd60">
+      <title>David E. Price</title>
+    </circle>
+    <circle cx="470.8571428571429" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Tom Harkin</title>
+    </circle>
+    <circle cx="470.8571428571429" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Henry A. Waxman</title>
+    </circle>
+    <circle cx="470.8571428571429" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Frank R. Wolf</title>
+    </circle>
+    <circle cx="470.8571428571429" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Harry Reid</title>
+    </circle>
+    <circle cx="470.8571428571429" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Joseph R. Pitts</title>
+    </circle>
+    <circle cx="470.8571428571429" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Steny H. Hoyer</title>
+    </circle>
+    <circle cx="479.1428571428571" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Dan Burton</title>
+    </circle>
+    <circle cx="479.1428571428571" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Maurice D. Hinchey</title>
+    </circle>
+    <circle cx="479.1428571428571" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Howard P. "Buck" McKeon</title>
+    </circle>
+    <circle cx="479.1428571428571" cy="237.74193548387098" r="3" fill="rgb(132, 165, 157)">
+      <title>Lois Capps</title>
+    </circle>
+    <circle cx="479.1428571428571" cy="229.67741935483872" r="3" fill="rgb(132, 165, 157)">
+      <title>Maxine Waters</title>
+    </circle>
+    <circle cx="487.4285714285715" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Judy Biggert</title>
+    </circle>
+    <circle cx="487.4285714285715" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Lynn C. Woolsey</title>
+    </circle>
+    <circle cx="487.4285714285715" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>John D. Rockefeller, IV</title>
+    </circle>
+    <circle cx="487.4285714285715" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Thad Cochran</title>
+    </circle>
+    <circle cx="487.4285714285715" cy="229.67741935483872" r="3" fill="rgb(132, 165, 157)">
+      <title>Nita M. Lowey</title>
+    </circle>
+    <circle cx="487.4285714285715" cy="221.61290322580643" r="3" fill="rgb(132, 165, 157)">
+      <title>Eleanor Holmes Norton</title>
+    </circle>
+    <circle cx="487.4285714285715" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Bill Pascrell, Jr.</title>
+    </circle>
+    <circle cx="487.4285714285715" cy="205.48387096774192" r="3" fill="#f6bd60">
+      <title>Harold Rogers</title>
+    </circle>
+    <circle cx="495.71428571428567" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>John W. Olver</title>
+    </circle>
+    <circle cx="495.71428571428567" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Barbara A. Mikulski</title>
+    </circle>
+    <circle cx="495.71428571428567" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Jim McDermott</title>
+    </circle>
+    <circle cx="495.71428571428567" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>John McCain</title>
+    </circle>
+    <circle cx="495.71428571428567" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Pat Roberts</title>
+    </circle>
+    <circle cx="495.71428571428567" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>Alcee L. Hastings</title>
+    </circle>
+    <circle cx="495.71428571428567" cy="213.5483870967742" r="3" fill="rgb(132, 165, 157)">
+      <title>Grace F. Napolitano</title>
+    </circle>
+    <circle cx="504" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Herb Kohl</title>
+    </circle>
+    <circle cx="504" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Ron Paul</title>
+    </circle>
+    <circle cx="504" cy="245.80645161290323" r="3" fill="rgb(132, 165, 157)">
+      <title>Eddie Bernice Johnson</title>
+    </circle>
+    <circle cx="512.2857142857142" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Leonard L. Boswell</title>
+    </circle>
+    <circle cx="512.2857142857142" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Jerry Lewis</title>
+    </circle>
+    <circle cx="512.2857142857142" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Edolphus Towns</title>
+    </circle>
+    <circle cx="512.2857142857142" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Carl Levin</title>
+    </circle>
+    <circle cx="512.2857142857142" cy="229.67741935483872" r="3" fill="#f6bd60">
+      <title>Orrin G. Hatch</title>
+    </circle>
+    <circle cx="512.2857142857142" cy="221.61290322580643" r="3" fill="#f6bd60">
+      <title>James M. Inhofe</title>
+    </circle>
+    <circle cx="512.2857142857142" cy="213.5483870967742" r="3" fill="#f6bd60">
+      <title>Richard C. Shelby</title>
+    </circle>
+    <circle cx="520.5714285714287" cy="261.93548387096774" r="3" fill="rgb(132, 165, 157)">
+      <title>Madeleine Z. Bordallo</title>
+    </circle>
+    <circle cx="520.5714285714287" cy="253.8709677419355" r="3" fill="rgb(132, 165, 157)">
+      <title>Dianne Feinstein</title>
+    </circle>
+    <circle cx="520.5714285714287" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Chuck Grassley</title>
+    </circle>
+    <circle cx="520.5714285714287" cy="237.74193548387098" r="3" fill="#f6bd60">
+      <title>Don Young</title>
+    </circle>
+    <circle cx="528.8571428571429" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Richard G. Lugar</title>
+    </circle>
+    <circle cx="537.1428571428571" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Fortney Pete Stark</title>
+    </circle>
+    <circle cx="537.1428571428571" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Howard Coble</title>
+    </circle>
+    <circle cx="537.1428571428571" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Sander M. Levin</title>
+    </circle>
+    <circle cx="545.4285714285714" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>C. W. Bill Young</title>
+    </circle>
+    <circle cx="545.4285714285714" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Charles B. Rangel</title>
+    </circle>
+    <circle cx="545.4285714285714" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Sam Johnson</title>
+    </circle>
+    <circle cx="553.7142857142857" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Dale E. Kildee</title>
+    </circle>
+    <circle cx="553.7142857142857" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>John Conyers, Jr.</title>
+    </circle>
+    <circle cx="553.7142857142857" cy="245.80645161290323" r="3" fill="rgb(132, 165, 157)">
+      <title>Louise McIntosh Slaughter</title>
+    </circle>
+    <circle cx="578.5714285714287" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Roscoe G. Bartlett</title>
+    </circle>
+    <circle cx="578.5714285714287" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>John D. Dingell</title>
+    </circle>
+    <circle cx="595.1428571428571" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Daniel K. Inouye</title>
+    </circle>
+    <circle cx="595.1428571428571" cy="253.8709677419355" r="3" fill="#f6bd60">
+      <title>Daniel K. Akaka</title>
+    </circle>
+    <circle cx="595.1428571428571" cy="245.80645161290323" r="3" fill="#f6bd60">
+      <title>Frank R. Lautenberg</title>
+    </circle>
+    <circle cx="603.4285714285714" cy="261.93548387096774" r="3" fill="#f6bd60">
+      <title>Ralph M. Hall</title>
+    </circle>
+  </g>
+  <g stroke="currentColor" transform="translate(0,0.5)">
+    <line x1="40" x2="620" y1="270" y2="270"></line>
+  </g>
+</svg>

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -124,6 +124,7 @@ export {default as travelersYearOverYear} from "./travelers-year-over-year.js";
 export {default as uniformRandomDifference} from "./uniform-random-difference.js";
 export {default as untypedDateBin} from "./untyped-date-bin.js";
 export {default as usCongressAge} from "./us-congress-age.js";
+export {default as usCongressAgeColorExplicit} from "./us-congress-age-color-explicit.js";
 export {default as usCongressAgeGender} from "./us-congress-age-gender.js";
 export {default as usPopulationStateAge} from "./us-population-state-age.js";
 export {default as usPopulationStateAgeDots} from "./us-population-state-age-dots.js";

--- a/test/plots/us-congress-age-color-explicit.js
+++ b/test/plots/us-congress-age-color-explicit.js
@@ -1,0 +1,22 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export default async function() {
+  const data = await d3.csv("data/us-congress-members.csv", d3.autoType);
+  return Plot.plot({
+    height: 300,
+    x: {
+      nice: true,
+      label: "Age →",
+      labelAnchor: "right"
+    },
+    y: {
+      grid: true,
+      label: "↑ Frequency"
+    },
+    marks: [
+      Plot.dot(data, Plot.stackY2({x: d => 2021 - d.birth, fill: d => d.gender === "F" ? "rgb(132, 165, 157)" : "#f6bd60", title: "full_name"})),
+      Plot.ruleY([0])
+    ]
+  });
+}


### PR DESCRIPTION
Alternative to #673 and #660. For ordinal or categorical color scales, if the domain contains only valid color values (or undefined or null), and neither a scheme nor a range is set, then the range defaults to the domain.