### PR TITLE
"sort fy by x" bug

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -25,6 +25,7 @@ export function channelSort(channels, facetChannels, data, options) {
     const X = channels.find(([, {scale}]) => scale === x) || facetChannels && facetChannels.find(([, {scale}]) => scale === x);
     if (!X) throw new Error(`missing channel for scale: ${x}`);
     const XV = X[1].value;
+    // const XV = x === "fy" || x === "fx" ? [...new Set(X[1].value)] : X[1].value;
     const [lo = 0, hi = Infinity] = limit && typeof limit[Symbol.iterator] === "function" ? limit : limit < 0 ? [limit] : [0, limit];
     if (y == null) {
       X[1].domain = () => {

--- a/test/data/actor_character_age_difference.csv
+++ b/test/data/actor_character_age_difference.csv
@@ -1,0 +1,244 @@
+name,birthday,title,character_name,character_year,characterage,character_gender,love_interest,release_date,actor_age,character_age,age_difference
+Ben Platt,1993-09-24,The Politician,Payton Hobart,hs senior,,M,"Alice Charles, Astrid Sloan, River Barkley",2019-09-27,26,17,9
+Zoey Deutch,1994-11-10,The Politician,Infinity Jackson,hs senior,,F,,2019-09-27,24,17,7
+Lucy Boynton,1994-01-17,The Politician,Astrid Sloan,hs senior,,F,"Payton Hobart, River Barkley",2019-09-27,25,17,8
+Julia Schlaepfer,1995-03-03,The Politician,Alice Charles,hs senior,,F,"Payton Hobart, James Sullivan",2019-09-27,24,17,7
+Laura Dreyfuss,1988-08-22,The Politician,McAfee Westbrook,hs senior,,F,Skye Leighton,2019-09-27,31,17,14
+Theo Germaine,,The Politician,James Sullivan,hs senior,,M,Alice Charles,2019-09-27,,17,
+Rahne Jones,1987-05-04,The Politician,Skye Leighton,hs senior,,NB,McAfee Westbrook,2019-09-27,32,17,15
+David Corenswet,1993-07-08,The Politician,River Barkley,hs senior,,M,"Astrid Sloan, Payton Hobart",2019-09-27,26,17,9
+Ryan J. Haddad,1992-01-03,The Politician,Andrew Cashman,hs senior,,M,,2019-09-27,27,17,10
+Alexis Bledel,1981-09-16,Gilmore Girls,Rory Gilmore,hs sophomore,,F,Dean Forester,2000-10-05,19,15,4
+Keiko Agena,1973-10-03,Gilmore Girls,Lane Kim,hs sophomore,,F,,2000-10-05,27,15,12
+Liza Weil,1977-06-05,Gilmore Girls,Paris Geller,hs sophomore,,F,,2000-10-05,23,15,8
+Jared Padalecki,1982-07-19,Gilmore Girls,Dean Forester,hs sophomore,,M,Rory Gilmore,2000-10-05,18,15,3
+Teal Redmann,1982-09-30,Gilmore Girls,Louise Grant,hs sophomore,,F,,2000-10-05,18,15,3
+Shelly Cole,1975-08-22,Gilmore Girls,Madeline Lynn,hs sophomore,,F,,2000-10-05,25,15,10
+Chad Michael Murray,1981-08-24,Gilmore Girls,Tristin Dugray,hs sophomore,,M,,2000-10-05,19,15,4
+Asa Butterfield,1997-04-01,Sex Education,Otis Milburn,,16,M,"Maeve Wiley, Lily Iglehart, Ola Nyman",2019-01-11,21,16,5
+Ncuti Gatwa,1992-10-15,Sex Education,Eric Effiong,,16,M,Adam Groff,2019-01-11,26,16,10
+Emma Mackey,1996-01-04,Sex Education,Maeve Wiley,,16,F,"Otis Milburn, Jackson Marchetti",2019-01-11,23,16,7
+Connor Swindells,1996-09-19,Sex Education,Adam Groff,,16,M,"Eric Effiong, Aimee Gibbs",2019-01-11,22,16,6
+Kedar Williams-Stirling,1994-12-14,Sex Education,Jackson Marchetti,,16,M,Maeve Wiley,2019-01-11,24,16,8
+Aimee Lou Wood,1995-02-03,Sex Education,Aimee Gibbs,,16,F,Adam Groff,2019-01-11,23,16,7
+Tanya Reynolds,1991-11-04,Sex Education,Lily Iglehart,,16,F,Otis Milburn,2019-01-11,27,16,11
+Patricia Allison,1994-12-07,Sex Education,Ola Nyman,,16,F,Otis Milburn,2019-01-11,24,16,8
+Mimi Keene,1998-08-05,Sex Education,Ruby Matthews,,16,F,,2019-01-11,20,16,4
+Simone Ashley,1995-03-30,Sex Education,Olivia Hanan,,16,F,,2019-01-11,23,16,7
+Chaneil Kular,1999-08-20,Sex Education,Anwar,,16,M,,2019-01-11,19,16,3
+Kiernan Shipka,1999-11-10,Chilling Adventures of Sabrina,Sabrina Spellman,,17,F,"Harvey Kinkle, Nicholas Scratch",2018-10-26,18,17,1
+Ross Lynch,1995-12-29,Chilling Adventures of Sabrina,Harvey Kinkle,hs junior,,M,Sabrina Spelllman,2018-10-26,22,16,6
+Jaz Sinclair,1994-07-22,Chilling Adventures of Sabrina,Rosalind Walker,hs junior,,F,,2018-10-26,24,16,8
+Tati Gabrielle,1996-01-24,Chilling Adventures of Sabrina,Prudence Night,hs junior,,F,,2018-10-26,22,16,6
+Adeline Rudolph,1995-02-10,Chilling Adventures of Sabrina,Agatha,hs junior,,F,,2018-10-26,23,16,7
+Lachlan Watson,2001-04-12,Chilling Adventures of Sabrina,Theo Putnam,hs junior,,TM,,2018-10-26,17,16,1
+Gavin Leatherwood,1994-06-07,Chilling Adventures of Sabrina,Nicholas Scratch,hs junior,,M,Sabrina Spellman,2018-10-26,24,16,8
+Abigail Cowen,1998-03-18,Chilling Adventures of Sabrina,Dorcas,hs junior,,F,,2018-10-26,20,16,4
+Jahi Di'Allo Winston,2003-11-30,Everything Sucks!,Luke O'Neil,hs freshman,,M,Kate Messner,2018-02-16,14,14,0
+Peyton Kennedy,2004-01-04,Everything Sucks!,Kate Messner,hs sophomore,,F,Emaline Addario,2018-02-16,14,15,-1
+Quinn Liebling,2003-03-20,Everything Sucks!,Tyler,hs freshman,,M,,2018-02-16,14,14,0
+Elijah Stevenson,1998-09-12,Everything Sucks!,Oliver,hs senior,,M,Emaline Addario,2018-02-16,19,17,2
+Rio Mangini,2002-10-06,Everything Sucks!,McQuaid,hs freshman,,M,,2018-02-16,15,14,1
+Sydney Sweeney,1997-09-12,Everything Sucks!,Emaline Addario,hs junior,,F,"Oliver, Kate Messner",2018-02-16,20,16,4
+Abi Brittle,2000-05-26,Everything Sucks!,Leslie,hs sophomore,,F,,2018-02-16,17,15,2
+Chris Colfer,1990-05-27,Glee,Kurt Hummel,hs sophomore,,M,,2009-05-19,18,15,3
+Lea Michele,1986-08-29,Glee,Rachel Berry,hs sophomore,,F,Finn Hudson,2009-05-19,22,15,7
+Kevin McHale,1988-06-14,Glee,Artie Abrams,hs freshman,,M,,2009-05-19,20,14,6
+Naya Rivera,1987-01-12,Glee,Santana Lopez,hs sophomore,,F,Noah 'Puck' Puckerman,2009-05-19,22,15,7
+Jenna Ushkowitz,1986-04-28,Glee,Tina Cohen-Chang,hs freshman,,F,,2009-05-19,23,14,9
+Amber Riley,1986-02-15,Glee,Mercedes Jones,hs sophomore,,F,,2009-05-19,23,15,8
+Mark Salling,1982-08-17,Glee,Noah 'Puck' Puckerman,hs sophomore,,M,"Quinn Fabray, Santana Lopez",2009-05-19,26,15,11
+Heather Morris,1987-02-01,Glee,Brittany S. Pierce,hs sophomore,,F,,2009-05-19,22,15,7
+Harry Shum Jr.,1982-04-28,Glee,Mike Chang,hs sophomore,,M,,2009-05-19,27,15,12
+Cory Monteith,1982-05-11,Glee,Finn Hudson,hs sophomore,,M,"Rachel Berry, Quinn Fabray",2009-05-19,27,15,12
+Dianna Agron,1986-04-30,Glee,Quinn Fabray,hs sophomore,,F,"Finn Hudson, Noah 'Puck' Puckerman",2009-05-19,23,15,8
+Lauren Potter,1990-05-10,Glee,Becky Jackson,hs sophomore,,F,,2009-05-19,19,15,4
+Finn Wolfhard,2002-12-23,Stranger Things,Michael 'Mike' Wheeler,7th grade,,M,,2016-07-15,13,12,1
+Millie Bobby Brown,2004-02-19,Stranger Things,Eleven,7th grade,,F,,2016-07-15,12,12,0
+Gaten Matarazzo,2002-09-08,Stranger Things,Dustin Henderson,7th grade,,M,,2016-07-15,13,12,1
+Caleb McLaughlin,2001-10-13,Stranger Things,Lucas Sinclair,7th grade,,M,,2016-07-15,14,12,2
+Natalia Dyer,1995-01-13,Stranger Things,Nancy Wheeler,hs senior,,F,Steve Harrington,2016-07-15,21,17,4
+Charlie Heaton,1994-02-06,Stranger Things,Jonathon Byers,hs senior,,M,,2016-07-15,22,17,5
+Joe Keery,1992-04-24,Stranger Things,Steve Harrington,hs senior,,M,Nancy Wheeler,2016-07-15,24,17,7
+Noah Schnapp,2004-10-03,Stranger Things,Will Byers,7th grade,,M,,2016-07-15,11,12,-1
+Sophia Lillis,2002-02-13,I Am Not Okay With This,Sydney Novak,hs junior,,F,,2020-02-26,18,16,2
+Wyatt Oleff,2003-07-13,I Am Not Okay With This,Stanley Barber,hs junior,,M,,2020-02-26,16,16,0
+Sofia Bryant,1999-12-26,I Am Not Okay With This,Dina,hs junior,,F,,2020-02-26,20,16,4
+Richard Ellis,1994-03-12,I Am Not Okay With This,Brad Lewis,hs junior,,M,,2020-02-26,25,16,9
+Zachary S. Williams,1999-11-05,I Am Not Okay With This,Rick Berry,hs junior,,M,,2020-02-26,20,16,4
+Keir Gilchrist,1992-09-28,Atypical,Sam Gardner,hs senior,,M,,2017-08-11,24,17,7
+Brigette Lundy-Paine,1994-08-10,Atypical,Casey Gardner,hs sophomore,,F,Evan Chapin,2017-08-11,23,15,8
+Graham Rogers,1990-12-16,Atypical,Evan Chapin,,16,M,Casey Gardner,2017-08-11,26,16,10
+Jenna Boyd,1993-03-04,Atypical,Paige,hs senior,,F,,2017-08-11,24,17,7
+Colin Ford,1996-09-12,Daybreak,Josh Wheeler,hs junior,,M,"Samaira 'Sam' Dean, KJ",2019-10-24,23,16,7
+Alyvia Alyn Lind,2007-07-27,Daybreak,Angelica Green,6th grade,,F,,2019-10-24,12,11,1
+Sophie Simnett,1997-12-05,Daybreak,Samaira 'Sam' Dean,hs junior,,F,Josh Wheeler,2019-10-24,21,16,5
+Austin Crute,1995-10-24,Daybreak,Wesley Fists,hs junior,,M,,2019-10-24,24,16,8
+Cody Kearsley,1991-03-10,Daybreak,Turbo Pokaski,hs senior,,M,,2019-10-24,28,17,11
+Jeanté Godlock,1988-04-24,Daybreak,Mona Lisa,hs junior,,F,,2019-10-24,31,16,15
+Gregory Kasyan,2001-04-12,Daybreak,Eli Cardashyan,hs senior,,M,,2019-10-24,18,17,1
+Charlie Plummer,1999-05-24,Looking for Alaska,Miles 'Pudge' Halter,hs junior,,M,"Alaska Young, Lara Buterskaya",2019-10-18,20,16,4
+Kristine Froseth,1995-09-21,Looking for Alaska,Alaska Young,hs junior,,F,"Miles 'Pudge' Halter, Jake",2019-10-18,24,16,8
+Denny Love,,Looking for Alaska,Chip 'The Colonel' Martin,hs junior,,M,Sara Bankhead Harbert,2019-10-18,,16,
+Jay Lee,,Looking for Alaska,Takumi Hikohito,hs junior,,M,,2019-10-18,,16,
+Sofia Vassilieva,1992-10-22,Looking for Alaska,Lara Buterskaya,hs junior,,F,Miles 'Pudge' Halter,2019-10-18,26,16,10
+Landry Bender,2000-08-03,Looking for Alaska,Sara Bankhead Harbert,hs junior,,F,Chip 'The Colonel' Martin,2019-10-18,19,16,3
+Shailene Woodley,1991-11-15,Secret Life of the American Teenager,Amy Juergens,hs freshman,,F,"Ben Boykewich, Ricky Underwood",2008-07-01,16,14,2
+Ken Baumann,1989-08-08,Secret Life of the American Teenager,Ben Boykewich,hs freshman,,M,"Amy Juergens, Adrian Lee",2008-07-01,18,14,4
+Daren Kagasoff,1987-09-16,Secret Life of the American Teenager,Ricky Underwood,hs sophomore,,M,Amy Juergens,2008-07-01,20,15,5
+Francia Raisa,1988-07-26,Secret Life of the American Teenager,Adrian Lee,hs sophomore,,F,"Ben Boykewich, Ricky Underwood, Jack Pappas",2008-07-01,19,15,4
+Megan Park,1986-07-24,Secret Life of the American Teenager,Grace Bowman,hs senior,,F,Jack Pappas,2008-07-01,21,17,4
+Greg Finley,1984-12-22,Secret Life of the American Teenager,Jack Pappas,college freshman,,M,"Grace Bowman, Adrian Lee",2008-07-01,23,18,5
+Camille Winbush,1990-02-09,Secret Life of the American Teenager,Lauren Treacy,hs freshman,,F,,2008-07-01,18,14,4
+Renee Olstead,1989-06-18,Secret Life of the American Teenager,Madison Cooperstein,hs freshman,,F,,2008-07-01,19,14,5
+Marlo Kelly,,Dare Me,Beth Cassidy,,,F,Addy Hanlon,2019-12-29,,,
+Herizen Guardiola,1996-07-24,Dare Me,Addy Hanlon,,,F,Beth Cassidy,2019-12-29,23,,
+Alison Thornton,1999-08-14,Dare Me,Tacy Cassidy,hs freshman,,F,,2019-12-29,20,14,6
+Eliza Taylor,1989-10-24,The 100,Clarke Griffin,,17,F,Finn Collins,2014-03-19,24,17,7
+Thomas McDonell,1986-05-02,The 100,Finn Collins,,17,M,"Clarke Griffin, Raven Rayes",2014-03-19,27,17,10
+Eli Goree,,The 100,Wells Jaha,,17,M,,2014-03-19,,17,
+Marie Avgeropoulos,1986-06-17,The 100,Octavia Blake,,17,F,Lincoln,2014-03-19,27,17,10
+Bob Morley,1984-12-20,The 100,Bellamy Blake,,23,M,,2014-03-19,29,23,6
+Christopher Larkin,1987-10-02,The 100,Monty Green,,16,M,,2014-03-19,26,16,10
+Devon Bostick,1991-11-13,The 100,Jasper Jordan,,16,M,,2014-03-19,22,16,6
+Lindsey Morgan,1990-02-27,The 100,Raven Reyes,,19,F,Finn Collins,2014-03-19,24,19,5
+Richard Harmon,1991-08-18,The 100,John Murphy,,17,M,,2014-03-19,22,17,5
+Ricky Whittle,1981-12-31,The 100,Lincoln,,25,M,Octavia Blake,2014-03-19,32,25,7
+Jarod Joseph,1985-10-09,The 100,Nathan Miller,,18,M,,2014-03-19,28,18,10
+Victor Zinck Jr.,,The 100,Dax,,17,M,,2014-03-19,,17,
+Kathryn Newton,1997-02-08,The Society,Allie Pressman,,17,F,"Will LeClair, Harry Bingham",2019-05-10,22,17,5
+Rachel Keller,1992-12-25,The Society,Cassandra Pressman,,18,F,,2019-05-10,26,18,8
+Jacques Colimon,1994-08-27,The Society,Will LeClair,,17,M,"Kelly Aldrich, Allie Pressman",2019-05-10,24,17,7
+Alex Fitzalan,1996-04-26,The Society,Harry Bingham,,17,M,,2019-05-10,23,17,6
+Kristine Froseth,1995-09-21,The Society,Kelly Aldrich,,17,F,"Harry Bingham, Will LeClair",2019-05-10,23,17,6
+Gideon Adlon,1997-03-30,The Society,Becca Gelb,,17,F,,2019-05-10,22,17,5
+Olivia DeJonge,1998-04-30,The Society,Elle Tomkins,,17,F,Campbell Eliot,2019-05-10,21,17,4
+Toby Wallace,1996-06-07,The Society,Campbell Eliot,,18,M,Elle Tomkins,2019-05-10,22,18,4
+José Julián,,The Society,Gordie Moreno,,17,M,,2019-05-10,,17,
+Jack Mulhern,,The Society,"Gareth ""Grizz"" Visser",,17,M,Sam Eliot,2019-05-10,,17,
+Olivia Nikkanen,1998-11-28,The Society,Gwen Patterson,,17,F,Clark,2019-05-10,20,17,3
+Natasha Liu Bordizzo,1994-08-25,The Society,Helena Wu,,17,F,Luke Holbrook,2019-05-10,24,17,7
+Alex MacNicoll,,The Society,Luke Holbrook,,18,M,Helena Wu,2019-05-10,,18,
+Sean Berdy,1993-06-03,The Society,Sam Eliot,,17,M,"Gareth ""Grizz"" Visser",2019-05-10,25,17,8
+KJ Apa,1997-06-17,Riverdale,Archie Andrews,,18,M,,2017-01-26,19,18,1
+Lili Reinhart,1996-09-13,Riverdale,Betty Cooper,,18,F,Jughead Jones,2017-01-26,20,18,2
+Camila Mendes,1994-06-29,Riverdale,Veronica Lodge,,18,F,,2017-01-26,22,18,4
+Cole Sprouse,1992-08-04,Riverdale,Jughead Jones,,18,M,Betty Cooper,2017-01-26,24,18,6
+Madelaine Petsch,1994-08-18,Riverdale,Cheryl Blossom,,19,F,,2017-01-26,22,19,3
+Dylan Minnette,1996-12-29,13 Reasons Why,Clay Jensen,,16,M,,2017-03-21,20,16,4
+Katherine Langford,1996-04-28,13 Reasons Why,Hannah Baker,,17,F,,2017-03-21,20,17,3
+Christian Navarro,1991-08-21,13 Reasons Why,Tony Padilla,,17,M,,2017-03-21,25,17,8
+Alisha Boe,1997-03-06,13 Reasons Why,Jessica Davis,,16,F,"Justin Foley, Alex Baker",2017-03-21,20,16,4
+Brandon Flynn,1993-10-11,13 Reasons Why,Justin Foley,,16,M,Jessica Davis,2017-03-21,23,16,7
+Justin Prentice,1994-03-25,13 Reasons Why,Bryce Walker,hs senior,18,M,,2017-03-21,22,17,5
+Miles Heizer,1994-05-16,13 Reasons Why,Alex Standall,,17,M,"Jessica Davis, Zach Dempsey",2017-03-21,22,17,5
+Ross Butler,1990-05-17,13 Reasons Why,Zach Dempsey,,17,M,"Hannah Baker, Alex Standall",2017-03-21,26,17,9
+Devin Druid,1998-01-27,13 Reasons Why,Tyler Down,,16,M,,2017-03-21,19,16,3
+Saoirse-Monica Jackson,1993-11-24,Derry Girls,Erin Quinn,5th Year,,F,,2017-03-21,23,17,6
+Louisa Harlond,1993-01-31,Derry Girls,Orla McCool,,15,F,,2017-03-21,24,15,9
+Jamie Lee O'Donnell,1987-03-04,Derry Girls,Michelle Mallon,5th Year,,F,,2017-03-21,30,17,13
+Nicola Coughlan,1987-01-09,Derry Girls,Clare Devlin,5th Year,,F,,2017-03-21,30,17,13
+Dylan Llewellyn,1992-09-10,Derry Girls,James Maguire,5th Year,,M,,2017-03-21,24,17,7
+Blake Lively,1987-08-25,Gossip Girl,Serena van der Woodsen,,16,F,"Dan Humphrey, Nate Archibald",2007-09-19,20,16,4
+Leighton Meester,1986-04-09,Gossip Girl,Blair Waldorf,,16,F,"Nate Archibald, Chuck Bass",2007-09-19,21,16,5
+Penn Badgley,1986-11-01,Gossip Girl,Dan Humphrey,,16,M,Serena van der Woodsen,2007-09-19,20,16,4
+Chace Crawford,1985-07-18,Gossip Girl,Nate Archibald,,16,M,"Blair Waldorf, Serena van der Woodsen",2007-09-19,22,16,6
+Ed Westwick,1987-06-27,Gossip Girl,Chuck Bass,,16,M,"Blair Waldorf, Jenny Humphrey",2007-09-19,20,16,4
+Taylor Momsen,1993-07-26,Gossip Girl,Jenny Humphrey,,14,F,"Nate Archibald, Chuck Bass",2007-09-19,14,14,0
+Jessica Szohr,1985-03-31,Gossip Girl,Vanessa Abrams,,16,F,"Nate Archibald, Dan Humphrey",2007-09-19,22,16,6
+Emily Alyn Lynd,2001-05-06,Gossip Girl Revival,Audrey Hope,,16,F,"Akeno ""Aki"" Menzies",2021-07-08,20,16,4
+Jordan Alexander,1993-07-27,Gossip Girl Revival,Julien Calloway,hs junior,,F,"Otto ""Obie"" Bergmann IV",2021-07-08,27,16,11
+Thomas Doherty,1995-04-21,Gossip Girl Revival,Max Wolfe,,17,M,,2021-07-08,26,17,9
+Savannah Smith,2000-07-27,Gossip Girl Revival,Monet de Haan,,16,F,,2021-07-08,20,16,4
+Evan Mock,1997-04-08,Gossip Girl Revival,"Akeno ""Aki"" Menzies",,16,M,Audrey Hope,2021-07-08,24,16,8
+Zion Moreno,1995-02-23,Gossip Girl Revival,Luna La,,16,F,,2021-07-08,26,16,10
+Whitney Peak,2003-01-28,Gossip Girl Revival,Zoya Lott,,15,F,"Otto ""Obie"" Bergmann IV",2021-07-08,18,15,3
+Eli Brown,1999-08-13,Gossip Girl Revival,"Otto ""Obie"" Bergmann IV",,16,M,"Zoya Lott, Julien Calloway",2021-07-08,21,16,5
+Mia Healey,,The Wilds,Shelby Goodkind,,17,F,Toni Shalifoe,2020-12-11,,17,
+Helena Howard,1998-07-23,The Wilds,Nora Reid,,17,F,,2020-12-11,22,17,5
+Erana James,1999-02-17,The Wilds,Toni Shalifoe,,17,F,,2020-12-11,21,17,4
+Sarah Pidgeon,,The Wilds,Leah Rilke,,17,F,,2020-12-11,,17,
+Jenna Clause,1999-02-20,The Wilds,Martha Blackburn,,16,F,,2020-12-11,21,16,5
+Sophia Ali,1995-11-07,The Wilds,Fatin Jadmani,,17,F,,2020-12-11,25,17,8
+Shannon Berry,,The Wilds,Dot Campbell,,17,F,,2020-12-11,,17,
+Reign Edwards,1996-12-01,The Wilds,Rachel Reid,,17,F,,2020-12-11,24,17,7
+Chase Stokes,1992-09-16,Outer Banks,"John Booker ""John B"" Routledge",,17,M,,2020-04-15,27,17,10
+Madelyn Cline,1997-12-21,Outer Banks,Sarah Cameron,,16,F,,2020-04-15,22,16,6
+Madison Bailey,1999-01-29,Outer Banks,"Kiara ""Kie"" Carrera",,16,F,Pope Heyward,2020-04-15,21,16,5
+Jonathan Daviss,1999-02-28,Outer Banks,Pope Heyward,,16,M,"Kiara ""Kie"" Carrera",2020-04-15,21,16,5
+Rudy Pankow,1998-08-12,Outer Banks,JJ Maybank,,16,M,,2020-04-15,21,16,5
+Austin North,1996-07-30,Outer Banks,Topper Thornton,,18,M,,2020-04-15,23,18,5
+Drew Starkey,1993-11-04,Outer Banks,Rafe Cameron,,19,M,,2020-04-15,26,19,7
+Diego Tinoco,1997-11-25,On My Block,Cesar Diaz,,14,M,,2018-03-16,20,14,6
+Brett Gray,1996-08-07,On My Block,Jamal Turner,,14,M,,2018-03-16,21,14,7
+Sierra Capri,1998-09-08,On My Block,Monse Finnie,,14,F,,2018-03-16,19,14,5
+Jason Genao,1996-07-03,On My Block,"Ruben ""Ruby"" Martinez",,14,M,,2018-03-16,21,14,7
+Jessica Marie Garcia,1987-03-23,On My Block,Jasmine Flores,,14,F,,2018-03-16,30,14,16
+Maitreyi Ramakrishnan,2001-12-28,Never Have I Ever,Devi Vishwakumar,hs sophomore,,F,"Paxton Hall-Yoshida, Benjamin ""Ben"" Gross",2020-04-27,18,15,3
+Darren Barnet,1991-04-27,Never Have I Ever,Paxton Hall-Yoshida,hs junior,,M,Devi Vishwakumar,2020-04-27,29,16,13
+Jaren Lewison,2000-12-09,Never Have I Ever,"Benjamin ""Ben"" Gross",hs sophomore,,M,Devi Vishwakumar,2020-04-27,19,15,4
+Lee Rodriguez,1999-11-28,Never Have I Ever,Fabiola Torres,hs sophomore,,F,Eve Hjelm,2020-04-27,20,15,5
+Ramona Young,1998-05-23,Never Have I Ever,Eleanor Wong,hs sophomore,,F,Oliver Martinez,2020-04-27,21,15,6
+Benjamin Norris,,Never Have I Ever,Trent Harrison,hs junior,,M,,2020-04-27,,16,
+Christina Kartchner,1994-11-04,Never Have I Ever,Eve Hjelm,hs sophomore,,F,Fabiola Torres,2020-04-27,25,15,10
+Virginia Gardner,1995-04-18,Runaways,Karolina Dean,,16,F,,2017-11-21,22,16,6
+Lyrica Okano,1994-11-09,Runaways,Nico Minoru,,16,F,,2017-11-21,23,16,7
+Ariela Barer,1998-10-14,Runaways,Gert Yorkes,,16,F,,2017-11-21,19,16,3
+Allegra Acosta,2002-12-12,Runaways,Molly Hayes Hernandez,,15,F,,2017-11-21,14,15,-1
+Rhenzy Feliz,1997-10-26,Runaways,Alex Wilder,,17,M,,2017-11-21,20,17,3
+Gregg Sulkin,1992-05-29,Runaways,Chase Stein,,17,M,,2017-11-21,25,17,8
+Daniel Ezra,1991-12-15,All American,Spencer James,,17,M,"Kia Williams, Layla Keating, Olivia Baker",2018-10-10,26,17,9
+Bre-Z,1987-07-22,All American,"Tamia ""Coop"" Cooper",,17,F,Patience Roberts,2018-10-10,31,17,14
+Greta Onieogou,1991-03-14,All American,Layla Keating,,17,F,"Spencer James, Asher Adams",2018-10-10,27,17,10
+Samantha Logan,1996-10-27,All American,Olivia Baker,,17,F,"Spencer James, Asher Adams",2018-10-10,21,17,4
+Michael Evans Behling,1996-05-06,All American,Jordan Baker,,17,M,,2018-10-10,22,17,5
+Cody Christian,1995-04-15,All American,Asher Adams,,17,M,"Layla Keating, Olivia Baker",2018-10-10,23,17,6
+Zendaya,1996-09-01,Euphoria,Rue Bennett,,17,F,,2019-06-16,22,17,5
+Hunter Schafer,1998-12-31,Euphoria,Jules,,17,F,,2019-06-16,20,17,3
+Jacob Elordi,1997-06-26,Euphoria,Nate Jacobs,,17,M,Maddy Perez,2019-06-16,21,17,4
+Algee Smith,1994-11-07,Euphoria,Chris McKay,,17,M,Cassie Howard,2019-06-16,24,17,7
+Alexa Demie,1990-12-11,Euphoria,Maddy Perez,,17,F,Nate Jacobs,2019-06-16,28,17,11
+Maude Apatow,1997-12-15,Euphoria,Lexi Howard,,16,F,,2019-06-16,21,16,5
+Sydney Sweeney,1997-09-12,Euphoria,Cassie Howard,,17,F,Chris McKay,2019-06-16,21,17,4
+Barbie Ferreira,1996-12-14,Euphoria,"Katherine ""Kat"" Hernandez",,17,F,"Daniel, Ethan",2019-06-16,22,17,5
+Storm Reid,2003-07-01,Euphoria,Gia Bennett,,15,F,,2019-06-16,15,15,0
+Chad Michael Murray,1981-08-24,One Tree Hill,Lucas Scott,,15,M,"Peyton Sawyer, Lindsey Strauss, Brooke Davis, Anna Taggaro, Nicki",2003-09-23,22,15,7
+James Lafferty,1985-07-25,One Tree Hill,Nathan Scott,,15,M,"Haley James, Peyton Sawyer, Taylor James",2003-09-23,18,15,3
+Hilarie Burton,1982-07-01,One Tree Hill,Peyton Sawyer,,15,F,"Lucas Scott, Nathan Scott, Julian Baker, Anna Taggaro, Jake Jagielski",2003-09-23,21,15,6
+Bethany Joy Lenz,1981-04-02,One Tree Hill,Haley James,,15,F,Nathan Scott,2003-09-23,22,15,7
+Sophia Bush,1982-07-08,One Tree Hill,Brooke Davis,,15,F,"Julian Baker, Lucas Scott, Owen Morello, Peyton Sawyer, Chase Adams, Nick Chavez",2003-09-23,21,15,6
+Benjamin McKenzie,1978-09-12,The O.C.,Ryan Atwood,hs sophomore,,M,"Taylor Townsend, Marissa Cooper",2003-08-05,24,15,9
+Adam Brody,1979-12-15,The O.C.,Seth Cohen,hs sophomore,,M,"Summer Roberts, Anna Stern",2003-08-05,23,15,8
+Mischa Barton,1986-01-24,The O.C.,Marissa Cooper,hs sophomore,,F,"Kevin Volchok, Alex Kelly, Ryan Atwood, Luke Ward",2003-08-05,17,15,2
+Rachel Bilson,1981-08-25,The O.C.,Summer Roberts,hs sophomore,,F,Seth Cohen,2003-08-05,21,15,6
+Chris Carmack,1980-12-22,The O.C.,Luke Ward,hs sophomore,,M,Marissa Cooper,2003-08-05,22,15,7
+Michael Cimino,1999-11-10,"Love, Victor",Victor Salazar,hs sophomore,,M,"Mia Brooks, Benji",2020-06-17,20,15,5
+Rachel Naomi Hilson,1995-10-30,"Love, Victor",Mia Brooks,hs sophomore,,F,"Victor Salazar, Andrew Spencer",2020-06-17,24,15,9
+Anthony Turpel,2000-01-26,"Love, Victor",Felix Weston,hs sophomore,,M,Lake Meriwether,2020-06-17,20,15,5
+Bebe Wood,2001-08-08,"Love, Victor",Lake Meriwether,hs sophomore,,F,Felix Weston,2020-06-17,18,15,3
+Mason Gooding,1996-11-14,"Love, Victor",Andrew Spencer,hs sophomore,,M,Mia Brooks,2020-06-17,23,15,8
+George Sear,1997-11-14,"Love, Victor",Benji Campbell,,17,M,Victor Salazar,2020-06-17,22,17,5
+Isabella Ferreira,2002-12-20,"Love, Victor",Pilar Salazar,hs freshman,,F,,2020-06-17,17,14,3
+Brianna Hildebrand,1996-08-14,Trinkets,Elodie Davis,,16,F,,2019-06-14,22,16,6
+Kiana Medeira,1992-11-04,Trinkets,"Maureen ""Moe"" Truax",,16,F,Noah Simos,2019-06-14,26,16,10
+Quintessa Swindell,1997-02-08,Trinkets,Tabitha Foster,,16,F,"Brady Finch, Luca Novak",2019-06-14,22,16,6
+Brandon Butler,1996-09-11,Trinkets,Brady Finch,,17,M,Tabitha Foster,2019-06-14,22,17,5
+Odiseas Georgiadis,1996-09-21,Trinkets,Noah Simos,,16,M,"Maureen ""Moe"" Truax",2019-06-14,22,16,6
+Troian Bellisario,1985-10-28,Pretty Little Liars,Spencer Hastings,,16,F,"Alex Santiago, Toby Cavanaugh",2010-06-08,24,16,8
+Ashley Benson,1989-12-18,Pretty Little Liars,Hanna Marin,,16,F,"Caleb Rivers, Sean Ackard, Travis Hobbs",2010-06-08,20,16,4
+Lucy Hale,1989-06-14,Pretty Little Liars,Aria Montgomery,,17,F,"Ezra Fitz, Noel Kahn, Jake, Jason DiLaurentis",2010-06-08,20,17,3
+Shay Mitchell,1987-04-10,Pretty Little Liars,Emily Fields,,16,F,"Maya St. Germain, Alison DiLaurentis",2010-06-08,23,16,7
+Ian Harding,1986-09-16,Pretty Little Liars,Ezra Fitz,,21,M,Aria Montgomery,2010-06-08,23,21,2
+Sasha Pieterse,1996-02-17,Pretty Little Liars,Alison DiLaurentis,,16,F,"Emily Fields, Ezra Fitz",2010-06-08,14,16,-2
+Bianca Lawson,1979-03-20,Pretty Little Liars,Maya St. Germain,,17,F,Emily Fields,2010-06-08,31,17,14
+Jackson Robert Scott,2008-09-18,Locke & Key,Bode Locke,,10,M,,2020-02-07,11,10,1
+Connor Jessup,1994-06-23,Locke & Key,Tyler Locke,,17,M,Jackie Veda,2020-02-07,25,17,8
+Emilia Jones,2002-02-23,Locke & Key,Kinsey Locke,hs sophomore,,F,"Gabe, Scot Cavendish",2020-02-07,17,15,2
+Griffin Gluck,2000-08-24,Locke & Key,Gabe,hs sophomore,,M,Kinsey Locke,2020-02-07,19,15,4
+Petrice Jones,1993-05-10,Locke & Key,Scot Cavendish,hs junior,,M,Kinsey Locke,2020-02-07,26,16,10
+Genevieve Kang,,Locke & Key,Jackie Veda,,17,F,Tyler Locke,2020-02-07,,17,
+Thomas Mitchell Barnet,,Locke & Key,Sam Lesser,hs junior,,M,,2020-02-07,,16,
+Kevin Alves,1991-10-19,Locke & Key,Javi,hs junior,,M,,2020-02-07,28,16,12
+Asha Bromfield,1994-11-09,Locke & Key,Zadie Wells,hs junior,,F,,2020-02-07,25,16,9
+Felix Mallard,1998-04-20,Locke & Key,Lucas Caravaggio,,17,M,,2020-02-07,21,17,4
+Hallea Jones,,Locke & Key,Eden Hawkins,hs junior,,F,,2020-02-07,,16,

--- a/test/output/ageDifference.svg
+++ b/test/output/ageDifference.svg
@@ -1,0 +1,656 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1260" viewBox="0 0 640 1260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="fy-axis" aria-description="title" transform="translate(490,0)" fill="none" text-anchor="start">
+    <g class="tick" opacity="1" transform="translate(0,49.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Everything Sucks!</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,85.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Stranger Things</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,121.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Riverdale</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,157.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Gilmore Girls</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,193.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Gossip Girl</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,229.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">I Am Not Okay With This</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,265.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Pretty Little Liars</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,301.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Secret Life of the American Teenager</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,337.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Runaways</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,373.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">13 Reasons Why</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,409.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Euphoria</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,445.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Love, Victor</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,481.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Outer Banks</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,517.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">The Wilds</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,553.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Never Have I Ever</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,589.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Chilling Adventures of Sabrina</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,625.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Dare Me</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,661.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Locke &amp; Key</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,697.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Looking for Alaska</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,733.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">One Tree Hill</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,769.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">The Society</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,805.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Trinkets</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,841.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Gossip Girl Revival</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,877.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Daybreak</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,913.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">On My Block</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,949.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Sex Education</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,985.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">The 100</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,1021.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">The O.C.</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,1057.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">All American</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,1093.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Atypical</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,1129.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Glee</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,1165.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">Derry Girls</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,1201.5)">
+      <line stroke="currentColor" x2="0"></line><text fill="currentColor" x="9" dy="0.32em">The Politician</text>
+    </g><text fill="currentColor" transform="translate(150,625) rotate(-90)" dy="-0.32em" text-anchor="middle">title</text>
+  </g>
+  <g aria-label="x-axis" aria-description="age_difference →" transform="translate(0,1230)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(85.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">0</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(198,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">5</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(310.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(423,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">15</text>
+    </g><text fill="currentColor" transform="translate(640,30)" dy="-0.32em" text-anchor="end">age_difference →</text>
+  </g>
+  <g aria-label="y-axis" aria-description="↑ Frequency" transform="translate(40,33)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g><text fill="currentColor" transform="translate(-40,0)" dy="-1em" text-anchor="start">↑ Frequency</text>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,69)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,105)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,141)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,177)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,213)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,249)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,285)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,321)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,357)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,393)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,429)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,465)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,501)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,537)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,573)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,609)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,645)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,681)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,717)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,753)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,789)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,825)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,861)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,897)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,933)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,969)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,1005)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,1041)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,1077)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,1113)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,1149)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="y-axis" transform="translate(40,1185)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,32.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,33)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="107.5" x2="107.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="41" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="86" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="131" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="176" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,69)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="118.75" x2="118.75" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="41" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="86" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,105)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="152.5" x2="152.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="86" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="131" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="176" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,141)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="175" x2="175" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="176" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="356" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,177)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="175" x2="175" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="86" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+      <rect x="221" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,213)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="175" x2="175" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="86" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,249)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="175" x2="175" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="41" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="131" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="176" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="401" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,285)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="175" x2="175" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="0" width="44" height="32"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,321)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="186.25" x2="186.25" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="41" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="131" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="221" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,357)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="197.5" x2="197.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="176" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="266" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,393)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="197.5" x2="197.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="86" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="9.142857142857142" width="44" height="22.857142857142858"></rect>
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,429)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="197.5" x2="197.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="176" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="266" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,465)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="197.5" x2="197.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="176" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+      <rect x="221" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,501)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="197.5" x2="197.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="176" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,537)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="208.75" x2="208.75" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="356" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,573)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="220" x2="220" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="86" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="176" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="221" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="266" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,609)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="220" x2="220" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,645)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="220" x2="220" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="86" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="266" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="356" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,681)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="220" x2="220" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,717)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="220" x2="220" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="221" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,753)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="220" x2="220" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+      <rect x="221" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+      <rect x="266" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,789)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="220" x2="220" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="176" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="221" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,825)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="231.25" x2="231.25" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="266" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="311" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,861)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="242.5" x2="242.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="86" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="176" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="401" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,897)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="242.5" x2="242.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="176" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="221" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="446" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,933)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="242.5" x2="242.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="221" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+      <rect x="266" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="311" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,969)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="242.5" x2="242.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="176" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="221" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+      <rect x="311" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,1005)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="242.5" x2="242.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="221" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="266" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,1041)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="253.75" x2="253.75" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="176" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="221" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="401" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,1077)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="253.75" x2="253.75" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="221" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,1113)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="253.75" x2="253.75" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="131" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="176" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="221" y="13.714285714285715" width="44" height="18.285714285714285"></rect>
+      <rect x="266" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="356" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,1149)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="287.5" x2="287.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="221" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="266" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="356" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,1185)">
+    <g aria-label="tick" stroke="red" transform="translate(0.5,0)">
+      <line x1="287.5" x2="287.5" y1="0" y2="32"></line>
+    </g>
+    <g aria-label="rect">
+      <rect x="221" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+      <rect x="266" y="18.285714285714285" width="44" height="13.714285714285715"></rect>
+      <rect x="311" y="27.42857142857143" width="44" height="4.571428571428569"></rect>
+      <rect x="401" y="22.857142857142858" width="44" height="9.142857142857142"></rect>
+    </g>
+  </g>
+</svg>

