### PR TITLE
a chart with no colors defaults to the identity color scale

### DIFF
--- a/src/scales.js
+++ b/src/scales.js
@@ -216,12 +216,12 @@ function inferScaleType(key, channels, {type, domain, range, scheme}) {
   if (kind === color
     && range === undefined
     && scheme === undefined
-    && isAll(domain, channels, isColor)) return "identity";
+    && (isAll(domain, channels, isColor) || (domain === undefined && channels.length === 0))) return "identity";
 
   // Similarly for symbols…
   if (kind === symbol
     && range === undefined
-    && isAll(domain, channels, isSymbol)) return "identity";
+    && (isAll(domain, channels, isSymbol) || (domain === undefined && channels.length === 0))) return "identity";
 
   // Some scales have default types.
   if (kind === radius) return "sqrt";

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -3,6 +3,11 @@ import * as d3 from "d3";
 import assert from "assert";
 import it from "../jsdom.js";
 
+it("The default color scale is identity", () => {
+  const color = Plot.scale({color: {}});
+  scaleEqual(color, {type: "identity"});
+});
+
 it("Plot.scale(description) returns a standalone scale", () => {
   const color = Plot.scale({color: {type: "linear"}});
   scaleEqual(color, {


### PR DESCRIPTION
- [ ] Should this be undefined instead? See discussion in #744.

fixes #744


cc: @yurivish 