### PR TITLE
warnings!

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -222,6 +222,15 @@ export function isTemporalString(values) {
   }
 }
 
+// Are these strings that might represent numbers? This is stricter than
+// coercion because we want to ignore false positives on e.g. empty strings.
+export function isNumericString(values) {
+  for (const value of values) {
+    if (value == null || value === "") continue;
+    return typeof value === "string" && !isNaN(value);
+  }
+}
+
 export function isNumeric(values) {
   for (const value of values) {
     if (value == null) continue;

--- a/src/options.js
+++ b/src/options.js
@@ -1,3 +1,4 @@
+import {parse as isoParse} from "isoformat";
 import {color, descending} from "d3";
 import {symbolAsterisk, symbolDiamond2, symbolPlus, symbolSquare2, symbolTriangle2, symbolX as symbolTimes} from "d3";
 import {symbolCircle, symbolCross, symbolDiamond, symbolSquare, symbolStar, symbolTriangle, symbolWye} from "d3";
@@ -207,6 +208,17 @@ export function isTemporal(values) {
   for (const value of values) {
     if (value == null) continue;
     return value instanceof Date;
+  }
+}
+
+// Are these strings that might represent dates? This is stricter than ISO 8601
+// because we want to ignore false positives on numbers; for example, the string
+// "1192" is more likely to represent a number than a date even though it is
+// valid ISO 8601 representing 1192-01-01.
+export function isTemporalString(values) {
+  for (const value of values) {
+    if (value == null) continue;
+    return typeof value === "string" && isNaN(value) && isoParse(value);
   }
 }
 

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,4 +1,4 @@
-import {create, cross, difference, groups, InternMap} from "d3";
+import {create, cross, difference, groups, InternMap, select} from "d3";
 import {Axes, autoAxisTicks, autoScaleLabels} from "./axes.js";
 import {Channel, channelSort} from "./channel.js";
 import {defined} from "./defined.js";
@@ -8,6 +8,7 @@ import {arrayify, isOptions, keyword, range, first, second, where} from "./optio
 import {Scales, ScaleFunctions, autoScaleRange, applyScales, exposeScales} from "./scales.js";
 import {applyInlineStyles, maybeClassName, maybeClip, styles} from "./style.js";
 import {basic} from "./transforms/basic.js";
+import {consumeWarnings} from "./warnings.js";
 
 export function plot(options = {}) {
   const {facet, style, caption, ariaLabel, ariaDescription} = options;
@@ -119,6 +120,19 @@ export function plot(options = {}) {
 
   figure.scale = exposeScales(scaleDescriptors);
   figure.legend = exposeLegends(scaleDescriptors, options);
+
+  const w = consumeWarnings();
+  if (w > 0) {
+    select(svg).append("text")
+        .attr("x", width)
+        .attr("y", 20)
+        .attr("dy", "-1em")
+        .attr("text-anchor", "end")
+        .text("⚠️")
+      .append("title")
+        .text(`${w.toLocaleString("en-US")} warning${w === 1 ? "" : "s"}. Please check the console.`);
+  }
+
   return figure;
 }
 

--- a/src/scales.js
+++ b/src/scales.js
@@ -1,5 +1,5 @@
 import {parse as isoParse} from "isoformat";
-import {isColor, isEvery, isOrdinal, isFirst, isSymbol, isTemporal, maybeSymbol, order, isTemporalString} from "./options.js";
+import {isColor, isEvery, isOrdinal, isFirst, isSymbol, isTemporal, maybeSymbol, order, isTemporalString, isNumericString} from "./options.js";
 import {registry, color, position, radius, opacity, symbol, length} from "./scales/index.js";
 import {ScaleLinear, ScaleSqrt, ScalePow, ScaleLog, ScaleSymlog, ScaleQuantile, ScaleThreshold, ScaleIdentity} from "./scales/quantitative.js";
 import {ScaleDiverging, ScaleDivergingSqrt, ScaleDivergingPow, ScaleDivergingLog, ScaleDivergingSymlog} from "./scales/diverging.js";
@@ -135,11 +135,21 @@ export function normalizeScale(key, scale, hint) {
 function Scale(key, channels = [], options = {}) {
   const type = inferScaleType(key, channels, options);
 
-  // Warn for common misuse of implicit band scales.
-  if (options.type === undefined && type === "band") {
+  // Warn for common misuses of implicit ordinal scales. We disable this test if
+  // you set the domain or range explicitly, since setting the domain or range
+  // (typically with a cardinality of more than two) is another indication that
+  // you intended for the scale to be ordinal; we also disable it for facet
+  // scales since these are always band scales.
+  if (options.type === undefined
+      && options.domain === undefined
+      && options.range === undefined
+      && key !== "fx"
+      && key !== "fy"
+      && isOrdinalScale({type})) {
     const values = channels.map(({value}) => value).filter(value => value !== undefined);
-    if (values.some(isTemporal)) warn(`Warning: some data associated with the ${key} scale are dates. Dates are typically associated with a "utc" or "time" scale rather than a "band" scale. If you are using a bar mark, you probably want to switch to a rect mark with the interval option; if you are using a group transform, you probably want to switch to a bin transform. If you intend to treat this data as ordinal, you can suppress this warning by setting the type of the ${key} scale to "band".`);
-    else if (values.some(isTemporalString)) warn(`Warning: some data associated with the ${key} scale are strings that appear to be dates (e.g., YYYY-MM-DD). If these strings represent dates, you should parse and convert them to Date objects. Dates are typically associated with a "utc" or "time" scale rather than a "band" scale. If you are using a bar mark, you probably want to switch to a rect mark with the interval option; if you are using a group transform, you probably want to switch to a bin transform. If you intend to treat this data as ordinal, you can suppress this warning by setting the type of the ${key} scale to "${typeof type === "symbol" ? type.description : type}".`);
+    if (values.some(isTemporal)) warn(`Warning: some data associated with the ${key} scale are dates. Dates are typically associated with a "utc" or "time" scale rather than a "${formatScaleType(type)}" scale. If you are using a bar mark, you probably want a rect mark with the interval option instead; if you are using a group transform, you probably want a bin transform instead. If you want to treat this data as ordinal, you can suppress this warning by setting the type of the ${key} scale to "${formatScaleType(type)}".`);
+    else if (values.some(isTemporalString)) warn(`Warning: some data associated with the ${key} scale are strings that appear to be dates (e.g., YYYY-MM-DD). If these strings represent dates, you should parse them to Date objects. Dates are typically associated with a "utc" or "time" scale rather than a "${formatScaleType(type)}" scale. If you are using a bar mark, you probably want a rect mark with the interval option instead; if you are using a group transform, you probably want a bin transform instead. If you want to treat this data as ordinal, you can suppress this warning by setting the type of the ${key} scale to "${formatScaleType(type)}".`);
+    else if (values.some(isNumericString)) warn(`Warning: some data associated with the ${key} scale are strings that appear to be numbers. If these strings represent numbers, you should parse or coerce them to numbers. Numbers are typically associated with a "linear" scale rather than a "${formatScaleType(type)}" scale. If you want to treat this data as ordinal, you can suppress this warning by setting the type of the ${key} scale to "${formatScaleType(type)}".`);
   }
 
   options.type = type; // Mutates input!
@@ -199,6 +209,10 @@ function Scale(key, channels = [], options = {}) {
   }
 }
 
+function formatScaleType(type) {
+  return typeof type === "symbol" ? type.description : type;
+}
+
 function inferScaleType(key, channels, {type, domain, range, scheme}) {
   // The facet scales are always band scales; this cannot be changed.
   if (key === "fx" || key === "fy") return "band";
@@ -255,11 +269,7 @@ function inferScaleType(key, channels, {type, domain, range, scheme}) {
 
   // If any channel is ordinal or temporal, it takes priority.
   const values = channels.map(({value}) => value).filter(value => value !== undefined);
-  if (values.some(isOrdinal)) {
-    const type = asOrdinalType(kind);
-    if (values.some(isTemporalString)) warn(`Warning: some data associated with the ${key} scale are strings that appear to be dates (e.g., YYYY-MM-DD). If these strings represent dates, you should parse and convert them to Date objects. If you intend to treat this data as ordinal, you can suppress this warning by setting the type of the ${key} scale to "${typeof type === "symbol" ? type.description : type}".`);
-    return type;
-  }
+  if (values.some(isOrdinal)) return asOrdinalType(kind);
   if (values.some(isTemporal)) return "utc";
   return "linear";
 }
@@ -285,7 +295,7 @@ export function isTemporalScale({type}) {
 }
 
 export function isOrdinalScale({type}) {
-  return type === "ordinal" || type === "point" || type === "band";
+  return type === "ordinal" || type === "point" || type === "band" || type === ordinalImplicit;
 }
 
 function isThresholdScale({type}) {

--- a/src/transforms/window.js
+++ b/src/transforms/window.js
@@ -1,5 +1,6 @@
 import {mapX, mapY} from "./map.js";
 import {deviation, max, min, median, mode, variance} from "d3";
+import {warn} from "../warnings.js";
 
 export function windowX(windowOptions = {}, options) {
   if (arguments.length === 1) options = windowOptions;
@@ -29,7 +30,7 @@ function maybeAnchor(anchor = "middle", k) {
 
 function maybeShift(shift) {
   if (shift === undefined) return;
-  console.warn("shift is deprecated; please use anchor instead");
+  warn("Warning: shift is deprecated; please use anchor instead");
   switch (`${shift}`.toLowerCase()) {
     case "centered": return "middle";
     case "leading": return "start";

--- a/src/transforms/window.js
+++ b/src/transforms/window.js
@@ -14,7 +14,11 @@ export function windowY(windowOptions = {}, options) {
 
 export function window(options = {}) {
   if (typeof options === "number") options = {k: options};
-  let {k, reduce, shift, anchor = maybeShift(shift)} = options;
+  let {k, reduce, shift, anchor} = options;
+  if (anchor === undefined && shift !== undefined) {
+    anchor = maybeShift(shift);
+    warn(`Warning: the shift option is deprecated; please use anchor "${anchor}" instead.`);
+  }
   if (!((k = Math.floor(k)) > 0)) throw new Error("invalid k");
   return maybeReduce(reduce)(k, maybeAnchor(anchor, k));
 }
@@ -29,8 +33,6 @@ function maybeAnchor(anchor = "middle", k) {
 }
 
 function maybeShift(shift) {
-  if (shift === undefined) return;
-  warn("Warning: shift is deprecated; please use anchor instead");
   switch (`${shift}`.toLowerCase()) {
     case "centered": return "middle";
     case "leading": return "start";

--- a/src/warnings.js
+++ b/src/warnings.js
@@ -1,0 +1,12 @@
+let warnings = 0;
+
+export function consumeWarnings() {
+  const w = warnings;
+  warnings = 0;
+  return w;
+}
+
+export function warn(message) {
+  console.warn(message);
+  ++warnings;
+}

--- a/test/output/crimeanWarOverlapped.svg
+++ b/test/output/crimeanWarOverlapped.svg
@@ -57,153 +57,108 @@
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">2,600</text>
     </g><text fill="currentColor" transform="translate(-40,20)" dy="-1em" text-anchor="start">↑ deaths</text>
   </g>
-  <g aria-label="x-axis" transform="translate(0,370)" fill="none" text-anchor="middle">
-    <g class="tick" opacity="1" transform="translate(54.5,0)">
+  <g aria-label="x-axis" transform="translate(0,370)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(40.5,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Apr</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(78.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">May</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(102.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jun</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(126.5,0)">
+    <g class="tick" opacity="1" transform="translate(112.70246238030096,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jul</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(150.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Aug</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(174.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Sep</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(198.5,0)">
+    <g class="tick" opacity="1" transform="translate(185.69835841313272,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Oct</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(222.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Nov</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(246.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Dec</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(270.5,0)">
+    <g class="tick" opacity="1" transform="translate(258.6942544459644,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jan</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(294.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Feb</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(318.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Mar</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(342.5,0)">
+    <g class="tick" opacity="1" transform="translate(330.10328317373455,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Apr</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(366.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">May</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(390.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jun</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(414.5,0)">
+    <g class="tick" opacity="1" transform="translate(402.3057455540356,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jul</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(438.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Aug</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(462.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Sep</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(486.5,0)">
+    <g class="tick" opacity="1" transform="translate(475.30164158686733,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Oct</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(510.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Nov</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(534.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Dec</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(558.5,0)">
+    <g class="tick" opacity="1" transform="translate(548.297537619699,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jan</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(582.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Feb</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(606.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Mar</text>
+    <g class="tick" opacity="1" transform="translate(620.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Apr</text>
     </g>
   </g>
-  <g aria-label="bar">
-    <rect x="259" width="22" y="20" height="350" fill="#4e79a7"></rect>
-    <rect x="283" width="22" y="101.2567910177472" height="268.7432089822528" fill="#4e79a7"></rect>
-    <rect x="235" width="22" y="151.32922854038392" height="218.67077145961608" fill="#4e79a7"></rect>
-    <rect x="307" width="22" y="217.2473741398044" height="152.7526258601956" fill="#4e79a7"></rect>
-    <rect x="211" width="22" y="263.00977906555596" height="106.99022093444404" fill="#4e79a7"></rect>
-    <rect x="139" width="22" y="265.03802969938425" height="104.96197030061575" fill="#4e79a7"></rect>
-    <rect x="379" width="22" y="268.3339369793553" height="101.66606302064469" fill="#4e79a7"></rect>
-    <rect x="163" width="22" y="270.1086562839551" height="99.8913437160449" fill="#4e79a7"></rect>
-    <rect x="355" width="22" y="305.6030423759507" height="64.39695762404932" fill="#4e79a7"></rect>
-    <rect x="187" width="22" y="306.23687069902206" height="63.76312930097794" fill="#4e79a7"></rect>
-    <rect x="427" width="22" y="308.7721839913075" height="61.227816008692514" fill="#4e79a7"></rect>
-    <rect x="331" width="22" y="309.53277797899307" height="60.46722202100693" fill="#4e79a7"></rect>
-    <rect x="403" width="22" y="321.5755161173488" height="48.4244838826512" fill="#4e79a7"></rect>
-    <rect x="283" width="22" y="324.2375950742485" height="45.762404925751525" fill="#f28e2c"></rect>
-    <rect x="115" width="22" y="324.491126403477" height="45.50887359652302" fill="#4e79a7"></rect>
-    <rect x="259" width="22" y="328.92792466497644" height="41.072075335023555" fill="#f28e2c"></rect>
-    <rect x="211" width="22" y="333.61825425570447" height="36.38174574429553" fill="#e15759"></rect>
-    <rect x="451" width="22" y="335.01267656646144" height="34.98732343353856" fill="#e15759"></rect>
-    <rect x="379" width="22" y="343.5059760956175" height="26.494023904382516" fill="#e15759"></rect>
-    <rect x="451" width="22" y="346.0412893879029" height="23.958710612097093" fill="#4e79a7"></rect>
-    <rect x="499" width="22" y="347.43571169865993" height="22.56428830134007" fill="#4e79a7"></rect>
-    <rect x="307" width="22" y="348.1963056863455" height="21.80369431365449" fill="#f28e2c"></rect>
-    <rect x="427" width="22" y="349.2104310032597" height="20.789568996740286" fill="#e15759"></rect>
-    <rect x="403" width="22" y="353.0134009416878" height="16.98659905831221" fill="#e15759"></rect>
-    <rect x="187" width="22" y="353.26693227091636" height="16.733067729083643" fill="#e15759"></rect>
-    <rect x="235" width="22" y="353.39369793553067" height="16.606302064469332" fill="#f28e2c"></rect>
-    <rect x="475" width="22" y="353.77399492937343" height="16.22600507062657" fill="#4e79a7"></rect>
-    <rect x="187" width="22" y="353.77399492937343" height="16.22600507062657" fill="#f28e2c"></rect>
-    <rect x="235" width="22" y="355.5487142339732" height="14.451285766026785" fill="#e15759"></rect>
-    <rect x="211" width="22" y="356.56283955088736" height="13.437160449112639" fill="#f28e2c"></rect>
-    <rect x="523" width="22" y="358.4643245201014" height="11.5356754798986" fill="#4e79a7"></rect>
-    <rect x="259" width="22" y="359.4784498370156" height="10.521550162984397" fill="#e15759"></rect>
-    <rect x="163" width="22" y="359.7319811662441" height="10.268018833755889" fill="#e15759"></rect>
-    <rect x="163" width="22" y="361.1264034770011" height="8.873596522998923" fill="#f28e2c"></rect>
-    <rect x="331" width="22" y="362.7743571169866" height="7.225642883013393" fill="#f28e2c"></rect>
-    <rect x="475" width="22" y="363.2814197754437" height="6.7185802245563195" fill="#e15759"></rect>
-    <rect x="355" width="22" y="363.78848243390075" height="6.211517566099246" fill="#e15759"></rect>
-    <rect x="331" width="22" y="363.91524809851506" height="6.084751901484935" fill="#e15759"></rect>
-    <rect x="547" width="22" y="363.91524809851506" height="6.084751901484935" fill="#f28e2c"></rect>
-    <rect x="547" width="22" y="364.67584208620065" height="5.324157913799354" fill="#4e79a7"></rect>
-    <rect x="283" width="22" y="364.67584208620065" height="5.324157913799354" fill="#e15759"></rect>
-    <rect x="355" width="22" y="365.30967040927203" height="4.69032959072797" fill="#f28e2c"></rect>
-    <rect x="595" width="22" y="365.5632017385006" height="4.436798261499405" fill="#f28e2c"></rect>
-    <rect x="499" width="22" y="365.8167330677291" height="4.183266932270897" fill="#e15759"></rect>
-    <rect x="403" width="22" y="365.8167330677291" height="4.183266932270897" fill="#f28e2c"></rect>
-    <rect x="307" width="22" y="365.94349873234336" height="4.0565012676566425" fill="#e15759"></rect>
-    <rect x="499" width="22" y="365.94349873234336" height="4.0565012676566425" fill="#f28e2c"></rect>
-    <rect x="379" width="22" y="366.0702643969576" height="3.9297356030423884" fill="#f28e2c"></rect>
-    <rect x="139" width="22" y="366.1970300615719" height="3.8029699384280775" fill="#f28e2c"></rect>
-    <rect x="523" width="22" y="366.45056139080043" height="3.5494386091995693" fill="#f28e2c"></rect>
-    <rect x="427" width="22" y="366.83085838464325" height="3.16914161535675" fill="#f28e2c"></rect>
-    <rect x="571" width="22" y="366.95762404925756" height="3.0423759507424393" fill="#4e79a7"></rect>
-    <rect x="115" width="22" y="367.08438971387176" height="2.915610286128242" fill="#f28e2c"></rect>
-    <rect x="451" width="22" y="367.46468670771463" height="2.535313292285366" fill="#f28e2c"></rect>
-    <rect x="571" width="22" y="367.5914523723289" height="2.408547627671112" fill="#f28e2c"></rect>
-    <rect x="523" width="22" y="367.71821803694314" height="2.281781963056858" fill="#e15759"></rect>
-    <rect x="475" width="22" y="367.71821803694314" height="2.281781963056858" fill="#f28e2c"></rect>
-    <rect x="595" width="22" y="368.09851503078596" height="1.9014849692140388" fill="#4e79a7"></rect>
-    <rect x="67" width="22" y="368.4788120246287" height="1.5211879753712765" fill="#4e79a7"></rect>
-    <rect x="91" width="22" y="368.60557768924303" height="1.3944223107569655" fill="#4e79a7"></rect>
-    <rect x="67" width="22" y="368.8591090184716" height="1.1408909815284005" fill="#f28e2c"></rect>
-    <rect x="91" width="22" y="369.23940601231436" height="0.7605939876856382" fill="#f28e2c"></rect>
-    <rect x="43" width="22" y="369.3661716769287" height="0.6338283230713273" fill="#f28e2c"></rect>
-    <rect x="547" width="22" y="369.74646867077143" height="0.253531329228565" fill="#e15759"></rect>
-    <rect x="43" width="22" y="369.87323433538575" height="0.1267656646142541" fill="#4e79a7"></rect>
-    <rect x="139" width="22" y="369.87323433538575" height="0.1267656646142541" fill="#e15759"></rect>
-    <rect x="43" width="22" y="370" height="0" fill="#e15759"></rect>
-    <rect x="67" width="22" y="370" height="0" fill="#e15759"></rect>
-    <rect x="91" width="22" y="370" height="0" fill="#e15759"></rect>
-    <rect x="115" width="22" y="370" height="0" fill="#e15759"></rect>
-    <rect x="571" width="22" y="370" height="0" fill="#e15759"></rect>
-    <rect x="595" width="22" y="370" height="0" fill="#e15759"></rect>
+  <g aria-label="rect">
+    <rect style="mix-blend-mode: multiply;" x="41" y="369.87323433538575" width="22.80300957592339" height="0.1267656646142541" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="64.8030095759234" y="368.4788120246287" width="23.596443228454184" height="1.5211879753712765" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="89.39945280437757" y="368.60557768924303" width="22.803009575923383" height="1.3944223107569655" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="113.20246238030096" y="324.491126403477" width="23.596443228454163" height="45.50887359652302" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="137.79890560875512" y="265.03802969938425" width="23.596443228454177" height="104.96197030061575" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="162.3953488372093" y="270.1086562839551" width="22.803009575923426" height="99.8913437160449" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="186.19835841313272" y="306.23687069902206" width="23.59644322845415" height="63.76312930097794" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="210.79480164158687" y="263.00977906555596" width="22.803009575923397" height="106.99022093444404" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="234.59781121751027" y="151.32922854038392" width="23.59644322845415" height="218.67077145961608" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="259.1942544459644" y="20" width="23.596443228454177" height="350" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="283.7906976744186" y="101.2567910177472" width="21.216142270861894" height="268.7432089822528" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="306.0068399452805" y="217.2473741398044" width="23.596443228454064" height="152.7526258601956" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="330.60328317373455" y="309.53277797899307" width="22.803009575923454" height="60.46722202100693" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="354.406292749658" y="305.6030423759507" width="23.59644322845412" height="64.39695762404932" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="379.0027359781121" y="268.3339369793553" width="22.803009575923454" height="101.66606302064469" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="402.8057455540356" y="321.5755161173488" width="23.59644322845412" height="48.4244838826512" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="427.4021887824897" y="308.7721839913075" width="23.596443228454234" height="61.227816008692514" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="451.99863201094394" y="346.0412893879029" width="22.803009575923397" height="23.958710612097093" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="475.80164158686733" y="353.77399492937343" width="23.596443228454177" height="16.22600507062657" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="500.3980848153215" y="347.43571169865993" width="22.80300957592334" height="22.56428830134007" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="524.2010943912449" y="358.4643245201014" width="23.596443228454177" height="11.5356754798986" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="548.797537619699" y="364.67584208620065" width="23.596443228454177" height="5.324157913799354" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="573.3939808481532" y="366.95762404925756" width="22.00957592339273" height="3.0423759507424393" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="596.4035567715459" y="368.09851503078596" width="23.596443228454064" height="1.9014849692140388" fill="#4e79a7"></rect>
+    <rect style="mix-blend-mode: multiply;" x="41" y="370" width="22.80300957592339" height="0" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="64.8030095759234" y="370" width="23.596443228454184" height="0" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="89.39945280437757" y="370" width="22.803009575923383" height="0" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="113.20246238030096" y="370" width="23.596443228454163" height="0" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="137.79890560875512" y="369.87323433538575" width="23.596443228454177" height="0.1267656646142541" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="162.3953488372093" y="359.7319811662441" width="22.803009575923426" height="10.268018833755889" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="186.19835841313272" y="353.26693227091636" width="23.59644322845415" height="16.733067729083643" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="210.79480164158687" y="333.61825425570447" width="22.803009575923397" height="36.38174574429553" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="234.59781121751027" y="355.5487142339732" width="23.59644322845415" height="14.451285766026785" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="259.1942544459644" y="359.4784498370156" width="23.596443228454177" height="10.521550162984397" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="283.7906976744186" y="364.67584208620065" width="21.216142270861894" height="5.324157913799354" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="306.0068399452805" y="365.94349873234336" width="23.596443228454064" height="4.0565012676566425" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="330.60328317373455" y="363.91524809851506" width="22.803009575923454" height="6.084751901484935" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="354.406292749658" y="363.78848243390075" width="23.59644322845412" height="6.211517566099246" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="379.0027359781121" y="343.5059760956175" width="22.803009575923454" height="26.494023904382516" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="402.8057455540356" y="353.0134009416878" width="23.59644322845412" height="16.98659905831221" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="427.4021887824897" y="349.2104310032597" width="23.596443228454234" height="20.789568996740286" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="451.99863201094394" y="335.01267656646144" width="22.803009575923397" height="34.98732343353856" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="475.80164158686733" y="363.2814197754437" width="23.596443228454177" height="6.7185802245563195" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="500.3980848153215" y="365.8167330677291" width="22.80300957592334" height="4.183266932270897" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="524.2010943912449" y="367.71821803694314" width="23.596443228454177" height="2.281781963056858" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="548.797537619699" y="369.74646867077143" width="23.596443228454177" height="0.253531329228565" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="573.3939808481532" y="370" width="22.00957592339273" height="0" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="596.4035567715459" y="370" width="23.596443228454064" height="0" fill="#e15759"></rect>
+    <rect style="mix-blend-mode: multiply;" x="41" y="369.3661716769287" width="22.80300957592339" height="0.6338283230713273" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="64.8030095759234" y="368.8591090184716" width="23.596443228454184" height="1.1408909815284005" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="89.39945280437757" y="369.23940601231436" width="22.803009575923383" height="0.7605939876856382" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="113.20246238030096" y="367.08438971387176" width="23.596443228454163" height="2.915610286128242" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="137.79890560875512" y="366.1970300615719" width="23.596443228454177" height="3.8029699384280775" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="162.3953488372093" y="361.1264034770011" width="22.803009575923426" height="8.873596522998923" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="186.19835841313272" y="353.77399492937343" width="23.59644322845415" height="16.22600507062657" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="210.79480164158687" y="356.56283955088736" width="22.803009575923397" height="13.437160449112639" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="234.59781121751027" y="353.39369793553067" width="23.59644322845415" height="16.606302064469332" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="259.1942544459644" y="328.92792466497644" width="23.596443228454177" height="41.072075335023555" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="283.7906976744186" y="324.2375950742485" width="21.216142270861894" height="45.762404925751525" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="306.0068399452805" y="348.1963056863455" width="23.596443228454064" height="21.80369431365449" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="330.60328317373455" y="362.7743571169866" width="22.803009575923454" height="7.225642883013393" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="354.406292749658" y="365.30967040927203" width="23.59644322845412" height="4.69032959072797" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="379.0027359781121" y="366.0702643969576" width="22.803009575923454" height="3.9297356030423884" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="402.8057455540356" y="365.8167330677291" width="23.59644322845412" height="4.183266932270897" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="427.4021887824897" y="366.83085838464325" width="23.596443228454234" height="3.16914161535675" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="451.99863201094394" y="367.46468670771463" width="22.803009575923397" height="2.535313292285366" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="475.80164158686733" y="367.71821803694314" width="23.596443228454177" height="2.281781963056858" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="500.3980848153215" y="365.94349873234336" width="22.80300957592334" height="4.0565012676566425" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="524.2010943912449" y="366.45056139080043" width="23.596443228454177" height="3.5494386091995693" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="548.797537619699" y="363.91524809851506" width="23.596443228454177" height="6.084751901484935" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="573.3939808481532" y="367.5914523723289" width="22.00957592339273" height="2.408547627671112" fill="#f28e2c"></rect>
+    <rect style="mix-blend-mode: multiply;" x="596.4035567715459" y="365.5632017385006" width="23.596443228454064" height="4.436798261499405" fill="#f28e2c"></rect>
   </g>
   <g aria-label="rule" stroke="currentColor" transform="translate(0,0.5)">
     <line x1="40" x2="620" y1="370" y2="370"></line>

--- a/test/output/crimeanWarStacked.svg
+++ b/test/output/crimeanWarStacked.svg
@@ -36,153 +36,108 @@
       <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">3,000</text>
     </g><text fill="currentColor" transform="translate(-40,20)" dy="-1em" text-anchor="start">↑ deaths</text>
   </g>
-  <g aria-label="x-axis" transform="translate(0,370)" fill="none" text-anchor="middle">
-    <g class="tick" opacity="1" transform="translate(54.5,0)">
+  <g aria-label="x-axis" transform="translate(0,370)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(40.5,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Apr</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(78.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">May</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(102.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jun</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(126.5,0)">
+    <g class="tick" opacity="1" transform="translate(112.70246238030096,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jul</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(150.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Aug</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(174.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Sep</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(198.5,0)">
+    <g class="tick" opacity="1" transform="translate(185.69835841313272,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Oct</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(222.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Nov</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(246.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Dec</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(270.5,0)">
+    <g class="tick" opacity="1" transform="translate(258.6942544459644,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jan</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(294.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Feb</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(318.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Mar</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(342.5,0)">
+    <g class="tick" opacity="1" transform="translate(330.10328317373455,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Apr</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(366.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">May</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(390.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jun</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(414.5,0)">
+    <g class="tick" opacity="1" transform="translate(402.3057455540356,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jul</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(438.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Aug</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(462.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Sep</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(486.5,0)">
+    <g class="tick" opacity="1" transform="translate(475.30164158686733,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Oct</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(510.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Nov</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(534.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Dec</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(558.5,0)">
+    <g class="tick" opacity="1" transform="translate(548.297537619699,0)">
       <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Jan</text>
     </g>
-    <g class="tick" opacity="1" transform="translate(582.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Feb</text>
-    </g>
-    <g class="tick" opacity="1" transform="translate(606.5,0)">
-      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Mar</text>
+    <g class="tick" opacity="1" transform="translate(620.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">Apr</text>
     </g>
   </g>
-  <g aria-label="bar">
-    <rect x="43" width="22" y="369.3371212121212" height="0.11047979797979224" fill="#4e79a7"></rect>
-    <rect x="67" width="22" y="367.67992424242425" height="1.3257575757575637" fill="#4e79a7"></rect>
-    <rect x="91" width="22" y="368.1218434343434" height="1.2152777777777715" fill="#4e79a7"></rect>
-    <rect x="115" width="22" y="327.7967171717172" height="39.66224747474746" fill="#4e79a7"></rect>
-    <rect x="139" width="22" y="275.0978535353536" height="91.47727272727263" fill="#4e79a7"></rect>
-    <rect x="163" width="22" y="266.2594696969697" height="87.05808080808083" fill="#4e79a7"></rect>
-    <rect x="187" width="22" y="285.70391414141415" height="55.571338383838395" fill="#4e79a7"></rect>
-    <rect x="211" width="22" y="233.33648989898992" height="93.24494949494951" fill="#4e79a7"></rect>
-    <rect x="235" width="22" y="152.35479797979795" height="190.57765151515153" fill="#4e79a7"></rect>
-    <rect x="259" width="22" y="20" height="305.03472222222223" fill="#4e79a7"></rect>
-    <rect x="283" width="22" y="91.2594696969697" height="234.2171717171717" fill="#4e79a7"></rect>
-    <rect x="307" width="22" y="214.33396464646466" height="133.12815656565652" fill="#4e79a7"></rect>
-    <rect x="331" width="22" y="305.70075757575756" height="52.698863636363626" fill="#4e79a7"></rect>
-    <rect x="355" width="22" y="304.375" height="56.123737373737356" fill="#4e79a7"></rect>
-    <rect x="379" width="22" y="254.8800505050505" height="88.60479797979795" fill="#4e79a7"></rect>
-    <rect x="403" width="22" y="309.3465909090909" height="42.20328282828291" fill="#4e79a7"></rect>
-    <rect x="427" width="22" y="295.75757575757575" height="53.361742424242436" fill="#4e79a7"></rect>
-    <rect x="451" width="22" y="316.417297979798" height="20.88068181818187" fill="#4e79a7"></rect>
-    <rect x="475" width="22" y="348.01452020202015" height="14.141414141414202" fill="#4e79a7"></rect>
-    <rect x="499" width="22" y="343.1534090909091" height="19.665404040403985" fill="#4e79a7"></rect>
-    <rect x="523" width="22" y="354.8642676767677" height="10.053661616161605" fill="#4e79a7"></rect>
-    <rect x="547" width="22" y="359.83585858585855" height="4.640151515151558" fill="#4e79a7"></rect>
-    <rect x="571" width="22" y="365.2493686868687" height="2.6515151515151274" fill="#4e79a7"></rect>
-    <rect x="595" width="22" y="364.4760101010101" height="1.6571969696969404" fill="#4e79a7"></rect>
-    <rect x="43" width="22" y="369.447601010101" height="0" fill="#e15759"></rect>
-    <rect x="67" width="22" y="369.0056818181818" height="0" fill="#e15759"></rect>
-    <rect x="91" width="22" y="369.3371212121212" height="0" fill="#e15759"></rect>
-    <rect x="115" width="22" y="367.45896464646466" height="0" fill="#e15759"></rect>
-    <rect x="139" width="22" y="366.5751262626262" height="0.11047979797984908" fill="#e15759"></rect>
-    <rect x="163" width="22" y="353.3175505050505" height="8.948863636363626" fill="#e15759"></rect>
-    <rect x="187" width="22" y="341.27525252525254" height="14.583333333333314" fill="#e15759"></rect>
-    <rect x="211" width="22" y="326.58143939393943" height="31.70770202020202" fill="#e15759"></rect>
-    <rect x="235" width="22" y="342.9324494949495" height="12.594696969696997" fill="#e15759"></rect>
-    <rect x="259" width="22" y="325.03472222222223" height="9.16982323232321" fill="#e15759"></rect>
-    <rect x="283" width="22" y="325.4766414141414" height="4.640151515151558" fill="#e15759"></rect>
-    <rect x="307" width="22" y="347.4621212121212" height="3.535353535353579" fill="#e15759"></rect>
-    <rect x="331" width="22" y="358.3996212121212" height="5.3030303030303685" fill="#e15759"></rect>
-    <rect x="355" width="22" y="360.49873737373736" height="5.413510101010104" fill="#e15759"></rect>
-    <rect x="379" width="22" y="343.48484848484844" height="23.09027777777777" fill="#e15759"></rect>
-    <rect x="403" width="22" y="351.5498737373738" height="14.804292929292899" fill="#e15759"></rect>
-    <rect x="427" width="22" y="349.1193181818182" height="18.118686868686893" fill="#e15759"></rect>
-    <rect x="451" width="22" y="337.29797979797985" height="30.49242424242425" fill="#e15759"></rect>
-    <rect x="475" width="22" y="362.15593434343435" height="5.855429292929273" fill="#e15759"></rect>
-    <rect x="499" width="22" y="362.8188131313131" height="3.6458333333333712" fill="#e15759"></rect>
-    <rect x="523" width="22" y="364.91792929292933" height="1.9886363636363171" fill="#e15759"></rect>
-    <rect x="547" width="22" y="364.4760101010101" height="0.22095959595958448" fill="#e15759"></rect>
-    <rect x="571" width="22" y="367.90088383838383" height="0" fill="#e15759"></rect>
-    <rect x="595" width="22" y="366.13320707070704" height="0" fill="#e15759"></rect>
-    <rect x="43" width="22" y="369.447601010101" height="0.552398989899018" fill="#f28e2c"></rect>
-    <rect x="67" width="22" y="369.0056818181818" height="0.994318181818187" fill="#f28e2c"></rect>
-    <rect x="91" width="22" y="369.3371212121212" height="0.6628787878788103" fill="#f28e2c"></rect>
-    <rect x="115" width="22" y="367.45896464646466" height="2.541035353535335" fill="#f28e2c"></rect>
-    <rect x="139" width="22" y="366.68560606060606" height="3.3143939393939377" fill="#f28e2c"></rect>
-    <rect x="163" width="22" y="362.26641414141415" height="7.733585858585855" fill="#f28e2c"></rect>
-    <rect x="187" width="22" y="355.85858585858585" height="14.141414141414145" fill="#f28e2c"></rect>
-    <rect x="211" width="22" y="358.28914141414145" height="11.710858585858546" fill="#f28e2c"></rect>
-    <rect x="235" width="22" y="355.5271464646465" height="14.472853535353522" fill="#f28e2c"></rect>
-    <rect x="259" width="22" y="334.20454545454544" height="35.79545454545456" fill="#f28e2c"></rect>
-    <rect x="283" width="22" y="330.11679292929296" height="39.883207070707044" fill="#f28e2c"></rect>
-    <rect x="307" width="22" y="350.99747474747477" height="19.00252525252523" fill="#f28e2c"></rect>
-    <rect x="331" width="22" y="363.70265151515156" height="6.297348484848442" fill="#f28e2c"></rect>
-    <rect x="355" width="22" y="365.91224747474746" height="4.08775252525254" fill="#f28e2c"></rect>
-    <rect x="379" width="22" y="366.5751262626262" height="3.4248737373737868" fill="#f28e2c"></rect>
-    <rect x="403" width="22" y="366.3541666666667" height="3.6458333333333144" fill="#f28e2c"></rect>
-    <rect x="427" width="22" y="367.2380050505051" height="2.7619949494949196" fill="#f28e2c"></rect>
-    <rect x="451" width="22" y="367.7904040404041" height="2.2095959595959016" fill="#f28e2c"></rect>
-    <rect x="475" width="22" y="368.0113636363636" height="1.988636363636374" fill="#f28e2c"></rect>
-    <rect x="499" width="22" y="366.4646464646465" height="3.535353535353522" fill="#f28e2c"></rect>
-    <rect x="523" width="22" y="366.90656565656565" height="3.093434343434353" fill="#f28e2c"></rect>
-    <rect x="547" width="22" y="364.6969696969697" height="5.303030303030312" fill="#f28e2c"></rect>
-    <rect x="571" width="22" y="367.90088383838383" height="2.099116161616166" fill="#f28e2c"></rect>
-    <rect x="595" width="22" y="366.13320707070704" height="3.8667929292929557" fill="#f28e2c"></rect>
+  <g aria-label="rect">
+    <rect x="41" y="369.3371212121212" width="22.80300957592339" height="0.11047979797979224" fill="#4e79a7"></rect>
+    <rect x="64.8030095759234" y="367.67992424242425" width="23.596443228454184" height="1.3257575757575637" fill="#4e79a7"></rect>
+    <rect x="89.39945280437757" y="368.1218434343434" width="22.803009575923383" height="1.2152777777777715" fill="#4e79a7"></rect>
+    <rect x="113.20246238030096" y="327.7967171717172" width="23.596443228454163" height="39.66224747474746" fill="#4e79a7"></rect>
+    <rect x="137.79890560875512" y="275.0978535353536" width="23.596443228454177" height="91.47727272727263" fill="#4e79a7"></rect>
+    <rect x="162.3953488372093" y="266.2594696969697" width="22.803009575923426" height="87.05808080808083" fill="#4e79a7"></rect>
+    <rect x="186.19835841313272" y="285.70391414141415" width="23.59644322845415" height="55.571338383838395" fill="#4e79a7"></rect>
+    <rect x="210.79480164158687" y="233.33648989898992" width="22.803009575923397" height="93.24494949494951" fill="#4e79a7"></rect>
+    <rect x="234.59781121751027" y="152.35479797979795" width="23.59644322845415" height="190.57765151515153" fill="#4e79a7"></rect>
+    <rect x="259.1942544459644" y="20" width="23.596443228454177" height="305.03472222222223" fill="#4e79a7"></rect>
+    <rect x="283.7906976744186" y="91.2594696969697" width="21.216142270861894" height="234.2171717171717" fill="#4e79a7"></rect>
+    <rect x="306.0068399452805" y="214.33396464646466" width="23.596443228454064" height="133.12815656565652" fill="#4e79a7"></rect>
+    <rect x="330.60328317373455" y="305.70075757575756" width="22.803009575923454" height="52.698863636363626" fill="#4e79a7"></rect>
+    <rect x="354.406292749658" y="304.375" width="23.59644322845412" height="56.123737373737356" fill="#4e79a7"></rect>
+    <rect x="379.0027359781121" y="254.8800505050505" width="22.803009575923454" height="88.60479797979795" fill="#4e79a7"></rect>
+    <rect x="402.8057455540356" y="309.3465909090909" width="23.59644322845412" height="42.20328282828291" fill="#4e79a7"></rect>
+    <rect x="427.4021887824897" y="295.75757575757575" width="23.596443228454234" height="53.361742424242436" fill="#4e79a7"></rect>
+    <rect x="451.99863201094394" y="316.417297979798" width="22.803009575923397" height="20.88068181818187" fill="#4e79a7"></rect>
+    <rect x="475.80164158686733" y="348.01452020202015" width="23.596443228454177" height="14.141414141414202" fill="#4e79a7"></rect>
+    <rect x="500.3980848153215" y="343.1534090909091" width="22.80300957592334" height="19.665404040403985" fill="#4e79a7"></rect>
+    <rect x="524.2010943912449" y="354.8642676767677" width="23.596443228454177" height="10.053661616161605" fill="#4e79a7"></rect>
+    <rect x="548.797537619699" y="359.83585858585855" width="23.596443228454177" height="4.640151515151558" fill="#4e79a7"></rect>
+    <rect x="573.3939808481532" y="365.2493686868687" width="22.00957592339273" height="2.6515151515151274" fill="#4e79a7"></rect>
+    <rect x="596.4035567715459" y="364.4760101010101" width="23.596443228454064" height="1.6571969696969404" fill="#4e79a7"></rect>
+    <rect x="41" y="369.447601010101" width="22.80300957592339" height="0" fill="#e15759"></rect>
+    <rect x="64.8030095759234" y="369.0056818181818" width="23.596443228454184" height="0" fill="#e15759"></rect>
+    <rect x="89.39945280437757" y="369.3371212121212" width="22.803009575923383" height="0" fill="#e15759"></rect>
+    <rect x="113.20246238030096" y="367.45896464646466" width="23.596443228454163" height="0" fill="#e15759"></rect>
+    <rect x="137.79890560875512" y="366.5751262626262" width="23.596443228454177" height="0.11047979797984908" fill="#e15759"></rect>
+    <rect x="162.3953488372093" y="353.3175505050505" width="22.803009575923426" height="8.948863636363626" fill="#e15759"></rect>
+    <rect x="186.19835841313272" y="341.27525252525254" width="23.59644322845415" height="14.583333333333314" fill="#e15759"></rect>
+    <rect x="210.79480164158687" y="326.58143939393943" width="22.803009575923397" height="31.70770202020202" fill="#e15759"></rect>
+    <rect x="234.59781121751027" y="342.9324494949495" width="23.59644322845415" height="12.594696969696997" fill="#e15759"></rect>
+    <rect x="259.1942544459644" y="325.03472222222223" width="23.596443228454177" height="9.16982323232321" fill="#e15759"></rect>
+    <rect x="283.7906976744186" y="325.4766414141414" width="21.216142270861894" height="4.640151515151558" fill="#e15759"></rect>
+    <rect x="306.0068399452805" y="347.4621212121212" width="23.596443228454064" height="3.535353535353579" fill="#e15759"></rect>
+    <rect x="330.60328317373455" y="358.3996212121212" width="22.803009575923454" height="5.3030303030303685" fill="#e15759"></rect>
+    <rect x="354.406292749658" y="360.49873737373736" width="23.59644322845412" height="5.413510101010104" fill="#e15759"></rect>
+    <rect x="379.0027359781121" y="343.48484848484844" width="22.803009575923454" height="23.09027777777777" fill="#e15759"></rect>
+    <rect x="402.8057455540356" y="351.5498737373738" width="23.59644322845412" height="14.804292929292899" fill="#e15759"></rect>
+    <rect x="427.4021887824897" y="349.1193181818182" width="23.596443228454234" height="18.118686868686893" fill="#e15759"></rect>
+    <rect x="451.99863201094394" y="337.29797979797985" width="22.803009575923397" height="30.49242424242425" fill="#e15759"></rect>
+    <rect x="475.80164158686733" y="362.15593434343435" width="23.596443228454177" height="5.855429292929273" fill="#e15759"></rect>
+    <rect x="500.3980848153215" y="362.8188131313131" width="22.80300957592334" height="3.6458333333333712" fill="#e15759"></rect>
+    <rect x="524.2010943912449" y="364.91792929292933" width="23.596443228454177" height="1.9886363636363171" fill="#e15759"></rect>
+    <rect x="548.797537619699" y="364.4760101010101" width="23.596443228454177" height="0.22095959595958448" fill="#e15759"></rect>
+    <rect x="573.3939808481532" y="367.90088383838383" width="22.00957592339273" height="0" fill="#e15759"></rect>
+    <rect x="596.4035567715459" y="366.13320707070704" width="23.596443228454064" height="0" fill="#e15759"></rect>
+    <rect x="41" y="369.447601010101" width="22.80300957592339" height="0.552398989899018" fill="#f28e2c"></rect>
+    <rect x="64.8030095759234" y="369.0056818181818" width="23.596443228454184" height="0.994318181818187" fill="#f28e2c"></rect>
+    <rect x="89.39945280437757" y="369.3371212121212" width="22.803009575923383" height="0.6628787878788103" fill="#f28e2c"></rect>
+    <rect x="113.20246238030096" y="367.45896464646466" width="23.596443228454163" height="2.541035353535335" fill="#f28e2c"></rect>
+    <rect x="137.79890560875512" y="366.68560606060606" width="23.596443228454177" height="3.3143939393939377" fill="#f28e2c"></rect>
+    <rect x="162.3953488372093" y="362.26641414141415" width="22.803009575923426" height="7.733585858585855" fill="#f28e2c"></rect>
+    <rect x="186.19835841313272" y="355.85858585858585" width="23.59644322845415" height="14.141414141414145" fill="#f28e2c"></rect>
+    <rect x="210.79480164158687" y="358.28914141414145" width="22.803009575923397" height="11.710858585858546" fill="#f28e2c"></rect>
+    <rect x="234.59781121751027" y="355.5271464646465" width="23.59644322845415" height="14.472853535353522" fill="#f28e2c"></rect>
+    <rect x="259.1942544459644" y="334.20454545454544" width="23.596443228454177" height="35.79545454545456" fill="#f28e2c"></rect>
+    <rect x="283.7906976744186" y="330.11679292929296" width="21.216142270861894" height="39.883207070707044" fill="#f28e2c"></rect>
+    <rect x="306.0068399452805" y="350.99747474747477" width="23.596443228454064" height="19.00252525252523" fill="#f28e2c"></rect>
+    <rect x="330.60328317373455" y="363.70265151515156" width="22.803009575923454" height="6.297348484848442" fill="#f28e2c"></rect>
+    <rect x="354.406292749658" y="365.91224747474746" width="23.59644322845412" height="4.08775252525254" fill="#f28e2c"></rect>
+    <rect x="379.0027359781121" y="366.5751262626262" width="22.803009575923454" height="3.4248737373737868" fill="#f28e2c"></rect>
+    <rect x="402.8057455540356" y="366.3541666666667" width="23.59644322845412" height="3.6458333333333144" fill="#f28e2c"></rect>
+    <rect x="427.4021887824897" y="367.2380050505051" width="23.596443228454234" height="2.7619949494949196" fill="#f28e2c"></rect>
+    <rect x="451.99863201094394" y="367.7904040404041" width="22.803009575923397" height="2.2095959595959016" fill="#f28e2c"></rect>
+    <rect x="475.80164158686733" y="368.0113636363636" width="23.596443228454177" height="1.988636363636374" fill="#f28e2c"></rect>
+    <rect x="500.3980848153215" y="366.4646464646465" width="22.80300957592334" height="3.535353535353522" fill="#f28e2c"></rect>
+    <rect x="524.2010943912449" y="366.90656565656565" width="23.596443228454177" height="3.093434343434353" fill="#f28e2c"></rect>
+    <rect x="548.797537619699" y="364.6969696969697" width="23.596443228454177" height="5.303030303030312" fill="#f28e2c"></rect>
+    <rect x="573.3939808481532" y="367.90088383838383" width="22.00957592339273" height="2.099116161616166" fill="#f28e2c"></rect>
+    <rect x="596.4035567715459" y="366.13320707070704" width="23.596443228454064" height="3.8667929292929557" fill="#f28e2c"></rect>
   </g>
   <g aria-label="rule" stroke="currentColor" transform="translate(0,0.5)">
     <line x1="40" x2="620" y1="370" y2="370"></line>

--- a/test/plots/crimean-war-overlapped.js
+++ b/test/plots/crimean-war-overlapped.js
@@ -11,7 +11,7 @@ export default async function() {
       label: null
     },
     marks: [
-      Plot.barY(data, {x: "date", y2: "deaths", sort: d => -d.deaths, fill: "cause"}),
+      Plot.rectY(data, {x: "date", interval: d3.utcMonth, y2: "deaths", fill: "cause", mixBlendMode: "multiply"}),
       Plot.ruleY([0])
     ]
   });

--- a/test/plots/crimean-war-stacked.js
+++ b/test/plots/crimean-war-stacked.js
@@ -11,7 +11,7 @@ export default async function() {
       label: null
     },
     marks: [
-      Plot.barY(data, {x: "date", y: "deaths", fill: "cause", reverse: true}),
+      Plot.rectY(data, {x: "date", interval: d3.utcMonth, y: "deaths", fill: "cause", reverse: true}),
       Plot.ruleY([0])
     ]
   });

--- a/test/plots/fruit-sales-date.js
+++ b/test/plots/fruit-sales-date.js
@@ -4,6 +4,9 @@ import * as d3 from "d3";
 export default async function() {
   const sales = await d3.csv("data/fruit-sales.csv", d3.autoType);
   return Plot.plot({
+    x: {
+      type: "band" // treat dates as ordinal, not temporal
+    },
     marks: [
       Plot.barY(sales, Plot.stackY({x: "date", y: "units", fill: "fruit"})),
       Plot.text(sales, Plot.stackY({x: "date", y: "units", text: "fruit" }))

--- a/test/plots/software-versions.js
+++ b/test/plots/software-versions.js
@@ -30,6 +30,7 @@ export default async function() {
       percent: true
     },
     color: {
+      type: "ordinal",
       scheme: "blues"
     },
     marks: [

--- a/test/plots/stargazers-hourly-group.js
+++ b/test/plots/stargazers-hourly-group.js
@@ -5,6 +5,7 @@ export default async function() {
   const stargazers = await d3.csv("data/stargazers.csv", d3.autoType);
   return Plot.plot({
     x: {
+      type: "band",
       label: "New stargazers per hour →"
     },
     y: {

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -1137,60 +1137,60 @@ it("plot({clamp, …}).scale('x').clamp reflects the given clamp option", () => 
 });
 
 it("plot({align, …}).scale('x').align reflects the given align option for point scales", () => {
-  assert.strictEqual(Plot.dot(["1", "2", "3"], {x: d => d}).plot({x: {align: 0}}).scale("x").align, 0);
-  assert.strictEqual(Plot.dot(["1", "2", "3"], {x: d => d}).plot({x: {align: 0.7}}).scale("x").align, 0.7);
-  assert.strictEqual(Plot.dot(["1", "2", "3"], {x: d => d}).plot({x: {align: "0.7"}}).scale("x").align, 0.7);
-  assert.strictEqual(Plot.dot(["1", "2", "3"], {x: d => d}).plot({x: {align: 1}}).scale("x").align, 1);
+  assert.strictEqual(Plot.dot("abc", {x: d => d}).plot({x: {align: 0}}).scale("x").align, 0);
+  assert.strictEqual(Plot.dot("abc", {x: d => d}).plot({x: {align: 0.7}}).scale("x").align, 0.7);
+  assert.strictEqual(Plot.dot("abc", {x: d => d}).plot({x: {align: "0.7"}}).scale("x").align, 0.7);
+  assert.strictEqual(Plot.dot("abc", {x: d => d}).plot({x: {align: 1}}).scale("x").align, 1);
 });
 
 it("plot({align, …}).scale('x').align reflects the given align option for band scales", () => {
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {align: 0}}).scale("x").align, 0);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {align: 0.7}}).scale("x").align, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {align: "0.7"}}).scale("x").align, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {align: 1}}).scale("x").align, 1);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {align: 0}}).scale("x").align, 0);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {align: 0.7}}).scale("x").align, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {align: "0.7"}}).scale("x").align, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {align: 1}}).scale("x").align, 1);
 });
 
 it("plot({paddingInner, …}).scale('x').paddingInner reflects the given paddingInner option for band scales", () => {
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {paddingInner: 0}}).scale("x").paddingInner, 0);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {paddingInner: 0.7}}).scale("x").paddingInner, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {paddingInner: "0.7"}}).scale("x").paddingInner, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {paddingInner: 1}}).scale("x").paddingInner, 1);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0, paddingInner: 0}}).scale("x").paddingInner, 0);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0, paddingInner: 0.7}}).scale("x").paddingInner, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0, paddingInner: "0.7"}}).scale("x").paddingInner, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0, paddingInner: 1}}).scale("x").paddingInner, 1);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {paddingInner: 0}}).scale("x").paddingInner, 0);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {paddingInner: 0.7}}).scale("x").paddingInner, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {paddingInner: "0.7"}}).scale("x").paddingInner, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {paddingInner: 1}}).scale("x").paddingInner, 1);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0, paddingInner: 0}}).scale("x").paddingInner, 0);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0, paddingInner: 0.7}}).scale("x").paddingInner, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0, paddingInner: "0.7"}}).scale("x").paddingInner, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0, paddingInner: 1}}).scale("x").paddingInner, 1);
 });
 
 it("plot({paddingOuter, …}).scale('x').paddingOuter reflects the given paddingOuter option for band scales", () => {
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {paddingOuter: 0}}).scale("x").paddingOuter, 0);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {paddingOuter: 0.7}}).scale("x").paddingOuter, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {paddingOuter: "0.7"}}).scale("x").paddingOuter, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {paddingOuter: 1}}).scale("x").paddingOuter, 1);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0, paddingOuter: 0}}).scale("x").paddingOuter, 0);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0, paddingOuter: 0.7}}).scale("x").paddingOuter, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0, paddingOuter: "0.7"}}).scale("x").paddingOuter, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0, paddingOuter: 1}}).scale("x").paddingOuter, 1);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {paddingOuter: 0}}).scale("x").paddingOuter, 0);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {paddingOuter: 0.7}}).scale("x").paddingOuter, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {paddingOuter: "0.7"}}).scale("x").paddingOuter, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {paddingOuter: 1}}).scale("x").paddingOuter, 1);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0, paddingOuter: 0}}).scale("x").paddingOuter, 0);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0, paddingOuter: 0.7}}).scale("x").paddingOuter, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0, paddingOuter: "0.7"}}).scale("x").paddingOuter, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0, paddingOuter: 1}}).scale("x").paddingOuter, 1);
 });
 
 it("plot({padding, …}).scale('x').paddingInner reflects the given padding option for band scales", () => {
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0}}).scale("x").paddingInner, 0);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0.7}}).scale("x").paddingInner, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: "0.7"}}).scale("x").paddingInner, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 1}}).scale("x").paddingInner, 1);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0}}).scale("x").paddingInner, 0);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0.7}}).scale("x").paddingInner, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: "0.7"}}).scale("x").paddingInner, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 1}}).scale("x").paddingInner, 1);
 });
 
 it("plot({padding, …}).scale('x').paddingOuter reflects the given padding option for band scales", () => {
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0}}).scale("x").paddingOuter, 0);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0.7}}).scale("x").paddingOuter, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: "0.7"}}).scale("x").paddingOuter, 0.7);
-  assert.strictEqual(Plot.cell(["1", "2", "3"], {x: d => d}).plot({x: {padding: 1}}).scale("x").paddingOuter, 1);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0}}).scale("x").paddingOuter, 0);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 0.7}}).scale("x").paddingOuter, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: "0.7"}}).scale("x").paddingOuter, 0.7);
+  assert.strictEqual(Plot.cell("abc", {x: d => d}).plot({x: {padding: 1}}).scale("x").paddingOuter, 1);
 });
 
 it("plot({padding, …}).scale('x').padding reflects the given padding option for point scales", () => {
-  assert.strictEqual(Plot.dot(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0}}).scale("x").padding, 0);
-  assert.strictEqual(Plot.dot(["1", "2", "3"], {x: d => d}).plot({x: {padding: 0.7}}).scale("x").padding, 0.7);
-  assert.strictEqual(Plot.dot(["1", "2", "3"], {x: d => d}).plot({x: {padding: "0.7"}}).scale("x").padding, 0.7);
-  assert.strictEqual(Plot.dot(["1", "2", "3"], {x: d => d}).plot({x: {padding: 1}}).scale("x").padding, 1);
+  assert.strictEqual(Plot.dot("abc", {x: d => d}).plot({x: {padding: 0}}).scale("x").padding, 0);
+  assert.strictEqual(Plot.dot("abc", {x: d => d}).plot({x: {padding: 0.7}}).scale("x").padding, 0.7);
+  assert.strictEqual(Plot.dot("abc", {x: d => d}).plot({x: {padding: "0.7"}}).scale("x").padding, 0.7);
+  assert.strictEqual(Plot.dot("abc", {x: d => d}).plot({x: {padding: 1}}).scale("x").padding, 1);
 });
 
 it("plot(…).scale('x').label reflects the default label for named fields, possibly reversed", () => {


### PR DESCRIPTION
Fixes #536 by introducing a warning mechanism. When a warning is triggered, a ⚠️ icon is displayed in the top-right corner of the plot.

<img width="973" alt="Screen Shot 2022-02-09 at 9 02 24 PM" src="https://user-images.githubusercontent.com/230541/153342834-48fffb5a-925b-4b2e-a5a3-174bbb8ac119.png">

Mousing over the warning indicator gives the tooltip _e.g._ “1 warning. Please check the console.” The console shows the warnings:

<img width="997" alt="Screen Shot 2022-02-09 at 9 48 08 PM" src="https://user-images.githubusercontent.com/230541/153345565-2b5d88da-720e-4d90-860e-a51663d41be8.png">

I have implemented three warnings so far:

* When dates are associated with an implicit band scale (typically because of a bar mark)
* When strings that appear to be dates are associated with an implicit band scale
* When strings that appear to be dates are associated with an implicit ordinal or point scale

I imagine we will think of lots of additional warnings in the future, but I think these three cover the most common mistake I’ve seen in Plot. We may want to have another tracking issue to cover ideas for other warnings (e.g., insets resulting in zero-width rects or bars, mixed-sign values with log scales, undefined or invalid data, etc.).

Ref. https://talk.observablehq.com/t/bar-chart-with-dates/6194/3