### PR TITLE
Update boolean scheme9 scales

### DIFF
--- a/src/scales/schemes.js
+++ b/src/scales/schemes.js
@@ -144,7 +144,7 @@ const ordinalSchemes = new Map([
 function scheme9(scheme, interpolate) {
   return ({length: n}) => {
     if (n === 1) return [scheme[3][1]]; // favor midpoint
-    if (n === 2) return [scheme[3][0], scheme[3][2]]; // favor extrema
+    if (n === 2) return [scheme[5][1], scheme[5][3]]; // favor extrema, avoid lightness
     n = Math.max(3, Math.floor(n));
     return n > 9 ? quantize(interpolate, n) : scheme[n];
   };

--- a/src/scales/schemes.js
+++ b/src/scales/schemes.js
@@ -144,7 +144,7 @@ const ordinalSchemes = new Map([
 function scheme9(scheme, interpolate) {
   return ({length: n}) => {
     if (n === 1) return [scheme[3][1]]; // favor midpoint
-    if (n === 2) return [scheme[5][1], scheme[5][3]]; // favor extrema, avoid lightness
+    if (n === 2) return [scheme[3][1], scheme[3][2]]; // favor darker
     n = Math.max(3, Math.floor(n));
     return n > 9 ? quantize(interpolate, n) : scheme[n];
   };

--- a/test/output/colorSchemesOrdinal.html
+++ b/test/output/colorSchemesOrdinal.html
@@ -3635,7 +3635,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-107-swatch" style="--color: #deebf7;">blues</span><span class="plot-107-swatch" style="--color: #3182bd;">1</span>
+    </style><span class="plot-107-swatch" style="--color: #9ecae1;">blues</span><span class="plot-107-swatch" style="--color: #3182bd;">1</span>
   </div>
   <div class="plot-108" style="
         --swatchWidth: 15px;
@@ -3805,7 +3805,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-112-swatch" style="--color: #e5f5e0;">greens</span><span class="plot-112-swatch" style="--color: #31a354;">1</span>
+    </style><span class="plot-112-swatch" style="--color: #a1d99b;">greens</span><span class="plot-112-swatch" style="--color: #31a354;">1</span>
   </div>
   <div class="plot-113" style="
         --swatchWidth: 15px;
@@ -3975,7 +3975,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-117-swatch" style="--color: #f0f0f0;">greys</span><span class="plot-117-swatch" style="--color: #636363;">1</span>
+    </style><span class="plot-117-swatch" style="--color: #bdbdbd;">greys</span><span class="plot-117-swatch" style="--color: #636363;">1</span>
   </div>
   <div class="plot-118" style="
         --swatchWidth: 15px;
@@ -4145,7 +4145,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-122-swatch" style="--color: #fee6ce;">oranges</span><span class="plot-122-swatch" style="--color: #e6550d;">1</span>
+    </style><span class="plot-122-swatch" style="--color: #fdae6b;">oranges</span><span class="plot-122-swatch" style="--color: #e6550d;">1</span>
   </div>
   <div class="plot-123" style="
         --swatchWidth: 15px;
@@ -4315,7 +4315,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-127-swatch" style="--color: #efedf5;">purples</span><span class="plot-127-swatch" style="--color: #756bb1;">1</span>
+    </style><span class="plot-127-swatch" style="--color: #bcbddc;">purples</span><span class="plot-127-swatch" style="--color: #756bb1;">1</span>
   </div>
   <div class="plot-128" style="
         --swatchWidth: 15px;
@@ -4485,7 +4485,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-132-swatch" style="--color: #fee0d2;">reds</span><span class="plot-132-swatch" style="--color: #de2d26;">1</span>
+    </style><span class="plot-132-swatch" style="--color: #fc9272;">reds</span><span class="plot-132-swatch" style="--color: #de2d26;">1</span>
   </div>
   <div class="plot-133" style="
         --swatchWidth: 15px;
@@ -6185,7 +6185,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-182-swatch" style="--color: #e5f5f9;">bugn</span><span class="plot-182-swatch" style="--color: #2ca25f;">1</span>
+    </style><span class="plot-182-swatch" style="--color: #99d8c9;">bugn</span><span class="plot-182-swatch" style="--color: #2ca25f;">1</span>
   </div>
   <div class="plot-183" style="
         --swatchWidth: 15px;
@@ -6355,7 +6355,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-187-swatch" style="--color: #e0ecf4;">bupu</span><span class="plot-187-swatch" style="--color: #8856a7;">1</span>
+    </style><span class="plot-187-swatch" style="--color: #9ebcda;">bupu</span><span class="plot-187-swatch" style="--color: #8856a7;">1</span>
   </div>
   <div class="plot-188" style="
         --swatchWidth: 15px;
@@ -6525,7 +6525,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-192-swatch" style="--color: #e0f3db;">gnbu</span><span class="plot-192-swatch" style="--color: #43a2ca;">1</span>
+    </style><span class="plot-192-swatch" style="--color: #a8ddb5;">gnbu</span><span class="plot-192-swatch" style="--color: #43a2ca;">1</span>
   </div>
   <div class="plot-193" style="
         --swatchWidth: 15px;
@@ -6695,7 +6695,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-197-swatch" style="--color: #fee8c8;">orrd</span><span class="plot-197-swatch" style="--color: #e34a33;">1</span>
+    </style><span class="plot-197-swatch" style="--color: #fdbb84;">orrd</span><span class="plot-197-swatch" style="--color: #e34a33;">1</span>
   </div>
   <div class="plot-198" style="
         --swatchWidth: 15px;
@@ -6865,7 +6865,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-202-swatch" style="--color: #ece7f2;">pubu</span><span class="plot-202-swatch" style="--color: #2b8cbe;">1</span>
+    </style><span class="plot-202-swatch" style="--color: #a6bddb;">pubu</span><span class="plot-202-swatch" style="--color: #2b8cbe;">1</span>
   </div>
   <div class="plot-203" style="
         --swatchWidth: 15px;
@@ -7035,7 +7035,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-207-swatch" style="--color: #ece2f0;">pubugn</span><span class="plot-207-swatch" style="--color: #1c9099;">1</span>
+    </style><span class="plot-207-swatch" style="--color: #a6bddb;">pubugn</span><span class="plot-207-swatch" style="--color: #1c9099;">1</span>
   </div>
   <div class="plot-208" style="
         --swatchWidth: 15px;
@@ -7205,7 +7205,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-212-swatch" style="--color: #e7e1ef;">purd</span><span class="plot-212-swatch" style="--color: #dd1c77;">1</span>
+    </style><span class="plot-212-swatch" style="--color: #c994c7;">purd</span><span class="plot-212-swatch" style="--color: #dd1c77;">1</span>
   </div>
   <div class="plot-213" style="
         --swatchWidth: 15px;
@@ -7375,7 +7375,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-217-swatch" style="--color: #fde0dd;">rdpu</span><span class="plot-217-swatch" style="--color: #c51b8a;">1</span>
+    </style><span class="plot-217-swatch" style="--color: #fa9fb5;">rdpu</span><span class="plot-217-swatch" style="--color: #c51b8a;">1</span>
   </div>
   <div class="plot-218" style="
         --swatchWidth: 15px;
@@ -7545,7 +7545,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-222-swatch" style="--color: #f7fcb9;">ylgn</span><span class="plot-222-swatch" style="--color: #31a354;">1</span>
+    </style><span class="plot-222-swatch" style="--color: #addd8e;">ylgn</span><span class="plot-222-swatch" style="--color: #31a354;">1</span>
   </div>
   <div class="plot-223" style="
         --swatchWidth: 15px;
@@ -7715,7 +7715,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-227-swatch" style="--color: #edf8b1;">ylgnbu</span><span class="plot-227-swatch" style="--color: #2c7fb8;">1</span>
+    </style><span class="plot-227-swatch" style="--color: #7fcdbb;">ylgnbu</span><span class="plot-227-swatch" style="--color: #2c7fb8;">1</span>
   </div>
   <div class="plot-228" style="
         --swatchWidth: 15px;
@@ -7885,7 +7885,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-232-swatch" style="--color: #fff7bc;">ylorbr</span><span class="plot-232-swatch" style="--color: #d95f0e;">1</span>
+    </style><span class="plot-232-swatch" style="--color: #fec44f;">ylorbr</span><span class="plot-232-swatch" style="--color: #d95f0e;">1</span>
   </div>
   <div class="plot-233" style="
         --swatchWidth: 15px;
@@ -8055,7 +8055,7 @@
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-237-swatch" style="--color: #ffeda0;">ylorrd</span><span class="plot-237-swatch" style="--color: #f03b20;">1</span>
+    </style><span class="plot-237-swatch" style="--color: #feb24c;">ylorrd</span><span class="plot-237-swatch" style="--color: #f03b20;">1</span>
   </div>
   <div class="plot-238" style="
         --swatchWidth: 15px;

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -718,7 +718,7 @@ it("plot(…).scale('color') can return a threshold scale with an explicit schem
   scaleEqual(plot.scale("color"), {
     type: "threshold",
     domain: [0],
-    range: [d3.schemeBlues[3][0], d3.schemeBlues[3][2]],
+    range: [d3.schemeBlues[3][1], d3.schemeBlues[3][2]],
     label: "body_mass_g"
   });
 });


### PR DESCRIPTION
The lighter color of the boolean color scales is difficult to see against a white background. This branch updates the default scale. See [this notebook](https://observablehq.com/@observablehq/boolean-colors-pr) to compare results.

<img width="1088" alt="Screen Shot 2022-01-25 at 5 29 37 PM" src="https://user-images.githubusercontent.com/1373882/151070449-150640e0-a6a4-4af6-acaa-e09af0696f67.png">
 