### PR TITLE
boolean greys

### DIFF
--- a/src/scales/schemes.js
+++ b/src/scales/schemes.js
@@ -143,6 +143,8 @@ const ordinalSchemes = new Map([
 
 function scheme9(scheme, interpolate) {
   return ({length: n}) => {
+    if (n === 1) return [scheme[3][1]]; // favor midpoint
+    if (n === 2) return [scheme[3][0], scheme[3][2]]; // favor extrema
     n = Math.max(3, Math.floor(n));
     return n > 9 ? quantize(interpolate, n) : scheme[n];
   };
@@ -182,6 +184,21 @@ export function ordinalRange(scheme, length) {
   const s = ordinalScheme(scheme);
   const r = typeof s === "function" ? s({length}) : s;
   return r.length !== length ? r.slice(0, length) : r;
+}
+
+// If the specified domain contains only booleans (ignoring null and undefined),
+// returns a corresponding range where false is mapped to the low color and true
+// is mapped to the high color of the specified scheme.
+export function maybeBooleanRange(domain, scheme) {
+  const range = new Set();
+  const [f, t] = ordinalScheme(scheme)({length: 2});
+  for (const value of domain) {
+    if (value == null) continue;
+    if (value === true) range.add(t);
+    else if (value === false) range.add(f);
+    else return;
+  }
+  return [...range];
 }
 
 const quantitativeSchemes = new Map([

--- a/test/output/colorSchemesOrdinal.html
+++ b/test/output/colorSchemesOrdinal.html
@@ -3601,7 +3601,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-106-swatch" style="--color: #deebf7;">blues</span>
+    </style><span class="plot-106-swatch" style="--color: #9ecae1;">blues</span>
   </div>
   <div class="plot-107" style="
         --swatchWidth: 15px;
@@ -3635,7 +3635,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-107-swatch" style="--color: #deebf7;">blues</span><span class="plot-107-swatch" style="--color: #9ecae1;">1</span>
+    </style><span class="plot-107-swatch" style="--color: #deebf7;">blues</span><span class="plot-107-swatch" style="--color: #3182bd;">1</span>
   </div>
   <div class="plot-108" style="
         --swatchWidth: 15px;
@@ -3771,7 +3771,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-111-swatch" style="--color: #e5f5e0;">greens</span>
+    </style><span class="plot-111-swatch" style="--color: #a1d99b;">greens</span>
   </div>
   <div class="plot-112" style="
         --swatchWidth: 15px;
@@ -3805,7 +3805,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-112-swatch" style="--color: #e5f5e0;">greens</span><span class="plot-112-swatch" style="--color: #a1d99b;">1</span>
+    </style><span class="plot-112-swatch" style="--color: #e5f5e0;">greens</span><span class="plot-112-swatch" style="--color: #31a354;">1</span>
   </div>
   <div class="plot-113" style="
         --swatchWidth: 15px;
@@ -3941,7 +3941,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-116-swatch" style="--color: #f0f0f0;">greys</span>
+    </style><span class="plot-116-swatch" style="--color: #bdbdbd;">greys</span>
   </div>
   <div class="plot-117" style="
         --swatchWidth: 15px;
@@ -3975,7 +3975,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-117-swatch" style="--color: #f0f0f0;">greys</span><span class="plot-117-swatch" style="--color: #bdbdbd;">1</span>
+    </style><span class="plot-117-swatch" style="--color: #f0f0f0;">greys</span><span class="plot-117-swatch" style="--color: #636363;">1</span>
   </div>
   <div class="plot-118" style="
         --swatchWidth: 15px;
@@ -4111,7 +4111,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-121-swatch" style="--color: #fee6ce;">oranges</span>
+    </style><span class="plot-121-swatch" style="--color: #fdae6b;">oranges</span>
   </div>
   <div class="plot-122" style="
         --swatchWidth: 15px;
@@ -4145,7 +4145,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-122-swatch" style="--color: #fee6ce;">oranges</span><span class="plot-122-swatch" style="--color: #fdae6b;">1</span>
+    </style><span class="plot-122-swatch" style="--color: #fee6ce;">oranges</span><span class="plot-122-swatch" style="--color: #e6550d;">1</span>
   </div>
   <div class="plot-123" style="
         --swatchWidth: 15px;
@@ -4281,7 +4281,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-126-swatch" style="--color: #efedf5;">purples</span>
+    </style><span class="plot-126-swatch" style="--color: #bcbddc;">purples</span>
   </div>
   <div class="plot-127" style="
         --swatchWidth: 15px;
@@ -4315,7 +4315,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-127-swatch" style="--color: #efedf5;">purples</span><span class="plot-127-swatch" style="--color: #bcbddc;">1</span>
+    </style><span class="plot-127-swatch" style="--color: #efedf5;">purples</span><span class="plot-127-swatch" style="--color: #756bb1;">1</span>
   </div>
   <div class="plot-128" style="
         --swatchWidth: 15px;
@@ -4451,7 +4451,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-131-swatch" style="--color: #fee0d2;">reds</span>
+    </style><span class="plot-131-swatch" style="--color: #fc9272;">reds</span>
   </div>
   <div class="plot-132" style="
         --swatchWidth: 15px;
@@ -4485,7 +4485,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-132-swatch" style="--color: #fee0d2;">reds</span><span class="plot-132-swatch" style="--color: #fc9272;">1</span>
+    </style><span class="plot-132-swatch" style="--color: #fee0d2;">reds</span><span class="plot-132-swatch" style="--color: #de2d26;">1</span>
   </div>
   <div class="plot-133" style="
         --swatchWidth: 15px;
@@ -6151,7 +6151,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-181-swatch" style="--color: #e5f5f9;">bugn</span>
+    </style><span class="plot-181-swatch" style="--color: #99d8c9;">bugn</span>
   </div>
   <div class="plot-182" style="
         --swatchWidth: 15px;
@@ -6185,7 +6185,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-182-swatch" style="--color: #e5f5f9;">bugn</span><span class="plot-182-swatch" style="--color: #99d8c9;">1</span>
+    </style><span class="plot-182-swatch" style="--color: #e5f5f9;">bugn</span><span class="plot-182-swatch" style="--color: #2ca25f;">1</span>
   </div>
   <div class="plot-183" style="
         --swatchWidth: 15px;
@@ -6321,7 +6321,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-186-swatch" style="--color: #e0ecf4;">bupu</span>
+    </style><span class="plot-186-swatch" style="--color: #9ebcda;">bupu</span>
   </div>
   <div class="plot-187" style="
         --swatchWidth: 15px;
@@ -6355,7 +6355,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-187-swatch" style="--color: #e0ecf4;">bupu</span><span class="plot-187-swatch" style="--color: #9ebcda;">1</span>
+    </style><span class="plot-187-swatch" style="--color: #e0ecf4;">bupu</span><span class="plot-187-swatch" style="--color: #8856a7;">1</span>
   </div>
   <div class="plot-188" style="
         --swatchWidth: 15px;
@@ -6491,7 +6491,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-191-swatch" style="--color: #e0f3db;">gnbu</span>
+    </style><span class="plot-191-swatch" style="--color: #a8ddb5;">gnbu</span>
   </div>
   <div class="plot-192" style="
         --swatchWidth: 15px;
@@ -6525,7 +6525,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-192-swatch" style="--color: #e0f3db;">gnbu</span><span class="plot-192-swatch" style="--color: #a8ddb5;">1</span>
+    </style><span class="plot-192-swatch" style="--color: #e0f3db;">gnbu</span><span class="plot-192-swatch" style="--color: #43a2ca;">1</span>
   </div>
   <div class="plot-193" style="
         --swatchWidth: 15px;
@@ -6661,7 +6661,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-196-swatch" style="--color: #fee8c8;">orrd</span>
+    </style><span class="plot-196-swatch" style="--color: #fdbb84;">orrd</span>
   </div>
   <div class="plot-197" style="
         --swatchWidth: 15px;
@@ -6695,7 +6695,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-197-swatch" style="--color: #fee8c8;">orrd</span><span class="plot-197-swatch" style="--color: #fdbb84;">1</span>
+    </style><span class="plot-197-swatch" style="--color: #fee8c8;">orrd</span><span class="plot-197-swatch" style="--color: #e34a33;">1</span>
   </div>
   <div class="plot-198" style="
         --swatchWidth: 15px;
@@ -6831,7 +6831,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-201-swatch" style="--color: #ece7f2;">pubu</span>
+    </style><span class="plot-201-swatch" style="--color: #a6bddb;">pubu</span>
   </div>
   <div class="plot-202" style="
         --swatchWidth: 15px;
@@ -6865,7 +6865,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-202-swatch" style="--color: #ece7f2;">pubu</span><span class="plot-202-swatch" style="--color: #a6bddb;">1</span>
+    </style><span class="plot-202-swatch" style="--color: #ece7f2;">pubu</span><span class="plot-202-swatch" style="--color: #2b8cbe;">1</span>
   </div>
   <div class="plot-203" style="
         --swatchWidth: 15px;
@@ -7001,7 +7001,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-206-swatch" style="--color: #ece2f0;">pubugn</span>
+    </style><span class="plot-206-swatch" style="--color: #a6bddb;">pubugn</span>
   </div>
   <div class="plot-207" style="
         --swatchWidth: 15px;
@@ -7035,7 +7035,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-207-swatch" style="--color: #ece2f0;">pubugn</span><span class="plot-207-swatch" style="--color: #a6bddb;">1</span>
+    </style><span class="plot-207-swatch" style="--color: #ece2f0;">pubugn</span><span class="plot-207-swatch" style="--color: #1c9099;">1</span>
   </div>
   <div class="plot-208" style="
         --swatchWidth: 15px;
@@ -7171,7 +7171,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-211-swatch" style="--color: #e7e1ef;">purd</span>
+    </style><span class="plot-211-swatch" style="--color: #c994c7;">purd</span>
   </div>
   <div class="plot-212" style="
         --swatchWidth: 15px;
@@ -7205,7 +7205,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-212-swatch" style="--color: #e7e1ef;">purd</span><span class="plot-212-swatch" style="--color: #c994c7;">1</span>
+    </style><span class="plot-212-swatch" style="--color: #e7e1ef;">purd</span><span class="plot-212-swatch" style="--color: #dd1c77;">1</span>
   </div>
   <div class="plot-213" style="
         --swatchWidth: 15px;
@@ -7341,7 +7341,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-216-swatch" style="--color: #fde0dd;">rdpu</span>
+    </style><span class="plot-216-swatch" style="--color: #fa9fb5;">rdpu</span>
   </div>
   <div class="plot-217" style="
         --swatchWidth: 15px;
@@ -7375,7 +7375,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-217-swatch" style="--color: #fde0dd;">rdpu</span><span class="plot-217-swatch" style="--color: #fa9fb5;">1</span>
+    </style><span class="plot-217-swatch" style="--color: #fde0dd;">rdpu</span><span class="plot-217-swatch" style="--color: #c51b8a;">1</span>
   </div>
   <div class="plot-218" style="
         --swatchWidth: 15px;
@@ -7511,7 +7511,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-221-swatch" style="--color: #f7fcb9;">ylgn</span>
+    </style><span class="plot-221-swatch" style="--color: #addd8e;">ylgn</span>
   </div>
   <div class="plot-222" style="
         --swatchWidth: 15px;
@@ -7545,7 +7545,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-222-swatch" style="--color: #f7fcb9;">ylgn</span><span class="plot-222-swatch" style="--color: #addd8e;">1</span>
+    </style><span class="plot-222-swatch" style="--color: #f7fcb9;">ylgn</span><span class="plot-222-swatch" style="--color: #31a354;">1</span>
   </div>
   <div class="plot-223" style="
         --swatchWidth: 15px;
@@ -7681,7 +7681,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-226-swatch" style="--color: #edf8b1;">ylgnbu</span>
+    </style><span class="plot-226-swatch" style="--color: #7fcdbb;">ylgnbu</span>
   </div>
   <div class="plot-227" style="
         --swatchWidth: 15px;
@@ -7715,7 +7715,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-227-swatch" style="--color: #edf8b1;">ylgnbu</span><span class="plot-227-swatch" style="--color: #7fcdbb;">1</span>
+    </style><span class="plot-227-swatch" style="--color: #edf8b1;">ylgnbu</span><span class="plot-227-swatch" style="--color: #2c7fb8;">1</span>
   </div>
   <div class="plot-228" style="
         --swatchWidth: 15px;
@@ -7851,7 +7851,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-231-swatch" style="--color: #fff7bc;">ylorbr</span>
+    </style><span class="plot-231-swatch" style="--color: #fec44f;">ylorbr</span>
   </div>
   <div class="plot-232" style="
         --swatchWidth: 15px;
@@ -7885,7 +7885,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-232-swatch" style="--color: #fff7bc;">ylorbr</span><span class="plot-232-swatch" style="--color: #fec44f;">1</span>
+    </style><span class="plot-232-swatch" style="--color: #fff7bc;">ylorbr</span><span class="plot-232-swatch" style="--color: #d95f0e;">1</span>
   </div>
   <div class="plot-233" style="
         --swatchWidth: 15px;
@@ -8021,7 +8021,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-236-swatch" style="--color: #ffeda0;">ylorrd</span>
+    </style><span class="plot-236-swatch" style="--color: #feb24c;">ylorrd</span>
   </div>
   <div class="plot-237" style="
         --swatchWidth: 15px;
@@ -8055,7 +8055,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-237-swatch" style="--color: #ffeda0;">ylorrd</span><span class="plot-237-swatch" style="--color: #feb24c;">1</span>
+    </style><span class="plot-237-swatch" style="--color: #ffeda0;">ylorrd</span><span class="plot-237-swatch" style="--color: #f03b20;">1</span>
   </div>
   <div class="plot-238" style="
         --swatchWidth: 15px;

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -718,7 +718,7 @@ it("plot(…).scale('color') can return a threshold scale with an explicit schem
   scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [0],
-    range: [d3.schemeBlues[3][0], d3.schemeBlues[3][1]],
+    range: [d3.schemeBlues[3][0], d3.schemeBlues[3][2]],
     label: "body_mass_g"
   });
 });


### PR DESCRIPTION
When the defined values associated with an ordinal or categorical color scale are entirely boolean (true or false), construct a default range from the *greys* color scheme, assigning the light gray to false and the dark gray to true (rather than *turbo* or *tableau10*). In addition, make the *n* = 2 ordinal schemes higher contrast by favoring the extrema.

I considered having categorical color scales continue to use *tableau10*, restricting this behavior to ordinal color scales. This would require changing the logic in asOrdinalType to similarly check whether the associated defined values are boolean. I wasn’t sure if it was desirable to do this check twice. And I went back and forth over whether this should be an exhaustive check or a fast check (looking only at the first defined value). But I think it’s better to do an exhaustive check here since the the *greys* color scheme won’t work very well if there are many values.

<img width="660" alt="Screen Shot 2022-01-20 at 11 27 54 AM" src="https://user-images.githubusercontent.com/230541/150409218-586f5211-9a63-46de-a1ff-341b572e7332.png">
