### PR TITLE
consider var(--foo) a color

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -273,6 +273,7 @@ export function isColor(value) {
   return value === "none"
     || value === "currentcolor"
     || (value.startsWith("url(") && value.endsWith(")")) // <funciri>, e.g. pattern or gradient
+    || (value.startsWith("var(") && value.endsWith(")")) // CSS variable
     || color(value) !== null;
 }
 


### PR DESCRIPTION
Fixes #765. It could be stricter (checking that the variable name starts with `--` for example), but I think this is fine as is.