### PR TITLE
don't crash on Plot.dot({ length: 1 }).plot()

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -24,8 +24,8 @@ export const zero = () => 0;
 export const string = x => x == null ? x : `${x}`;
 export const number = x => x == null ? x : +x;
 export const boolean = x => x == null ? x : !!x;
-export const first = d => d == null ? null : d[0];
-export const second = d => d == null ? null : d[1];
+export const first = x => x ? x[0] : undefined;
+export const second = x => x ? x[1] : undefined;
 export const constant = x => () => x;
 
 // Some channels may allow a string constant to be specified; to differentiate

--- a/src/options.js
+++ b/src/options.js
@@ -24,8 +24,8 @@ export const zero = () => 0;
 export const string = x => x == null ? x : `${x}`;
 export const number = x => x == null ? x : +x;
 export const boolean = x => x == null ? x : !!x;
-export const first = d => d[0];
-export const second = d => d[1];
+export const first = d => d == null ? null : d[0];
+export const second = d => d == null ? null : d[1];
 export const constant = x => () => x;
 
 // Some channels may allow a string constant to be specified; to differentiate

--- a/test/marks/dot-test.js
+++ b/test/marks/dot-test.js
@@ -22,6 +22,10 @@ it("dot() has the expected defaults", () => {
   assert.strictEqual(dot.shapeRendering, undefined);
 });
 
+it("dot accepts undefined data", () => {
+  Plot.dot({ length: 1 }).initialize();
+});
+
 it("dot(data, {r}) allows r to be a constant radius", () => {
   const dot = Plot.dot(undefined, {r: 42});
   assert.strictEqual(dot.r, 42);

--- a/test/marks/dot-test.js
+++ b/test/marks/dot-test.js
@@ -23,7 +23,7 @@ it("dot() has the expected defaults", () => {
 });
 
 it("dot accepts undefined data", () => {
-  Plot.dot({ length: 1 }).initialize();
+  Plot.dot({length: 1}).initialize();
 });
 
 it("dot(data, {r}) allows r to be a constant radius", () => {


### PR DESCRIPTION
> TypeError: Cannot read properties of undefined (reading '0')
 
Plot.dot({ length: 1 }).plot()

The original use case was in a circlePacking layout where we would have Plot.dot({length:10}, circlePack({r: Math.random})).

However that use case is now solved by having the circlePack layout explicitly pass x: null, y: null. So maybe not worth the potential performance hit of checking each datum against null?