### PR TITLE
fix for null scales

### DIFF
--- a/src/legends.js
+++ b/src/legends.js
@@ -1,5 +1,5 @@
 import {rgb} from "d3";
-import {isObject} from "./options.js";
+import {isScaleOptions} from "./options.js";
 import {normalizeScale} from "./scales.js";
 import {legendRamp} from "./legends/ramp.js";
 import {legendSwatches, legendSymbols} from "./legends/swatches.js";
@@ -13,17 +13,17 @@ const legendRegistry = new Map([
 export function legend(options = {}) {
   for (const [key, value] of legendRegistry) {
     const scale = options[key];
-    if (isObject(scale)) { // e.g., ignore {color: "red"}
+    if (isScaleOptions(scale)) { // e.g., ignore {color: "red"}
       let hint;
       // For symbol legends, pass a hint to the symbol scale.
       if (key === "symbol") {
-        const {fill, stroke = fill === undefined && isObject(options.color) ? "color" : undefined} = options;
+        const {fill, stroke = fill === undefined && isScaleOptions(options.color) ? "color" : undefined} = options;
         hint = {fill, stroke};
       }
       return value(
         normalizeScale(key, scale, hint),
         legendOptions(scale, options),
-        key => isObject(options[key]) ? normalizeScale(key, options[key]) : null
+        key => isScaleOptions(options[key]) ? normalizeScale(key, options[key]) : null
       );
     }
   }
@@ -75,7 +75,7 @@ export function Legends(scales, options) {
   const legends = [];
   for (const [key, value] of legendRegistry) {
     const o = options[key];
-    if (o && o.legend) {
+    if (o?.legend && (key in scales)) {
       const legend = value(scales[key], legendOptions(scales[key], o), key => scales[key]);
       if (legend != null) legends.push(legend);
     }

--- a/src/options.js
+++ b/src/options.js
@@ -74,7 +74,16 @@ export function arrayify(data, type) {
 
 // Disambiguates an options object (e.g., {y: "x2"}) from a primitive value.
 export function isObject(option) {
-  return option && option.toString === objectToString;
+  return option?.toString === objectToString;
+}
+
+// Disambiguates a scale options object (e.g., {color: {type: "linear"}}) from
+// some other option (e.g., {color: "red"}). When creating standalone legends,
+// this is used to test whether a scale is defined; this should be consistent
+// with inferScaleType when there are no channels associated with the scale, and
+// if this returns true, then normalizeScale must return non-null.
+export function isScaleOptions(option) {
+  return isObject(option) && (option.type !== undefined || option.domain !== undefined);
 }
 
 // Disambiguates an options object (e.g., {y: "x2"}) from a channel value

--- a/test/legends/legends-test.js
+++ b/test/legends/legends-test.js
@@ -5,3 +5,11 @@ it("Plot.legend({color: {type:'identity'}}) returns undefined", () => {
   const l = Plot.legend({color: {type: "identity"}});
   assert.strictEqual(l, undefined);
 });
+
+it("Plot.legend({}) throws an error", () => {
+  assert.throws(() => Plot.legend({}), /unknown legend type/);
+});
+
+it("Plot.legend({color: {}}) throws an error", () => {
+  assert.throws(() => Plot.legend({color: {}}), /unknown legend type/);
+});

--- a/test/output/emptyLegend.svg
+++ b/test/output/emptyLegend.svg
@@ -1,0 +1,17 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <rect aria-label="frame" fill="none" stroke="currentColor" transform="translate(0.5,0.5)" x="0" y="0" width="639" height="59"></rect>
+</svg>

--- a/test/plots/empty-legend.js
+++ b/test/plots/empty-legend.js
@@ -1,0 +1,12 @@
+import * as Plot from "@observablehq/plot";
+
+export default async function() {
+  return Plot.plot({
+    color: {
+      legend: true // ignored because no color scale
+    },
+    marks: [
+      Plot.frame()
+    ]
+  });
+}

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -40,6 +40,7 @@ export {default as diamondsCaratPrice} from "./diamonds-carat-price.js";
 export {default as diamondsCaratPriceDots} from "./diamonds-carat-price-dots.js";
 export {default as documentationLinks} from "./documentation-links.js";
 export {default as empty} from "./empty.js";
+export {default as emptyLegend} from "./empty-legend.js";
 export {default as emptyX} from "./empty-x.js";
 export {default as figcaption} from "./figcaption.js";
 export {default as figcaptionHtml} from "./figcaption-html.js";


### PR DESCRIPTION
#756 changed the test used to determine whether or not a scale exists. This updates Plot.legend to match. Now `Plot.legend({color: {}})` throws an error because it does not consider the color scale to be defined (there is neither a type nor a domain). Supersedes #757.