### PR TITLE
fix emoji warning rendering in chrome

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -129,7 +129,8 @@ export function plot(options = {}) {
         .attr("y", 20)
         .attr("dy", "-1em")
         .attr("text-anchor", "end")
-        .text("⚠️")
+        .attr("font-family", "initial") // fix emoji rendering in Chrome
+        .text("\u26a0\ufe0f") // emoji variation selector
       .append("title")
         .text(`${w.toLocaleString("en-US")} warning${w === 1 ? "" : "s"}. Please check the console.`);
   }


### PR DESCRIPTION
We need the emoji [variation selector](https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)) and, apparently, to avoid the system-ui font.

Before:
<img width="640" alt="Screen Shot 2022-02-26 at 9 46 07 AM" src="https://user-images.githubusercontent.com/230541/155853644-7ca3b165-1f3f-466d-b373-5f0b260dd193.png">

After:
<img width="640" alt="Screen Shot 2022-02-26 at 9 45 51 AM" src="https://user-images.githubusercontent.com/230541/155853648-860c6ac1-cb9c-4e49-a7b9-c47d93ef80bf.png">
