### PR TITLE
call the layout once with all the frame indices

### DIFF
--- a/src/layouts/dodge.js
+++ b/src/layouts/dodge.js
@@ -40,40 +40,43 @@ export function dodgeY(dodgeOptions = {}, options = {}) {
 
 function dodge(y, x, anchor, padding, options) {
   const [, r] = maybeNumberChannel(options.r, 3);
-  return layout(options, (I, scales, {[x]: X, r: R}, dimensions) => {
+  return layout(options, (index, scales, {[x]: X, r: R}, dimensions) => {
     if (X == null) throw new Error(`missing channel: ${x}`);
     let [ky, ty] = anchor(dimensions);
     const compare = ky ? compareAscending : compareSymmetric;
-    if (ky) ty += ky * ((R ? max(I, i => R[i]) : r) + padding); else ky = 1;
+    if (ky) ty += ky * ((R ? max(index, I => max(I, i => R[i])) : r) + padding); else ky = 1;
     if (!R) R = new Float64Array(X.length).fill(r);
     const Y = new Float64Array(X.length);
-    const tree = IntervalTree();
-    for (const i of I) {
-      const intervals = [];
-      const l = X[i] - R[i];
-      const r = X[i] + R[i];
 
-      // For any previously placed circles that may overlap this circle, compute
-      // the y-positions that place this circle tangent to these other circles.
-      // https://observablehq.com/@mbostock/circle-offset-along-line
-      tree.queryInterval(l - padding, r + padding, ([,, j]) => {
-        const yj = Y[j];
-        const dx = X[i] - X[j];
-        const dr = R[i] + padding + R[j];
-        const dy = Math.sqrt(dr * dr - dx * dx);
-        intervals.push([yj - dy, yj + dy]);
-      });
-
-      // Find the best y-value where this circle can fit.
-      for (let y of intervals.flat().sort(compare)) {
-        if (intervals.every(([lo, hi]) => y <= lo || y >= hi)) {
-          Y[i] = y;
-          break;
+    for (const I of index) {
+      const tree = IntervalTree();
+      for (const i of I) {
+        const intervals = [];
+        const l = X[i] - R[i];
+        const r = X[i] + R[i];
+  
+        // For any previously placed circles that may overlap this circle, compute
+        // the y-positions that place this circle tangent to these other circles.
+        // https://observablehq.com/@mbostock/circle-offset-along-line
+        tree.queryInterval(l - padding, r + padding, ([,, j]) => {
+          const yj = Y[j];
+          const dx = X[i] - X[j];
+          const dr = R[i] + padding + R[j];
+          const dy = Math.sqrt(dr * dr - dx * dx);
+          intervals.push([yj - dy, yj + dy]);
+        });
+  
+        // Find the best y-value where this circle can fit.
+        for (let y of intervals.flat().sort(compare)) {
+          if (intervals.every(([lo, hi]) => y <= lo || y >= hi)) {
+            Y[i] = y;
+            break;
+          }
         }
+  
+        // Insert the placed circle into the interval tree.
+        tree.insert([l, r, i]);
       }
-
-      // Insert the placed circle into the interval tree.
-      tree.insert([l, r, i]);
     }
     return {[y]: Y.map(y => y * ky + ty)};
   });

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -88,6 +88,7 @@ export {default as ordinalBar} from "./ordinal-bar.js";
 export {default as penguinCulmen} from "./penguin-culmen.js";
 export {default as penguinCulmenArray} from "./penguin-culmen-array.js";
 export {default as penguinDodge} from "./penguin-dodge.js";
+export {default as penguinDodgeChannel} from "./penguin-dodge-channel.js";
 export {default as penguinFacetDodge} from "./penguin-facet-dodge.js";
 export {default as penguinIslandUnknown} from "./penguin-island-unknown.js";
 export {default as penguinMass} from "./penguin-mass.js";

--- a/test/plots/penguin-dodge-channel.js
+++ b/test/plots/penguin-dodge-channel.js
@@ -1,0 +1,12 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export default async function() {
+  const penguins = await d3.csv("data/penguins.csv", d3.autoType);
+  return Plot.plot({
+    height: 200,
+    marks: [
+      Plot.dot(penguins, Plot.dodgeY({x: "body_mass_g", r: d3.randomLcg(42)}))
+    ]
+  });
+}


### PR DESCRIPTION
implements my comment https://github.com/observablehq/plot/pull/648#issuecomment-1022492736

The layout is called once, with an index that is an array of arrays, one for each facet.

this addresses two concerns:
1. makes it possible to create "smarter" layouts that can work on either the elements of each facet or the whole set of elements
2. performance (memory allocation is done once for all the facets)

the cost is a slightly more complex function to write, because it needs to iterate on the arrays in index; but this is consistent with what we do in transforms.