### PR TITLE
relax cardinality test

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -186,7 +186,7 @@ function groupAesthetics({ariaLabel: AL, title: T, fill: F, fillOpacity: FO, str
 
 function groupZ(I, Z, z) {
   const G = group(I, i => Z[i]);
-  if (z === undefined && G.size > I.length >> 2) {
+  if (z === undefined && G.size > I.length >> 1) {
     warn(`Warning: the implicit z channel has high cardinality. This may occur when the fill or stroke channel is associated with quantitative data rather than ordinal or categorical data. You can suppress this warning by setting the z option explicitly; if this data represents a single series, set z to null.`);
   }
   return G.values();


### PR DESCRIPTION
I was thinking “fast divide by two”, not divide by four.