### PR TITLE
add context for errors

### DIFF
--- a/src/legends.js
+++ b/src/legends.js
@@ -27,7 +27,7 @@ export function legend(options = {}) {
       );
     }
   }
-  throw new Error("unknown legend type");
+  throw new Error("unknown legend type; no scale found");
 }
 
 export function exposeLegends(scales, defaults = {}) {

--- a/src/plot.js
+++ b/src/plot.js
@@ -58,7 +58,7 @@ export function plot(options = {}) {
 
   // Initialize the marks’ channels, indexing them by mark and scale as needed.
   for (const mark of marks) {
-    if (stateByMark.has(mark)) throw new Error("duplicate mark");
+    if (stateByMark.has(mark)) throw new Error("duplicate mark; each mark must be unique");
     const markFacets = facets === undefined ? undefined
       : mark.facet === "auto" ? mark.data === facet.data ? facetsIndex : undefined
       : mark.facet === "include" ? facetsIndex
@@ -240,7 +240,7 @@ export class Mark {
       }
       if (name == null) throw new Error("missing channel name");
       const key = `${name}`;
-      if (key === "__proto__") throw new Error("illegal channel name");
+      if (key === "__proto__") throw new Error(`illegal channel name: ${key}`);
       if (names.has(key)) throw new Error(`duplicate channel: ${key}`);
       names.add(key);
       return true;
@@ -292,7 +292,7 @@ class Render extends Mark {
   constructor(render) {
     super();
     if (render == null) return;
-    if (typeof render !== "function") throw new TypeError("invalid mark");
+    if (typeof render !== "function") throw new TypeError("invalid mark; missing render function");
     this.render = render;
   }
   render() {}

--- a/src/scales.js
+++ b/src/scales.js
@@ -45,7 +45,7 @@ export function Scales(channels, {
           insetLeft = inset !== undefined ? inset : key === "x" ? globalInsetLeft : 0 // not fx
         } = scaleOptions || {};
         if (transform == null) transform = undefined;
-        else if (typeof transform !== "function") throw new Error("invalid scale transform");
+        else if (typeof transform !== "function") throw new Error(`invalid scale transform; not a function`);
         scale.percent = !!percent;
         scale.transform = transform;
         if (key === "x" || key === "fx") {
@@ -385,10 +385,10 @@ export function scale(options = {}) {
   for (const key in options) {
     if (!registry.has(key)) continue; // ignore unknown properties
     if (!isScaleOptions(options[key])) continue; // e.g., ignore {color: "red"}
-    if (scale !== undefined) throw new Error("ambiguous scale definition");
+    if (scale !== undefined) throw new Error("ambiguous scale definition; multiple scales found");
     scale = exposeScale(normalizeScale(key, options[key]));
   }
-  if (scale === undefined) throw new Error("invalid scale definition");
+  if (scale === undefined) throw new Error("invalid scale definition; no scale found");
   return scale;
 }
 

--- a/src/scales/quantitative.js
+++ b/src/scales/quantitative.js
@@ -150,7 +150,7 @@ export function ScaleThreshold(key, channels, {
   range = interpolate !== undefined ? quantize(interpolate, domain.length + 1) : registry.get(key) === color ? ordinalRange(scheme, domain.length + 1) : undefined,
   reverse
 }) {
-  if (!pairs(domain).every(([a, b]) => ascending(a, b) <= 0)) throw new Error("non-ascending domain");
+  if (!pairs(domain).every(([a, b]) => ascending(a, b) <= 0)) throw new Error(`the ${key} scale has a non-ascending domain`);
   if (reverse) range = reverseof(range); // domain ascending, so reverse range
   return {type: "threshold", scale: scaleThreshold(domain, range === undefined ? [] : range).unknown(unknown), domain, range};
 }

--- a/src/style.js
+++ b/src/style.js
@@ -244,7 +244,7 @@ export function* groupIndex(I, position, {z}, channels) {
 export function maybeClip(clip) {
   if (clip === true) return "frame";
   if (clip == null || clip === false) return false;
-  throw new Error(`clip method not implemented: ${clip}`);
+  throw new Error(`invalid clip method: ${clip}`);
 }
 
 export function applyIndirectStyles(selection, mark, {width, height, marginLeft, marginRight, marginTop, marginBottom}) {

--- a/src/transforms/bin.js
+++ b/src/transforms/bin.js
@@ -242,7 +242,7 @@ function maybeThresholds(thresholds, interval) {
       case "sturges": return thresholdSturges;
       case "auto": return thresholdAuto;
     }
-    throw new Error("invalid thresholds");
+    throw new Error(`invalid thresholds: ${thresholds}`);
   }
   return thresholds; // pass array, count, or function to bin.thresholds
 }
@@ -250,7 +250,7 @@ function maybeThresholds(thresholds, interval) {
 // Unlike the interval transform, we require a range method, too.
 function maybeRangeInterval(interval) {
   interval = maybeInterval(interval);
-  if (!isInterval(interval)) throw new Error("invalid interval");
+  if (!isInterval(interval)) throw new Error(`invalid interval: ${interval}`);
   return interval;
 }
 

--- a/src/transforms/group.js
+++ b/src/transforms/group.js
@@ -223,7 +223,7 @@ export function maybeReduce(reduce, value) {
     case "y1": return reduceY1;
     case "y2": return reduceY2;
   }
-  throw new Error("invalid reduce");
+  throw new Error(`invalid reduce: ${reduce}`);
 }
 
 export function maybeSubgroup(outputs, Z, F, S) {

--- a/src/transforms/interval.js
+++ b/src/transforms/interval.js
@@ -16,7 +16,7 @@ export function maybeInterval(interval) {
       range: (lo, hi) => range(Math.ceil(lo / n), hi / n).map(x => n * x)
     };
   }
-  if (typeof interval.floor !== "function" || typeof interval.offset !== "function") throw new Error("invalid interval");
+  if (typeof interval.floor !== "function" || typeof interval.offset !== "function") throw new Error("invalid interval; missing floor or offset function");
   return interval;
 }
 

--- a/src/transforms/map.js
+++ b/src/transforms/map.js
@@ -46,7 +46,7 @@ function maybeMap(map) {
     case "rank": return mapFunction(rank);
     case "quantile": return mapFunction(rankQuantile);
   }
-  throw new Error("invalid map");
+  throw new Error(`invalid map: ${map}`);
 }
 
 function rankQuantile(V) {
@@ -58,7 +58,7 @@ function mapFunction(f) {
   return {
     map(I, S, T) {
       const M = f(take(S, I));
-      if (M.length !== I.length) throw new Error("mismatched length");
+      if (M.length !== I.length) throw new Error("map function returned a mismatched length");
       for (let i = 0, n = I.length; i < n; ++i) T[I[i]] = M[i];
     }
   };

--- a/src/transforms/normalize.js
+++ b/src/transforms/normalize.js
@@ -28,7 +28,7 @@ export function normalize(basis) {
     case "sum": return normalizeSum;
     case "extent": return normalizeExtent;
   }
-  throw new Error("invalid basis");
+  throw new Error(`invalid basis: ${basis}`);
 }
 
 function normalizeBasis(basis) {

--- a/src/transforms/select.js
+++ b/src/transforms/select.js
@@ -19,10 +19,10 @@ export function select(selector, options = {}) {
   // channel values as input. The selector object must have exactly one key.
   let key, value;
   for (key in selector) {
-    if (value !== undefined) throw new Error("ambiguous select definition");
+    if (value !== undefined) throw new Error("ambiguous selector; multiple inputs");
     value = maybeSelector(selector[key]);
   }
-  if (value === undefined) throw new Error("invalid select definition");
+  if (value === undefined) throw new Error(`invalid selector: ${selector}`);
   return selectChannel(key, value, options);
 }
 

--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -225,7 +225,7 @@ function maybeOrder(order, offset, ky) {
   }
   if (typeof order === "function") return orderFunction(order);
   if (Array.isArray(order)) return orderGiven(order);
-  throw new Error("invalid order");
+  throw new Error(`invalid order: ${order}`);
 }
 
 // by value

--- a/src/transforms/window.js
+++ b/src/transforms/window.js
@@ -20,7 +20,7 @@ export function window(options = {}) {
     anchor = maybeShift(shift);
     warn(`Warning: the shift option is deprecated; please use anchor "${anchor}" instead.`);
   }
-  if (!((k = Math.floor(k)) > 0)) throw new Error("invalid k");
+  if (!((k = Math.floor(k)) > 0)) throw new Error(`invalid k: ${k}`);
   return maybeReduce(reduce)(k, maybeAnchor(anchor, k));
 }
 
@@ -30,7 +30,7 @@ function maybeAnchor(anchor = "middle", k) {
     case "start": return 0;
     case "end": return k - 1;
   }
-  throw new Error("invalid anchor");
+  throw new Error(`invalid anchor: ${anchor}`);
 }
 
 function maybeShift(shift) {
@@ -39,7 +39,7 @@ function maybeShift(shift) {
     case "leading": return "start";
     case "trailing": return "end";
   }
-  throw new Error("invalid shift");
+  throw new Error(`invalid shift: ${shift}`);
 }
 
 function maybeReduce(reduce = "mean") {
@@ -60,7 +60,7 @@ function maybeReduce(reduce = "mean") {
       case "last": return reduceLast;
     }
   }
-  if (typeof reduce !== "function") throw new Error("invalid reduce");
+  if (typeof reduce !== "function") throw new Error(`invalid reduce: ${reduce}`);
   return reduceSubarray(reduce);
 }
 


### PR DESCRIPTION
Before

```
Error: invalid reduce
```

After

```
Error: invalid reduce: avg
```

This should make it easier to track down errors.