### PR TITLE
x and y reducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1357,8 +1357,10 @@ The following aggregation methods are supported:
 * *deviation* - the standard deviation
 * *variance* - the variance per [Welford’s algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm)
 * *mode* - the value with the most occurrences
+* *x* - the middle the bin’s *x*-extent (when binning on *x*)
 * *x1* - the lower bound of the bin’s *x*-extent (when binning on *x*)
 * *x2* - the upper bound of the bin’s *x*-extent (when binning on *x*)
+* *y* - the middle the bin’s *y*-extent (when binning on *y*)
 * *y1* - the lower bound of the bin’s *y*-extent (when binning on *y*)
 * *y2* - the upper bound of the bin’s *y*-extent (when binning on *y*)
 * a function to be passed the array of values for each bin and the extent of the bin

--- a/src/transforms/group.js
+++ b/src/transforms/group.js
@@ -215,8 +215,10 @@ export function maybeReduce(reduce, value) {
     case "median": return reduceAccessor(median);
     case "variance": return reduceAccessor(variance);
     case "mode": return reduceAccessor(mode);
+    case "x": return reduceX;
     case "x1": return reduceX1;
     case "x2": return reduceX2;
+    case "y": return reduceY;
     case "y1": return reduceY1;
     case "y2": return reduceY2;
   }
@@ -312,6 +314,23 @@ function reduceProportion(value, scope) {
       ? {scope, label: "Frequency", reduce: (I, V, basis = 1) => I.length / basis}
       : {scope, reduce: (I, V, basis = 1) => sum(I, i => V[i]) / basis};
 }
+
+function mid(x1, x2) {
+  const m = (+x1 + +x2) / 2;
+  return x1 instanceof Date ? new Date(m) : m;
+}
+
+const reduceX = {
+  reduce(I, X, {x1, x2}) {
+    return mid(x1, x2);
+  }
+};
+
+const reduceY = {
+  reduce(I, X, {y1, y2}) {
+    return mid(y1, y2);
+  }
+};
 
 const reduceX1 = {
   reduce(I, X, {x1}) {

--- a/test/plots/athletes-bins-colors.js
+++ b/test/plots/athletes-bins-colors.js
@@ -5,7 +5,7 @@ export default async function() {
   const athletes = await d3.csv("data/athletes.csv", d3.autoType);
   return Plot.plot({
     marks: [
-      Plot.rectY(athletes, Plot.binX({fill: "x1", y: "count"}, {x: "weight"})),
+      Plot.rectY(athletes, Plot.binX({fill: "x", y: "count"}, {x: "weight"})),
       Plot.ruleY([0])
     ]
   });


### PR DESCRIPTION
We added x1, x2, y1, y2 in #613, but we should have x and y too for symmetry.