### PR TITLE
text wrap (lineWidth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,6 +1109,8 @@ The following text-specific constant options are also supported:
 * **textAnchor** - the [text anchor](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/text-anchor) for horizontal position; start, end, or middle
 * **lineAnchor** - the line anchor for vertical position; top, bottom, or middle
 * **lineHeight** - the line height in ems; defaults to 1
+* **lineWidth** - the line width in ems, for wrapping; defaults to Infinity
+* **monospace** - if true, changes the default fontFamily and metrics to monospace
 * **fontFamily** - the font name; defaults to [system-ui](https://drafts.csswg.org/css-fonts-4/#valdef-font-family-system-ui)
 * **fontSize** - the font size in pixels; defaults to 10
 * **fontStyle** - the [font style](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style); defaults to normal
@@ -1116,6 +1118,8 @@ The following text-specific constant options are also supported:
 * **fontWeight** - the [font weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight); defaults to normal
 * **frameAnchor** - the frame anchor; top-left, top, top-right, right, bottom-right, bottom, bottom-left, left, or middle (default)
 * **rotate** - the rotation angle in degrees clockwise; defaults to 0
+
+If a **lineWidth** is specified, input text values will be wrapped as needed to fit while preserving existing newlines. The line wrapping implementation is rudimentary; for non-ASCII, non-U.S. English text, or for when a different font is used, you may get better results by hard-wrapping the text yourself (by supplying newlines in the input). If the **monospace** option is truthy, the default **fontFamily** changes to “ui-monospace, monospace”, and the **lineWidth** option is interpreted as characters (ch) rather than ems.
 
 The **fontSize** and **rotate** options can be specified as either channels or constants. When fontSize or rotate is specified as a number, it is interpreted as a constant; otherwise it is interpreted as a channel.
 

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -19,6 +19,7 @@ export class Text extends Mark {
       textAnchor = /right$/i.test(frameAnchor) ? "end" : /left$/i.test(frameAnchor) ? "start" : "middle",
       lineAnchor = /^top/i.test(frameAnchor) ? "top" : /^bottom/i.test(frameAnchor) ? "bottom" : "middle",
       lineHeight = 1,
+      lineWidth = Infinity,
       fontFamily,
       fontSize,
       fontStyle,
@@ -44,6 +45,7 @@ export class Text extends Mark {
     this.textAnchor = impliedString(textAnchor, "middle");
     this.lineAnchor = keyword(lineAnchor, "lineAnchor", ["top", "middle", "bottom"]);
     this.lineHeight = +lineHeight;
+    this.lineWidth = +lineWidth;
     this.fontFamily = string(fontFamily);
     this.fontSize = cfontSize;
     this.fontStyle = string(fontStyle);
@@ -81,11 +83,12 @@ export class Text extends Mark {
   }
 }
 
-function applyMultilineText(selection, {lineAnchor, lineHeight}, T) {
+function applyMultilineText(selection, {lineAnchor, lineHeight, lineWidth}, T) {
   if (!T) return;
   const format = isTemporal(T) ? isoFormat : isNumeric(T) ? formatNumber() : string;
+  const linesof = isFinite(lineWidth) ? t => lineWrap(t, lineWidth * defaultWidthMap.m, defaultWidth) : t => t.split(/\r\n?|\n/g);
   selection.each(function(i) {
-    const lines = format(T[i]).split(/\r\n?|\n/g);
+    const lines = linesof(format(T[i]));
     const n = lines.length;
     const y = lineAnchor === "top" ? 0.71 : lineAnchor === "bottom" ? 1 - n : (164 - n * 100) / 200;
     if (n > 1) {
@@ -161,4 +164,103 @@ function maybeFontSizeChannel(fontSize) {
   return fontSizes.has(fontSize) || /^[+-]?\d*\.?\d+(e[+-]?\d+)?(\w*|%)$/.test(fontSize)
     ? [undefined, fontSize]
     : [fontSize, undefined];
+}
+
+// This is a greedy algorithm for line wrapping. It would be better to use the
+// Knuth–Plass line breaking algorithm (but that would be much more complex).
+// https://en.wikipedia.org/wiki/Line_wrap_and_word_wrap
+function lineWrap(input, maxWidth, widthof = (_, i, j) => j - i) {
+  const lines = [];
+  let lineStart, lineEnd = 0;
+  for (const [wordStart, wordEnd, required] of lineBreaks(input)) {
+    // Record the start of a line. This isn’t the same as the previous line’s
+    // end because we often skip spaces between lines.
+    if (lineStart === undefined) lineStart = wordStart;
+
+    // If the current line is not empty, and if adding the current word would
+    // make the line longer than the allowed width, then break the line at the
+    // previous word end.
+    if (lineEnd > lineStart && widthof(input, lineStart, wordEnd) > maxWidth) {
+      lines.push(input.slice(lineStart, lineEnd));
+      lineStart = wordStart;
+    }
+
+    // If this is a required break (a newline), emit the line and reset.
+    if (required) {
+      lines.push(input.slice(lineStart, wordEnd));
+      lineStart = undefined;
+      continue;
+    }
+
+    // Extend the current line to include the new word.
+    lineEnd = wordEnd;
+  }
+  return lines;
+}
+
+// This is a rudimentary (and U.S.-centric) algorithm for finding opportunities
+// to break lines between words. A better and far more comprehensive approach
+// would be to use the official Unicode Line Breaking Algorithm.
+// https://unicode.org/reports/tr14/
+function* lineBreaks(input) {
+  let i = 0, j = 0;
+  const n = input.length;
+  while (j < n) {
+    let k = 1;
+    switch (input[j]) {
+      case "-": // hyphen
+        ++j;
+        yield [i, j, false];
+        i = j;
+        break;
+      case " ":
+        yield [i, j, false];
+        while (input[++j] === " "); // skip multiple spaces
+        i = j;
+        break;
+      case "\r": if (input[j + 1] === "\n") ++k; // falls through
+      case "\n":
+        yield [i, j, true];
+        j += k;
+        i = j;
+        break;
+      default:
+        ++j;
+        break;
+    }
+  }
+  yield [i, j, true];
+}
+
+// Computed with measureText(text) at 100px system-ui.
+const defaultWidthMap = {
+  a: 50, b: 55, c: 50, d: 55, e: 51, f: 30, g: 55, h: 54, i: 21, j: 21, k: 49, l: 20, m: 80, n: 53, o: 53, p: 55, q: 55, r: 31, s: 47, t: 30, u: 53, v: 48, w: 72, x: 47, y: 49, z: 47,
+  A: 64, B: 60, C: 69, D: 68, E: 55, F: 53, G: 71, H: 70, I: 22, J: 50, K: 60, L: 52, M: 83, N: 70, O: 73, P: 58, Q: 73, R: 60, S: 59, T: 58, U: 70, V: 63, W: 92, X: 63, Y: 61, Z: 62,
+  0: 61, 1: 44, 2: 57, 3: 59, 4: 60, 5: 58, 6: 62, 7: 55, 8: 60, 9: 62,
+  " ": 21, "!": 27, '"': 40, "'": 25, ",": 21, "-": 43, ".": 21, "/": 28, ":": 21, ";": 21, "?": 49, "‘": 21, "’": 21, "“": 36, "”": 36, "(": 32, ")": 32
+};
+
+// This is a rudimentary (and U.S.-centric) algorithm for measuring the width of
+// a string based on a technique of Gregor Aisch; it assumes that individual
+// characters are laid out independently and does not implement the Unicode
+// grapheme cluster breaking algorithm. It does understand code points, though,
+// and so treats things like emoji as having the width of a lowercase e (and
+// should be equivalent to using for-of to iterate over code points, while also
+// being fast). TODO Optimize this by noting that we often re-measure characters
+// that were previously measured?
+// http://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries
+// https://exploringjs.com/impatient-js/ch_strings.html#atoms-of-text
+function defaultWidth(text, start, end) {
+  let sum = 0;
+  for (let i = start; i < end; ++i) {
+    sum += defaultWidthMap[text[i]] || defaultWidthMap.e;
+    const first = text.charCodeAt(i);
+    if (first >= 0xd800 && first <= 0xdbff) { // high surrogate
+      const second = text.charCodeAt(i + 1);
+      if (second >= 0xdc00 && second <= 0xdfff) { // low surrogate
+        ++i; // surrogate pair
+      }
+    }
+  }
+  return sum;
 }

--- a/test/output/mobyDick.svg
+++ b/test/output/mobyDick.svg
@@ -1,0 +1,174 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1200" viewBox="0 0 640 1200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g text-anchor="start" font-size="14" transform="translate(0.5,0.5)"><text transform="translate(0,0)">
+      <tspan x="0" y="0.852em">Call me Ishmael. Some years ago—never mind how long precisely—having little or</tspan>
+      <tspan x="0" y="2.052em">no money in my purse, and nothing particular to interest me on shore, I thought I</tspan>
+      <tspan x="0" y="3.252em">would sail about a little and see the watery part of the world. It is a way I have of</tspan>
+      <tspan x="0" y="4.452em">driving off the spleen and regulating the circulation. Whenever I find myself</tspan>
+      <tspan x="0" y="5.652em">growing grim about the mouth; whenever it is a damp, drizzly November in my</tspan>
+      <tspan x="0" y="6.851999999999999em">soul; whenever I find myself involuntarily pausing before coffin warehouses, and</tspan>
+      <tspan x="0" y="8.052em">bringing up the rear of every funeral I meet; and especially whenever my hypos get</tspan>
+      <tspan x="0" y="9.251999999999999em">such an upper hand of me, that it requires a strong moral principle to prevent me</tspan>
+      <tspan x="0" y="10.452em">from deliberately stepping into the street, and methodically knocking people’s</tspan>
+      <tspan x="0" y="11.652000000000001em">hats off—then, I account it high time to get to sea as soon as I can. This is my</tspan>
+      <tspan x="0" y="12.852em">substitute for pistol and ball. With a philosophical flourish Cato throws himself</tspan>
+      <tspan x="0" y="14.052000000000001em">upon his sword; I quietly take to the ship. There is nothing surprising in this. If they</tspan>
+      <tspan x="0" y="15.252em">but knew it, almost all men in their degree, some time or other, cherish very nearly</tspan>
+      <tspan x="0" y="16.452em">the same feelings towards the ocean with me.</tspan>
+      <tspan x="0" y="18.852em">There now is your insular city of the Manhattoes, belted round by wharves as</tspan>
+      <tspan x="0" y="20.052em">Indian isles by coral reefs—commerce surrounds it with her surf. Right and left, the</tspan>
+      <tspan x="0" y="21.252em">streets take you waterward. Its extreme downtown is the battery, where that noble</tspan>
+      <tspan x="0" y="22.452em">mole is washed by waves, and cooled by breezes, which a few hours previous</tspan>
+      <tspan x="0" y="23.652em">were out of sight of land. Look at the crowds of water-gazers there.</tspan>
+      <tspan x="0" y="26.052em">Circumambulate the city of a dreamy Sabbath afternoon. Go from Corlears Hook to</tspan>
+      <tspan x="0" y="27.252em">Coenties Slip, and from thence, by Whitehall, northward. What do you</tspan>
+      <tspan x="0" y="28.452em">see?—Posted like silent sentinels all around the town, stand thousands upon</tspan>
+      <tspan x="0" y="29.652em">thousands of mortal men fixed in ocean reveries. Some leaning against the spiles;</tspan>
+      <tspan x="0" y="30.852em">some seated upon the pier-heads; some looking over the bulwarks of ships from</tspan>
+      <tspan x="0" y="32.052em">China; some high aloft in the rigging, as if striving to get a still better seaward</tspan>
+      <tspan x="0" y="33.252em">peep. But these are all landsmen; of week days pent up in lath and plaster—tied to</tspan>
+      <tspan x="0" y="34.452em">counters, nailed to benches, clinched to desks. How then is this? Are the green</tspan>
+      <tspan x="0" y="35.652em">fields gone? What do they here?</tspan>
+      <tspan x="0" y="38.052em">But look! here come more crowds, pacing straight for the water, and seemingly</tspan>
+      <tspan x="0" y="39.252em">bound for a dive. Strange! Nothing will content them but the extremest limit of the</tspan>
+      <tspan x="0" y="40.452em">land; loitering under the shady lee of yonder warehouses will not suffice. No. They</tspan>
+      <tspan x="0" y="41.652em">must get just as nigh the water as they possibly can without falling in. And there</tspan>
+      <tspan x="0" y="42.852em">they stand—miles of them—leagues. Inlanders all, they come from lanes and alleys,</tspan>
+      <tspan x="0" y="44.052em">streets and avenues—north, east, south, and west. Yet here they all unite. Tell me,</tspan>
+      <tspan x="0" y="45.252em">does the magnetic virtue of the needles of the compasses of all those ships attract</tspan>
+      <tspan x="0" y="46.452em">them thither?</tspan>
+      <tspan x="0" y="48.852em">Once more. Say you are in the country; in some high land of lakes. Take almost</tspan>
+      <tspan x="0" y="50.052em">any path you please, and ten to one it carries you down in a dale, and leaves you</tspan>
+      <tspan x="0" y="51.252em">there by a pool in the stream. There is magic in it. Let the most absent-minded of</tspan>
+      <tspan x="0" y="52.452em">men be plunged in his deepest reveries—stand that man on his legs, set his feet a-</tspan>
+      <tspan x="0" y="53.652em">going, and he will infallibly lead you to water, if water there be in all that region.</tspan>
+      <tspan x="0" y="54.852em">Should you ever be athirst in the great American desert, try this experiment, if</tspan>
+      <tspan x="0" y="56.052em">your caravan happen to be supplied with a metaphysical professor. Yes, as every</tspan>
+      <tspan x="0" y="57.252em">one knows, meditation and water are wedded for ever.</tspan>
+      <tspan x="0" y="59.652em">But here is an artist. He desires to paint you the dreamiest, shadiest, quietest,</tspan>
+      <tspan x="0" y="60.852em">most enchanting bit of romantic landscape in all the valley of the Saco. What is the</tspan>
+      <tspan x="0" y="62.052em">chief element he employs? There stand his trees, each with a hollow trunk, as if a</tspan>
+      <tspan x="0" y="63.251999999999995em">hermit and a crucifix were within; and here sleeps his meadow, and there sleep his</tspan>
+      <tspan x="0" y="64.452em">cattle; and up from yonder cottage goes a sleepy smoke. Deep into distant</tspan>
+      <tspan x="0" y="65.652em">woodlands winds a mazy way, reaching to overlapping spurs of mountains bathed</tspan>
+      <tspan x="0" y="66.852em">in their hill-side blue. But though the picture lies thus tranced, and though this</tspan>
+      <tspan x="0" y="68.05199999999999em">pine-tree shakes down its sighs like leaves upon this shepherd’s head, yet all were</tspan>
+      <tspan x="0" y="69.252em">vain, unless the shepherd’s eye were fixed upon the magic stream before him. Go</tspan>
+      <tspan x="0" y="70.452em">visit the Prairies in June, when for scores on scores of miles you wade knee-deep</tspan>
+      <tspan x="0" y="71.652em">among Tiger-lilies—what is the one charm wanting?—Water—there is not a drop of</tspan>
+      <tspan x="0" y="72.852em">water there! Were Niagara but a cataract of sand, would you travel your thousand</tspan>
+      <tspan x="0" y="74.05199999999999em">miles to see it? Why did the poor poet of Tennessee, upon suddenly receiving two</tspan>
+      <tspan x="0" y="75.252em">handfuls of silver, deliberate whether to buy him a coat, which he sadly needed, or</tspan>
+      <tspan x="0" y="76.452em">invest his money in a pedestrian trip to Rockaway Beach? Why is almost every</tspan>
+      <tspan x="0" y="77.65199999999999em">robust healthy boy with a robust healthy soul in him, at some time or other crazy</tspan>
+      <tspan x="0" y="78.85199999999999em">to go to sea? Why upon your first voyage as a passenger, did you yourself feel</tspan>
+      <tspan x="0" y="80.05199999999999em">such a mystical vibration, when first told that you and your ship were now out of</tspan>
+      <tspan x="0" y="81.252em">sight of land? Why did the old Persians hold the sea holy? Why did the Greeks give</tspan>
+      <tspan x="0" y="82.45199999999998em">it a separate deity, and own brother of Jove? Surely all this is not without meaning.</tspan>
+      <tspan x="0" y="83.65199999999999em">And still deeper the meaning of that story of Narcissus, who because he could not</tspan>
+      <tspan x="0" y="84.85199999999999em">grasp the tormenting, mild image he saw in the fountain, plunged into it and was</tspan>
+      <tspan x="0" y="86.05199999999999em">drowned. But that same image, we ourselves see in all rivers and oceans. It is the</tspan>
+      <tspan x="0" y="87.252em">image of the ungraspable phantom of life; and this is the key to it all.</tspan>
+      <tspan x="0" y="89.65199999999999em">Now, when I say that I am in the habit of going to sea whenever I begin to grow</tspan>
+      <tspan x="0" y="90.85199999999999em">hazy about the eyes, and begin to be over conscious of my lungs, I do not mean to</tspan>
+      <tspan x="0" y="92.05199999999999em">have it inferred that I ever go to sea as a passenger. For to go as a passenger you</tspan>
+      <tspan x="0" y="93.252em">must needs have a purse, and a purse is but a rag unless you have something in it.</tspan>
+      <tspan x="0" y="94.45199999999998em">Besides, passengers get sea-sick—grow quarrelsome—don’t sleep of nights—do not</tspan>
+      <tspan x="0" y="95.65199999999999em">enjoy themselves much, as a general thing;—no, I never go as a passenger; nor,</tspan>
+      <tspan x="0" y="96.85199999999999em">though I am something of a salt, do I ever go to sea as a Commodore, or a Captain,</tspan>
+      <tspan x="0" y="98.05199999999999em">or a Cook. I abandon the glory and distinction of such offices to those who like</tspan>
+      <tspan x="0" y="99.252em">them. For my part, I abominate all honorable respectable toils, trials, and</tspan>
+      <tspan x="0" y="100.45199999999998em">tribulations of every kind whatsoever. It is quite as much as I can do to take care</tspan>
+      <tspan x="0" y="101.65199999999999em">of myself, without taking care of ships, barques, brigs, schooners, and what not.</tspan>
+      <tspan x="0" y="102.85199999999999em">And as for going as cook,—though I confess there is considerable glory in that, a</tspan>
+      <tspan x="0" y="104.05199999999999em">cook being a sort of officer on ship-board—yet, somehow, I never fancied broiling</tspan>
+      <tspan x="0" y="105.252em">fowls;—though once broiled, judiciously buttered, and judgmatically salted and</tspan>
+      <tspan x="0" y="106.45199999999998em">peppered, there is no one who will speak more respectfully, not to say</tspan>
+      <tspan x="0" y="107.65199999999999em">reverentially, of a broiled fowl than I will. It is out of the idolatrous dotings of the</tspan>
+      <tspan x="0" y="108.85199999999999em">old Egyptians upon broiled ibis and roasted river horse, that you see the mummies</tspan>
+      <tspan x="0" y="110.05199999999999em">of those creatures in their huge bake-houses the pyramids.</tspan>
+      <tspan x="0" y="112.45199999999998em">No, when I go to sea, I go as a simple sailor, right before the mast, plumb down</tspan>
+      <tspan x="0" y="113.65199999999999em">into the forecastle, aloft there to the royal mast-head. True, they rather order me</tspan>
+      <tspan x="0" y="114.85199999999999em">about some, and make me jump from spar to spar, like a grasshopper in a May</tspan>
+      <tspan x="0" y="116.05199999999999em">meadow. And at first, this sort of thing is unpleasant enough. It touches one’s</tspan>
+      <tspan x="0" y="117.25199999999998em">sense of honor, particularly if you come of an old established family in the land,</tspan>
+      <tspan x="0" y="118.45199999999998em">the Van Rensselaers, or Randolphs, or Hardicanutes. And more than all, if just</tspan>
+      <tspan x="0" y="119.65199999999999em">previous to putting your hand into the tar-pot, you have been lording it as a</tspan>
+      <tspan x="0" y="120.85199999999999em">country schoolmaster, making the tallest boys stand in awe of you. The transition</tspan>
+      <tspan x="0" y="122.05199999999999em">is a keen one, I assure you, from a schoolmaster to a sailor, and requires a strong</tspan>
+      <tspan x="0" y="123.25199999999998em">decoction of Seneca and the Stoics to enable you to grin and bear it. But even this</tspan>
+      <tspan x="0" y="124.45199999999998em">wears off in time.</tspan>
+      <tspan x="0" y="126.85199999999999em">What of it, if some old hunks of a sea-captain orders me to get a broom and sweep</tspan>
+      <tspan x="0" y="128.052em">down the decks? What does that indignity amount to, weighed, I mean, in the</tspan>
+      <tspan x="0" y="129.25199999999998em">scales of the New Testament? Do you think the archangel Gabriel thinks anything</tspan>
+      <tspan x="0" y="130.452em">the less of me, because I promptly and respectfully obey that old hunks in that</tspan>
+      <tspan x="0" y="131.652em">particular instance? Who ain’t a slave? Tell me that. Well, then, however the old</tspan>
+      <tspan x="0" y="132.85199999999998em">sea-captains may order me about—however they may thump and punch me about, I</tspan>
+      <tspan x="0" y="134.052em">have the satisfaction of knowing that it is all right; that everybody else is one way</tspan>
+      <tspan x="0" y="135.25199999999998em">or other served in much the same way—either in a physical or metaphysical point of</tspan>
+      <tspan x="0" y="136.452em">view, that is; and so the universal thump is passed round, and all hands should rub</tspan>
+      <tspan x="0" y="137.652em">each other’s shoulder-blades, and be content.</tspan>
+      <tspan x="0" y="140.052em">Again, I always go to sea as a sailor, because they make a point of paying me for</tspan>
+      <tspan x="0" y="141.25199999999998em">my trouble, whereas they never pay passengers a single penny that I ever heard</tspan>
+      <tspan x="0" y="142.452em">of. On the contrary, passengers themselves must pay. And there is all the</tspan>
+      <tspan x="0" y="143.652em">difference in the world between paying and being paid. The act of paying is</tspan>
+      <tspan x="0" y="144.85199999999998em">perhaps the most uncomfortable infliction that the two orchard thieves entailed</tspan>
+      <tspan x="0" y="146.052em">upon us. But being paid,—what will compare with it? The urbane activity with which</tspan>
+      <tspan x="0" y="147.25199999999998em">a man receives money is really marvellous, considering that we so earnestly</tspan>
+      <tspan x="0" y="148.452em">believe money to be the root of all earthly ills, and that on no account can a</tspan>
+      <tspan x="0" y="149.652em">monied man enter heaven. Ah! how cheerfully we consign ourselves to perdition!</tspan>
+      <tspan x="0" y="152.052em">Finally, I always go to sea as a sailor, because of the wholesome exercise and pure</tspan>
+      <tspan x="0" y="153.25199999999998em">air of the fore-castle deck. For as in this world, head winds are far more prevalent</tspan>
+      <tspan x="0" y="154.452em">than winds from astern (that is, if you never violate the Pythagorean maxim), so for</tspan>
+      <tspan x="0" y="155.65200000000002em">the most part the Commodore on the quarter-deck gets his atmosphere at second</tspan>
+      <tspan x="0" y="156.852em">hand from the sailors on the forecastle. He thinks he breathes it first; but not so. In</tspan>
+      <tspan x="0" y="158.052em">much the same way do the commonalty lead their leaders in many other things, at</tspan>
+      <tspan x="0" y="159.252em">the same time that the leaders little suspect it. But wherefore it was that after</tspan>
+      <tspan x="0" y="160.452em">having repeatedly smelt the sea as a merchant sailor, I should now take it into my</tspan>
+      <tspan x="0" y="161.65200000000002em">head to go on a whaling voyage; this the invisible police officer of the Fates, who</tspan>
+      <tspan x="0" y="162.852em">has the constant surveillance of me, and secretly dogs me, and influences me in</tspan>
+      <tspan x="0" y="164.052em">some unaccountable way—he can better answer than any one else. And, doubtless,</tspan>
+      <tspan x="0" y="165.252em">my going on this whaling voyage, formed part of the grand programme of</tspan>
+      <tspan x="0" y="166.452em">Providence that was drawn up a long time ago. It came in as a sort of brief</tspan>
+      <tspan x="0" y="167.65200000000002em">interlude and solo between more extensive performances. I take it that this part of</tspan>
+      <tspan x="0" y="168.852em">the bill must have run something like this:</tspan>
+      <tspan x="0" y="171.252em">“Grand Contested Election for the Presidency of the United States. “WHALING</tspan>
+      <tspan x="0" y="172.452em">VOYAGE BY ONE ISHMAEL. “BLOODY BATTLE IN AFFGHANISTAN.”</tspan>
+      <tspan x="0" y="174.852em">Though I cannot tell why it was exactly that those stage managers, the Fates, put</tspan>
+      <tspan x="0" y="176.052em">me down for this shabby part of a whaling voyage, when others were set down for</tspan>
+      <tspan x="0" y="177.252em">magnificent parts in high tragedies, and short and easy parts in genteel comedies,</tspan>
+      <tspan x="0" y="178.452em">and jolly parts in farces—though I cannot tell why this was exactly; yet, now that I</tspan>
+      <tspan x="0" y="179.65200000000002em">recall all the circumstances, I think I can see a little into the springs and motives</tspan>
+      <tspan x="0" y="180.852em">which being cunningly presented to me under various disguises, induced me to set</tspan>
+      <tspan x="0" y="182.052em">about performing the part I did, besides cajoling me into the delusion that it was a</tspan>
+      <tspan x="0" y="183.252em">choice resulting from my own unbiased freewill and discriminating judgment.</tspan>
+      <tspan x="0" y="185.65200000000002em">Chief among these motives was the overwhelming idea of the great whale himself.</tspan>
+      <tspan x="0" y="186.852em">Such a portentous and mysterious monster roused all my curiosity. Then the wild</tspan>
+      <tspan x="0" y="188.052em">and distant seas where he rolled his island bulk; the undeliverable, nameless perils</tspan>
+      <tspan x="0" y="189.252em">of the whale; these, with all the attending marvels of a thousand Patagonian sights</tspan>
+      <tspan x="0" y="190.452em">and sounds, helped to sway me to my wish. With other men, perhaps, such things</tspan>
+      <tspan x="0" y="191.65200000000002em">would not have been inducements; but as for me, I am tormented with an</tspan>
+      <tspan x="0" y="192.852em">everlasting itch for things remote. I love to sail forbidden seas, and land on</tspan>
+      <tspan x="0" y="194.052em">barbarous coasts. Not ignoring what is good, I am quick to perceive a horror, and</tspan>
+      <tspan x="0" y="195.252em">could still be social with it—would they let me—since it is but well to be on friendly</tspan>
+      <tspan x="0" y="196.452em">terms with all the inmates of the place one lodges in.</tspan>
+      <tspan x="0" y="198.852em">By reason of these things, then, the whaling voyage was welcome; the great flood-</tspan>
+      <tspan x="0" y="200.052em">gates of the wonder-world swung open, and in the wild conceits that swayed me</tspan>
+      <tspan x="0" y="201.252em">to my purpose, two and two there floated into my inmost soul, endless</tspan>
+      <tspan x="0" y="202.452em">processions of the whale, and, mid most of them all, one grand hooded phantom,</tspan>
+      <tspan x="0" y="203.65200000000002em">like a snow hill in the air.</tspan>
+    </text></g>
+</svg>

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -75,6 +75,7 @@ export {default as metroUnemploymentMoving} from "./metro-unemployment-moving.js
 export {default as metroUnemploymentNormalize} from "./metro-unemployment-normalize.js";
 export {default as metroUnemploymentRidgeline} from "./metro-unemployment-ridgeline.js";
 export {default as metroUnemploymentStroke} from "./metro-unemployment-stroke.js";
+export {default as mobyDick} from "./moby-dick.js";
 export {default as mobyDickFaceted} from "./moby-dick-faceted.js";
 export {default as mobyDickLetterFrequency} from "./moby-dick-letter-frequency.js";
 export {default as mobyDickLetterPairs} from "./moby-dick-letter-pairs.js";

--- a/test/plots/moby-dick.js
+++ b/test/plots/moby-dick.js
@@ -1,0 +1,12 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export default async function() {
+  const mobydick = await d3.text("data/moby-dick-chapter-1.txt");
+  return Plot.plot({
+    height: 1200,
+    marks: [
+      Plot.text([mobydick], {fontSize: 14, lineWidth: 40, lineHeight: 1.2, frameAnchor: "top-left"})
+    ]
+  });
+}


### PR DESCRIPTION
Implements text wrapping using a *lineWidth* option on the text mark. Fixes #688. Tasks:

- [x] Don’t wrap by default (when *lineWidth* is Infinity).
- [x] Allow *lineWidth* to be specified in ems.
- [x] ~~Allow *lineWidth* to be specified in pixels? (But how?)~~ No.
- [x] Preserve newlines in input.
- [x] ~~Optionally ignore newlines in input?~~ No.
- [x] ~~Optionally coalesce multiple spaces in input?~~ No.
- [x] Support monospace text layout (a *monospace* option, say)?
- [x] ~~Support tabular numerals?~~ No.
- [x] ~~Measure text metrics dynamically with Canvas, if fast enough?~~ No.
- [x] ~~Allow custom implementations for text metrics?~~ No.
- [x] ~~Implement Unicode line breaking algorithm.~~ No, too hard.
- [x] ~~Implement Unicode grapheme cluster breaking algorithm.~~ No, too hard.
- [x] ~~Implement Knuth–Plass line breaking algorithm.~~ No, too hard.
- [x] Documentation
- [x] Tests

Even though this is very rudimentary, I think it will be super useful and can be improved in the future based on usage.

I think the biggest blocker is just whether it’s okay to have *lineWidth* in ems. That’s the easiest thing for us to implement based on the baked-in rudimentary text metrics, but I think people are likely to get confused because they are more likely to be thinking in pixels. The problem with pixels is that the *fontSize* isn’t necessarily in pixels, either #378 and so we’d almost certainly need to invoke the browser’s full text metrics in order to compute it. And that also means an element will need to be attached to the DOM, and it’s slow, etc. So, I think maybe *lineWidth* in ems is the best option under the “worse is better” philosophy. We could also expose a hook for computing text metrics yourself, but that feels super low-level, and also not necessary since you could just specify text with newlines if you want to do the wrapping yourself.