### PR TITLE
tuple area shorthand

### DIFF
--- a/src/marks/area.js
+++ b/src/marks/area.js
@@ -1,7 +1,7 @@
 import {area as shapeArea, create} from "d3";
 import {Curve} from "../curve.js";
 import {Mark} from "../plot.js";
-import {indexOf, maybeZ} from "../options.js";
+import {first, indexOf, maybeZ, second} from "../options.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyGroupedChannelStyles, groupIndex} from "../style.js";
 import {maybeIdentityX, maybeIdentityY} from "../transforms/identity.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
@@ -56,6 +56,7 @@ export class Area extends Mark {
 }
 
 export function area(data, options) {
+  if (options === undefined) return areaY(data, {x: first, y: second});
   return new Area(data, options);
 }
 


### PR DESCRIPTION
This allows e.g.

![untitled (12)](https://user-images.githubusercontent.com/230541/155754027-bd9544ae-7c07-47f6-9011-5a09976411da.png)

```js
Plot.area(timeSeries).plot()
```

Where `timeSeries` is an array of [date, number] tuples. This makes Plot.area consistent with Plot.line shorthand. Related #785.