### PR TITLE
shorthand boolean colors

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -37,6 +37,7 @@ export const constant = x => () => x;
 export function maybeColorChannel(value, defaultValue) {
   if (value === undefined) value = defaultValue;
   return value === null ? [undefined, "none"]
+    : typeof value === "boolean" ? [undefined, value ? "currentColor" : "none"]
     : isColor(value) ? [undefined, value]
     : [value, undefined];
 }
@@ -241,7 +242,9 @@ export function isEvery(values, is) {
 // coercion here, though note that d3-color instances would need to support
 // valueOf to work correctly with InternMap.
 export function isColor(value) {
-  if (typeof value !== "string") return false;
+  const type = typeof value;
+  if (type === "boolean") return true; // true for currentColor, false for none
+  if (type !== "string") return false;
   value = value.toLowerCase();
   return value === "currentcolor" || value === "none" || color(value) !== null;
 }

--- a/src/scales.js
+++ b/src/scales.js
@@ -158,6 +158,7 @@ function Scale(key, channels = [], options = {}) {
       switch (registry.get(key)) {
         case position: options = coerceType(channels, options, coerceNumber, Float64Array); break;
         case symbol: options = coerceType(channels, options, maybeSymbol); break;
+        case color: options = coerceType(channels, options, coerceColorBoolean); break;
       }
       break;
     case "utc":
@@ -332,6 +333,11 @@ function coerceType(channels, options, coerce, type) {
 
 function coerceArray(array, coerce, type = Array) {
   if (array !== undefined) return type.from(array, coerce);
+}
+
+// If a color is specified as a boolean, promote it to the corresponding string.
+function coerceColorBoolean(x) {
+  return x === true ? "currentColor" : x === false ? "none" : x;
 }
 
 // Unlike Mark’s number, here we want to convert null and undefined to NaN,


### PR DESCRIPTION
Not sure if this is a good idea, but this implements https://github.com/observablehq/plot/pull/692#issuecomment-1017795011. I think my preference is that we consider booleans to be abstract data rather than literal colors, independent of whether they are specified as constants or channels.