### PR TITLE
labelArrow

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -4,6 +4,12 @@ import {formatIsoDate} from "./format.js";
 import {radians} from "./math.js";
 import {impliedString} from "./style.js";
 
+function maybeLabelArrow(labelArrow = true) {
+  return labelArrow === true ? "auto"
+    : labelArrow === false || labelArrow == null ? "none"
+    : keyword(labelArrow, "labelArrow", ["auto", "none", "up", "down", "left", "right"]);
+}
+
 export class AxisX {
   constructor({
     name = "x",
@@ -16,6 +22,7 @@ export class AxisX {
     grid,
     label,
     labelAnchor,
+    labelArrow,
     labelOffset,
     line,
     tickRotate
@@ -30,6 +37,7 @@ export class AxisX {
     this.grid = boolean(grid);
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "left", "right"]);
+    this.labelArrow = maybeLabelArrow(labelArrow);
     this.labelOffset = number(labelOffset);
     this.line = boolean(line);
     this.tickRotate = number(tickRotate);
@@ -103,6 +111,7 @@ export class AxisY {
     grid,
     label,
     labelAnchor,
+    labelArrow,
     labelOffset,
     line,
     tickRotate
@@ -117,6 +126,7 @@ export class AxisY {
     this.grid = boolean(grid);
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "top", "bottom"]);
+    this.labelArrow = maybeLabelArrow(labelArrow);
     this.labelOffset = number(labelOffset);
     this.line = boolean(line);
     this.tickRotate = number(tickRotate);

--- a/test/plots/aapl-candlestick.js
+++ b/test/plots/aapl-candlestick.js
@@ -7,7 +7,8 @@ export default async function() {
     inset: 6,
     grid: true,
     y: {
-      label: "↑ Apple stock price ($)",
+      label: "Apple stock price ($)",
+      labelArrow: "up",
       fontVariant: null
     },
     color: {

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -44,7 +44,7 @@ it("plot(…).scale('x') returns the expected linear scale for penguins", async 
     range: [20, 620],
     interpolate: d3.interpolateNumber,
     clamp: false,
-    label: "body_mass_g →"
+    label: "body_mass_g"
   });
 });
 
@@ -307,7 +307,7 @@ it("plot(…).scale(name) promotes the given zero option to the domain", async (
     range: [20, 620],
     interpolate: d3.interpolateNumber,
     clamp: false,
-    label: "body_mass_g →"
+    label: "body_mass_g"
   });
 });
 
@@ -320,7 +320,7 @@ it("plot(…).scale(name) handles the zero option correctly for descending domai
     range: [20, 620],
     interpolate: d3.interpolateNumber,
     clamp: false,
-    label: "← body_mass_g"
+    label: "body_mass_g"
   });
 });
 
@@ -333,7 +333,7 @@ it("plot(…).scale(name) handles the zero option correctly for polylinear domai
     range: [20, 320, 620],
     interpolate: d3.interpolateNumber,
     clamp: false,
-    label: "body_mass_g →"
+    label: "body_mass_g"
   });
 });
 
@@ -346,7 +346,7 @@ it("plot(…).scale(name) handles the zero option correctly for descending polyl
     range: [20, 320, 620],
     interpolate: d3.interpolateNumber,
     clamp: false,
-    label: "← body_mass_g"
+    label: "body_mass_g"
   });
 });
 
@@ -1174,13 +1174,13 @@ it("plot({padding, …}).scale('x').padding reflects the given padding option fo
 });
 
 it("plot(…).scale('x').label reflects the default label for named fields, possibly reversed", () => {
-  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: "foo"}).plot().scale("x").label, "foo →");
-  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: "foo"}).plot({x: {reverse: true}}).scale("x").label, "← foo");
+  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: "foo"}).plot().scale("x").label, "foo");
+  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: "foo"}).plot({x: {reverse: true}}).scale("x").label, "foo");
 });
 
 it("plot(…).scale('y').label reflects the default label for named fields, possibly reversed", () => {
-  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {y: "foo"}).plot().scale("y").label, "↑ foo");
-  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {y: "foo"}).plot({y: {reverse: true}}).scale("y").label, "↓ foo");
+  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {y: "foo"}).plot().scale("y").label, "foo");
+  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {y: "foo"}).plot({y: {reverse: true}}).scale("y").label, "foo");
 });
 
 it("plot(…).scale('x').label reflects the explicit label", () => {
@@ -1190,13 +1190,13 @@ it("plot(…).scale('x').label reflects the explicit label", () => {
 
 it("plot(…).scale('x').label reflects a function label, if not overridden by an explicit label", () => {
   const foo = Object.assign(d => d.foo, {label: "Foo"});
-  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: foo}).plot().scale("x").label, "Foo →");
+  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: foo}).plot().scale("x").label, "Foo");
   assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: foo}).plot({x: {label: null}}).scale("x").label, null);
 });
 
 it("plot(…).scale('x').label reflects a channel transform label, if not overridden by an explicit label", () => {
   const foo = {transform: data => data.map(d => d.foo), label: "Foo"};
-  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: foo}).plot().scale("x").label, "Foo →");
+  assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: foo}).plot().scale("x").label, "Foo");
   assert.strictEqual(Plot.dot([{foo: 1}, {foo: 2}, {foo: 3}], {x: foo}).plot({x: {label: null}}).scale("x").label, null);
 });
 
@@ -1305,7 +1305,7 @@ it("plot(…).scale(name) reflects the given custom interpolator", async () => {
     range: [20, 620],
     interpolate,
     clamp: false,
-    label: "body_mass_g →"
+    label: "body_mass_g"
   });
 });
 
@@ -1362,7 +1362,7 @@ it("plot(…).scale(name) reflects the given transform", async () => {
     clamp: false,
     interpolate: d3.interpolateNumber,
     transform,
-    label: "body_mass_g →"
+    label: "body_mass_g"
   });
 });
 


### PR DESCRIPTION
Fixes #510. TODO:

- [ ] I’m getting a little confused as to whether *label* and *labelArrow* are options on scales or axes. For the most part, we only need labels (and arrows) on axes. But, labels are also used for legends. So, I probably shouldn’t only implement *labelArrow* on axes, as we will probably also want them on legends. But (color) legends are always oriented left-right, and we don’t support labels on all legends (related #621).

This isn’t a high priority so I’m just going to let this sit. I thought it would be easier. 🙁 