### PR TITLE
Add plot cheatsheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 * [Changelog](./CHANGELOG.md)
 * [Contributing](./CONTRIBUTING.md)
 
+For an interactive overview, see the [Plot Cheatsheets](https://observablehq.com/@observablehq/plot-cheatsheets), or download the [PDF](img/plot-cheatsheets.pdf). 
+
 ## Installing
 
 In Observable notebooks, Plot and D3 are available by default as part of the [standard library](https://observablehq.com/@observablehq/recommended-libraries).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * [Changelog](./CHANGELOG.md)
 * [Contributing](./CONTRIBUTING.md)
 
-For an interactive overview, see the [Plot Cheatsheets](https://observablehq.com/@observablehq/plot-cheatsheets), or download the [PDF](img/plot-cheatsheets.pdf). 
+For a quick overview, see the interactive [Plot Cheatsheets](https://observablehq.com/@observablehq/plot-cheatsheets), or download the [PDF](img/plot-cheatsheets.pdf). 
 
 ## Installing
 


### PR DESCRIPTION
Adds a link to the cheatsheets landing notebook and uploads the PDF. Unsure if we want to feature them this prominently, though I didn't see another obvious place for them in the `README.md` file. 

Note, this is a **draft**, as the PDF is not yet finalized and the notebook is not yet published. 