### PR TITLE
indexed bar shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,7 +770,7 @@ Returns a new horizontal bar↔︎ with the given *data* and *options*. The foll
 * **x1** - the starting horizontal position; bound to the *x* scale
 * **x2** - the ending horizontal position; bound to the *x* scale
 
-If neither the **x1** nor **x2** option is specified, the **x** option may be specified as shorthand to apply an implicit [stackX transform](#plotstackxstack-options); this is the typical configuration for a horizontal bar chart with bars aligned at *x* = 0. If the **x** option is not specified, it defaults to the identity function.
+If neither the **x1** nor **x2** option is specified, the **x** option may be specified as shorthand to apply an implicit [stackX transform](#plotstackxstack-options); this is the typical configuration for a horizontal bar chart with bars aligned at *x* = 0. If the **x** option is not specified, it defaults to the identity function. If *options* is undefined, then it defaults to **x2** as the identity function and **y** as the index of data; this allows an array of numbers to be passed to Plot.barX to make a quick sequential bar chart.
 
 If an **interval** is specified, such as d3.utcDay, **x1** and **x2** can be derived from **x**: *interval*.floor(*x*) is invoked for each *x* to produce *x1*, and *interval*.offset(*x1*) is invoked for each *x1* to produce *x2*. If the interval is specified as a number *n*, *x1* and *x2* are taken as the two consecutive multiples of *n* that bracket *x*.
 
@@ -791,7 +791,7 @@ Returns a new vertical bar↕︎ with the given *data* and *options*. The follow
 * **y1** - the starting vertical position; bound to the *y* scale
 * **y2** - the ending vertical position; bound to the *y* scale
 
-If neither the **y1** nor **y2** option is specified, the **y** option may be specified as shorthand to apply an implicit [stackY transform](#plotstackystack-options); this is the typical configuration for a vertical bar chart with bars aligned at *y* = 0. If the **y** option is not specified, it defaults to the identity function.
+If neither the **y1** nor **y2** option is specified, the **y** option may be specified as shorthand to apply an implicit [stackY transform](#plotstackystack-options); this is the typical configuration for a vertical bar chart with bars aligned at *y* = 0. If the **y** option is not specified, it defaults to the identity function. If *options* is undefined, then it defaults to **y2** as the identity function and **x** as the index of data; this allows an array of numbers to be passed to Plot.barY to make a quick sequential bar chart.
 
 If an **interval** is specified, such as d3.utcDay, **y1** and **y2** can be derived from **y**: *interval*.floor(*y*) is invoked for each *y* to produce *y1*, and *interval*.offset(*y1*) is invoked for each *y1* to produce *y2*. If the interval is specified as a number *n*, *y1* and *y2* are taken as the two consecutive multiples of *n* that bracket *y*.
 

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,6 +1,6 @@
 import {create} from "d3";
 import {Mark} from "../plot.js";
-import {number} from "../options.js";
+import {identity, indexOf, number} from "../options.js";
 import {isCollapsed} from "../scales.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, impliedString, applyAttr, applyChannelStyles} from "../style.js";
 import {maybeIdentityX, maybeIdentityY} from "../transforms/identity.js";
@@ -114,10 +114,10 @@ export class BarY extends AbstractBar {
   }
 }
 
-export function barX(data, options) {
+export function barX(data, options = {y: indexOf, x2: identity}) {
   return new BarX(data, maybeStackX(maybeIntervalX(maybeIdentityX(options))));
 }
 
-export function barY(data, options) {
+export function barY(data, options = {x: indexOf, y2: identity}) {
   return new BarY(data, maybeStackY(maybeIntervalY(maybeIdentityY(options))));
 }

--- a/test/marks/bar-test.js
+++ b/test/marks/bar-test.js
@@ -5,9 +5,9 @@ it("barX() has the expected defaults", () => {
   const bar = Plot.barX();
   assert.strictEqual(bar.data, undefined);
   // assert.strictEqual(bar.transform, undefined);
-  assert.deepStrictEqual(bar.channels.map(c => c.name), ["x1", "x2"]);
+  assert.deepStrictEqual(bar.channels.map(c => c.name), ["x1", "x2", "y"]);
   // assert.deepStrictEqual(bar.channels.map(c => Plot.valueof([1, 2, 3], c.value)), [[0, 0, 0], [1, 2, 3]]);
-  assert.deepStrictEqual(bar.channels.map(c => c.scale), ["x", "x"]);
+  assert.deepStrictEqual(bar.channels.map(c => c.scale), ["x", "x", "y"]);
   assert.strictEqual(bar.fill, undefined);
   assert.strictEqual(bar.fillOpacity, undefined);
   assert.strictEqual(bar.stroke, undefined);
@@ -99,9 +99,9 @@ it("barY() has the expected defaults", () => {
   const bar = Plot.barY();
   assert.strictEqual(bar.data, undefined);
   // assert.strictEqual(bar.transform, undefined);
-  assert.deepStrictEqual(bar.channels.map(c => c.name), ["y1", "y2"]);
+  assert.deepStrictEqual(bar.channels.map(c => c.name), ["y1", "y2", "x"]);
   // assert.deepStrictEqual(bar.channels.map(c => Plot.valueof([1, 2, 3], c.value)), [[0, 0, 0], [1, 2, 3]]);
-  assert.deepStrictEqual(bar.channels.map(c => c.scale), ["y", "y"]);
+  assert.deepStrictEqual(bar.channels.map(c => c.scale), ["y", "y", "x"]);
   assert.strictEqual(bar.fill, undefined);
   assert.strictEqual(bar.fillOpacity, undefined);
   assert.strictEqual(bar.stroke, undefined);

--- a/test/plots/ordinal-bar.js
+++ b/test/plots/ordinal-bar.js
@@ -6,7 +6,7 @@ export default async function() {
       grid: true
     },
     marks: [
-      Plot.barY("ABCDEF", {x: (d, i) => i, y2: d => d}),
+      Plot.barY("ABCDEF"),
       Plot.ruleY([0])
     ]
   });


### PR DESCRIPTION
Allows e.g. 

<img width="640" alt="Screen Shot 2022-02-24 at 3 25 50 PM" src="https://user-images.githubusercontent.com/230541/155624436-58aabcc6-85a1-4fed-a214-42743160ccac.png">

```js
Plot.barY(d3.range(20).map(Math.random)).plot()
```

The alternative in main is one-dimensional stacked bars, which typically isn’t very useful because all the bars will have the same color.

<img width="640" alt="Screen Shot 2022-02-24 at 3 27 24 PM" src="https://user-images.githubusercontent.com/230541/155624577-b26fad8a-690c-4119-8d69-dc77a8dcaa25.png">

