### PR TITLE
trivial intervals for rect

### DIFF
--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -4,7 +4,7 @@ import {Mark} from "../plot.js";
 import {isCollapsed} from "../scales.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, impliedString, applyAttr, applyChannelStyles} from "../style.js";
 import {maybeIdentityX, maybeIdentityY} from "../transforms/identity.js";
-import {maybeIntervalX, maybeIntervalY} from "../transforms/interval.js";
+import {maybeTrivialIntervalX, maybeTrivialIntervalY} from "../transforms/interval.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
 
 const defaults = {
@@ -68,13 +68,13 @@ export class Rect extends Mark {
 }
 
 export function rect(data, options) {
-  return new Rect(data, maybeIntervalX(maybeIntervalY(options)));
+  return new Rect(data, maybeTrivialIntervalX(maybeTrivialIntervalY(options)));
 }
 
 export function rectX(data, options = {y: indexOf, interval: 1, x2: identity}) {
-  return new Rect(data, maybeStackX(maybeIntervalY(maybeIdentityX(options))));
+  return new Rect(data, maybeStackX(maybeTrivialIntervalY(maybeIdentityX(options))));
 }
 
 export function rectY(data, options = {x: indexOf, interval: 1, y2: identity}) {
-  return new Rect(data, maybeStackY(maybeIntervalX(maybeIdentityY(options))));
+  return new Rect(data, maybeStackY(maybeTrivialIntervalX(maybeIdentityY(options))));
 }

--- a/test/output/groupedRects.svg
+++ b/test/output/groupedRects.svg
@@ -1,0 +1,95 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis" aria-description="↑ Frequency" transform="translate(40,0)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,370.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.0</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,335.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.1</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,300.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.2</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,265.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.3</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,230.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.4</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,195.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.5</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,160.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.6</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,125.50000000000001)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.7</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,90.49999999999999)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.8</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,55.49999999999999)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0.9</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,20.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">1.0</text>
+    </g><text fill="currentColor" transform="translate(-40,20)" dy="-1em" text-anchor="start">↑ Frequency</text>
+  </g>
+  <g aria-label="x-axis" transform="translate(0,370)" fill="none" text-anchor="middle">
+    <g class="tick" opacity="1" transform="translate(69.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">A</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(127.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">B</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(185.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">C</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(243.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">D</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(301.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">E</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(359.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">F</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(417.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">G</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(475.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">H</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(533.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">I</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(591.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">J</text>
+    </g>
+  </g>
+  <g aria-label="rect">
+    <rect x="69" y="20" width="0" height="350"></rect>
+    <rect x="127" y="20" width="0" height="350"></rect>
+    <rect x="185" y="20" width="0" height="350"></rect>
+    <rect x="243" y="20" width="0" height="350"></rect>
+    <rect x="301" y="20" width="0" height="350"></rect>
+    <rect x="359" y="20" width="0" height="350"></rect>
+    <rect x="417" y="20" width="0" height="350"></rect>
+    <rect x="475" y="20" width="0" height="350"></rect>
+    <rect x="533" y="20" width="0" height="350"></rect>
+    <rect x="591" y="20" width="0" height="350"></rect>
+  </g>
+</svg>

--- a/test/plots/grouped-rects.js
+++ b/test/plots/grouped-rects.js
@@ -1,0 +1,9 @@
+import * as Plot from "@observablehq/plot";
+
+export default async function() {
+  return Plot.plot({
+    marks: [
+      Plot.rectY({length: 10}, Plot.groupX({y: "count"}, {x: (d, i) => "ABCDEFGHIJ"[i]}))
+    ]
+  });
+}

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -61,6 +61,7 @@ export {default as gistempAnomalyMoving} from "./gistemp-anomaly-moving.js";
 export {default as gistempAnomalyTransform} from "./gistemp-anomaly-transform.js";
 export {default as googleTrendsRidgeline} from "./google-trends-ridgeline.js";
 export {default as gridChoropleth} from "./grid-choropleth.js";
+export {default as groupedRects} from "./grouped-rects.js";
 export {default as hadcrutWarmingStripes} from "./hadcrut-warming-stripes.js";
 export {default as highCardinalityOrdinal} from "./high-cardinality-ordinal.js";
 export {default as identityScale} from "./identity-scale.js";


### PR DESCRIPTION
E.g. promotes *x* to *x1* and *x2* if the latter two are not specified.

~~I’m not sure why the aaplMonthly snapshot changed.~~ 🤔 Update: Fil figured it out.