### PR TITLE
undefined instead of error

### DIFF
--- a/src/legends.js
+++ b/src/legends.js
@@ -27,7 +27,6 @@ export function legend(options = {}) {
       );
     }
   }
-  throw new Error("unknown legend type");
 }
 
 export function exposeLegends(scales, defaults = {}) {

--- a/src/scales.js
+++ b/src/scales.js
@@ -388,7 +388,6 @@ export function scale(options = {}) {
     if (scale !== undefined) throw new Error("ambiguous scale definition");
     scale = exposeScale(normalizeScale(key, options[key]));
   }
-  if (scale === undefined) throw new Error("invalid scale definition");
   return scale;
 }
 

--- a/test/legends/legends-test.js
+++ b/test/legends/legends-test.js
@@ -5,11 +5,8 @@ it("Plot.legend({color: {type:'identity'}}) returns undefined", () => {
   const l = Plot.legend({color: {type: "identity"}});
   assert.strictEqual(l, undefined);
 });
-
-it("Plot.legend({}) throws an error", () => {
-  assert.throws(() => Plot.legend({}), /unknown legend type/);
-});
-
-it("Plot.legend({color: {}}) throws an error", () => {
-  assert.throws(() => Plot.legend({color: {}}), /unknown legend type/);
+it("Plot.legend(description) returns undefined if given no scale definition", () => {
+  assert.strictEqual(Plot.legend(), undefined);
+  assert.strictEqual(Plot.legend({}), undefined);
+  assert.strictEqual(Plot.legend({color: {}}), undefined);
 });

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -14,12 +14,10 @@ it("Plot.scale(description) returns a standalone scale", () => {
   });
 });
 
-it("Plot.scale({}) throws an error", () => {
-  assert.throws(() => Plot.scale({}), /invalid scale definition/);
-});
-
-it("Plot.scale({color: {}}) throws an error", () => {
-  assert.throws(() => Plot.scale({color: {}}), /invalid scale definition/);
+it("Plot.scale(description) returns undefined if given no scale definition", () => {
+  assert.strictEqual(Plot.scale(), undefined);
+  assert.strictEqual(Plot.scale({}), undefined);
+  assert.strictEqual(Plot.scale({color: {}}), undefined);
 });
 
 it("plot(…).scale(name) returns undefined for an unused scale", () => {


### PR DESCRIPTION
This makes Plot.scale and Plot.legend more consistent with plot.scale and plot.legend: they all now return undefined if no scale definition is provided. I’m not sure this is really an improvement, though. It seems like you’d want to have an error if your standalone scale or legend definition failed. But putting this up for discussion…

Related #772.