--- a/test/plots/age-difference.js
+++ b/test/plots/age-difference.js
@@ -1,0 +1,28 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export default async function() {
+  const agediff = await d3.csv("data/actor_character_age_difference.csv", d3.autoType);
+  return Plot.plot({
+    facet: {
+      data: agediff,
+      y: "title",
+      marginRight: 150
+    },
+    marks: [
+      Plot.tickX(
+        agediff,
+        Plot.groupZ({ x: "median" }, {
+            x: "age_difference",
+            z: "title",
+            stroke: "red",
+            sort: {fy: "x"}
+        })
+      ), // only for sorting
+      Plot.rectY(
+        agediff,
+        Plot.binX({ y: "count" }, { x: "age_difference", thresholds: 10 })
+      )
+    ]
+  });
+}

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -6,6 +6,7 @@ export {default as aaplCloseUntyped} from "./aapl-close-untyped.js";
 export {default as aaplMonthly} from "./aapl-monthly.js";
 export {default as aaplVolume} from "./aapl-volume.js";
 export {default as aaplVolumeRect} from "./aapl-volume-rect.js";
+export {default as ageDifference} from "./age-difference.js";
 export {default as anscombeQuartet} from "./anscombe-quartet.js";
 export {default as athletesBinsColors} from "./athletes-bins-colors.js";
 export {default as athletesHeightWeight} from "./athletes-height-weight.js";


### PR DESCRIPTION
This branch is trying to fix the following issue:

When we have "sort fy by x" and a transform, the series are not indexed properly. The channel to sort (XV, in this case *fy*) is indexed by the original data, and the channel by which to sort (YV, in this case *x*) is indexed by the transformed (grouped) data.

It can be solved, in the case of this unit test, by grouping data by series:
> const XV = x === "fy" || x === "fx" ? [...new Set(X[1].value)] : X[1].value;

However this is not a proper fix, since it should apply only when data is indeed grouped this way. We have to understand how the data is reindexed, or alternatively we have to make the facet information follow along with the grouping.


Note: the broken test is the _expected_ chart, but we can't achieve it yet without breaking a few others:

<img width="602" alt="Capture d’écran 2022-04-05 à 23 24 20" src="https://user-images.githubusercontent.com/7001/161852159-a1102f5d-d1a0-4554-9385-7383c5cbea88.png">



cc: @enjalot 