### PR TITLE
first tentative for a layouts option

### DIFF
--- a/src/layouts.js
+++ b/src/layouts.js
@@ -24,7 +24,7 @@ function layoutCollide({x: X, y: Y, r: R}) {
       .force("x", forceX(({x}) => x))
       .force("y", forceY(({y}) => y))
       .force("collide", forceCollide(({r}) => 1 + r));
-    simulation.nodes(nodes).tick(30);
+    simulation.nodes(nodes).tick(30).stop();
     for (const node of nodes) X[node.i] = node.x, Y[node.i] = node.y;
   };
 }

--- a/src/layouts.js
+++ b/src/layouts.js
@@ -1,0 +1,31 @@
+import {forceSimulation, forceX, forceY, forceCollide, rgb} from "d3";
+
+export function maybeLayout(layout) {
+  if (typeof layout === "function") return layout;
+  switch("" + layout) {
+    case "darker":
+      return layoutDarker;
+    case "collide":
+      return layoutCollide;
+    default:
+      throw new Error(`unknow layout ${layout}`);
+  }
+}
+
+function layoutDarker(values) {
+  for (let i = 0; i < values.fill.length; i++) values.fill[i] = rgb(values.fill[i]).darker();
+  return () => {};
+}
+
+function layoutCollide({x: X, y: Y, r: R}) {
+  console.warn("collide", X, Y, R);
+  return (index) => {
+    const nodes = Array.from(index, i => ({i, x: X[i], y: Y[i], r: R ? R[i] : 8}));
+    const simulation = forceSimulation()
+      .force("x", forceX(({x}) => x))
+      .force("y", forceY(({y}) => y))
+      .force("collide", forceCollide(({r}) => 1 + r));
+    simulation.nodes(nodes).tick(30);
+    for (const node of nodes) X[node.i] = node.x, Y[node.i] = node.y;
+  };
+}

--- a/src/layouts.js
+++ b/src/layouts.js
@@ -18,7 +18,6 @@ function layoutDarker(values) {
 }
 
 function layoutCollide({x: X, y: Y, r: R}) {
-  console.warn("collide", X, Y, R);
   return (index) => {
     const nodes = Array.from(index, i => ({i, x: X[i], y: Y[i], r: R ? R[i] : 8}));
     const simulation = forceSimulation()


### PR DESCRIPTION
two layouts are available:
- "darker" changes the fill channel
- "collide" collides the x/y/r channels

The layouts can be given as a function, which receives the *scaled* values, and returns a function of (index, dimensions), which is called for each facet. You can pass several layouts which will be called one after the other.

(Very rough: no error checking, mutation of the values arrays… no options…)

testing: https://observablehq.com/@fil/plot-layouts-initial-tests

issues/questions:
- [ ] currently doesn't allow dynamic layouts (where we would immediately return the <g> then proceed to compute and update the positions in an async fashion