### PR TITLE
default diverging based on scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ The normal scale types—*linear*, *sqrt*, *pow*, *log*, *symlog*, and *ordinal*
 
 For a *threshold* scale, the *domain* represents *n* (typically numeric) thresholds which will produce a *range* of *n* + 1 output colors; the *i*th color of the *range* applies to values that are smaller than the *i*th element of the domain and larger or equal to the *i* - 1th element of the domain. For a *quantile* scale, the *domain* represents all input values to the scale, and the *n* option specifies how many quantiles to compute from the *domain*; *n* quantiles will produce *n* - 1 thresholds, and an output range of *n* colors. For a *quantize* scale, the domain will be transformed into approximately *n* quantized values, where *n* is an option that defaults to 5.
 
-Picking a diverging color scheme name defaults the scale type to *diverging*. By default, all diverging color scales are symmetric around the pivot; set *symmetric* to false if you want to cover the whole extent on both sides.
+By default, all diverging color scales are symmetric around the pivot; set *symmetric* to false if you want to cover the whole extent on both sides.
 
 Color scales support two additional options:
 
@@ -371,7 +371,7 @@ The following diverging scale schemes are supported:
 * <sub><img src="./img/burd.png" width="32" height="16" alt="burd"></sub> *burd*
 * <sub><img src="./img/buylrd.png" width="32" height="16" alt="buylrd"></sub> *buylrd*
 
-Diverging color scales support a *scale*.**pivot** option, which defaults to zero. Values below the pivot will use the lower half of the color scheme (*e.g.*, reds for the *rdgy* scheme), while values above the pivot will use the upper half (grays for *rdgy*).
+Picking a diverging color scheme name defaults the scale type to *diverging*; set the scale type to *linear* to treat the color scheme as sequential instead. Diverging color scales support a *scale*.**pivot** option, which defaults to zero. Values below the pivot will use the lower half of the color scheme (*e.g.*, reds for the *rdgy* scheme), while values above the pivot will use the upper half (grays for *rdgy*).
 
 The following cylical color schemes are supported:
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ The normal scale types—*linear*, *sqrt*, *pow*, *log*, *symlog*, and *ordinal*
 
 For a *threshold* scale, the *domain* represents *n* (typically numeric) thresholds which will produce a *range* of *n* + 1 output colors; the *i*th color of the *range* applies to values that are smaller than the *i*th element of the domain and larger or equal to the *i* - 1th element of the domain. For a *quantile* scale, the *domain* represents all input values to the scale, and the *n* option specifies how many quantiles to compute from the *domain*; *n* quantiles will produce *n* - 1 thresholds, and an output range of *n* colors. For a *quantize* scale, the domain will be transformed into approximately *n* quantized values, where *n* is an option that defaults to 5.
 
-By default, all diverging color scales are symmetric around the pivot; set *symmetric* to false if you want to cover the whole extent on both sides.
+Picking a diverging color scheme name defaults the scale type to *diverging*. By default, all diverging color scales are symmetric around the pivot; set *symmetric* to false if you want to cover the whole extent on both sides.
 
 Color scales support two additional options:
 

--- a/src/scales.js
+++ b/src/scales.js
@@ -262,7 +262,7 @@ function inferScaleType(key, channels, {type, domain, range, scheme, pivot}) {
   // Otherwise, infer the scale type from the data! Prefer the domain, if
   // present, over channels. (The domain and channels should be consistently
   // typed, and the domain is more explicit and typically much smaller.) We only
-  // check the first defined value for expedience and simplicitly; we expect
+  // check the first defined value for expedience and simplicity; we expect
   // that the types are consistent.
   if (domain !== undefined) {
     if (isOrdinal(domain)) return asOrdinalType(kind);

--- a/src/scales.js
+++ b/src/scales.js
@@ -3,6 +3,7 @@ import {isColor, isEvery, isOrdinal, isFirst, isTemporal, isTemporalString, isNu
 import {registry, color, position, radius, opacity, symbol, length} from "./scales/index.js";
 import {ScaleLinear, ScaleSqrt, ScalePow, ScaleLog, ScaleSymlog, ScaleQuantile, ScaleQuantize, ScaleThreshold, ScaleIdentity} from "./scales/quantitative.js";
 import {ScaleDiverging, ScaleDivergingSqrt, ScaleDivergingPow, ScaleDivergingLog, ScaleDivergingSymlog} from "./scales/diverging.js";
+import {isDivergingScheme} from "./scales/schemes.js";
 import {ScaleTime, ScaleUtc} from "./scales/temporal.js";
 import {ScaleOrdinal, ScalePoint, ScaleBand, ordinalImplicit} from "./scales/ordinal.js";
 import {isSymbol, maybeSymbol} from "./symbols.js";
@@ -212,7 +213,7 @@ function formatScaleType(type) {
   return typeof type === "symbol" ? type.description : type;
 }
 
-function inferScaleType(key, channels, {type, domain, range, scheme}) {
+function inferScaleType(key, channels, {type, domain, range, scheme, pivot}) {
   // The facet scales are always band scales; this cannot be changed.
   if (key === "fx" || key === "fy") return "band";
 
@@ -266,6 +267,7 @@ function inferScaleType(key, channels, {type, domain, range, scheme}) {
   if (domain !== undefined) {
     if (isOrdinal(domain)) return asOrdinalType(kind);
     if (isTemporal(domain)) return "utc";
+    if (kind === color && (pivot != null || isDivergingScheme(scheme))) return "diverging";
     return "linear";
   }
 
@@ -273,6 +275,7 @@ function inferScaleType(key, channels, {type, domain, range, scheme}) {
   const values = channels.map(({value}) => value).filter(value => value !== undefined);
   if (values.some(isOrdinal)) return asOrdinalType(kind);
   if (values.some(isTemporal)) return "utc";
+  if (kind === color && (pivot != null || isDivergingScheme(scheme))) return "diverging";
   return "linear";
 }
 

--- a/src/scales/schemes.js
+++ b/src/scales/schemes.js
@@ -258,3 +258,21 @@ export function quantitativeScheme(scheme) {
   if (!quantitativeSchemes.has(s)) throw new Error(`unknown scheme: ${s}`);
   return quantitativeSchemes.get(s);
 }
+
+const divergingSchemes = new Set([
+  "brbg",
+  "prgn",
+  "piyg",
+  "puor",
+  "rdbu",
+  "rdgy",
+  "rdylbu",
+  "rdylgn",
+  "spectral",
+  "burd",
+  "buylrd"
+]);
+
+export function isDivergingScheme(scheme) {
+  return scheme != null && divergingSchemes.has(`${scheme}`.toLowerCase());
+}

--- a/test/plots/gistemp-anomaly-moving.js
+++ b/test/plots/gistemp-anomaly-moving.js
@@ -10,7 +10,6 @@ export default async function() {
       grid: true
     },
     color: {
-      type: "diverging",
       scheme: "BuRd",
       symmetric: false
     },

--- a/test/plots/gistemp-anomaly-transform.js
+++ b/test/plots/gistemp-anomaly-transform.js
@@ -12,7 +12,6 @@ export default async function() {
       grid: true
     },
     color: {
-      type: "diverging",
       scheme: "BuRd",
       domain: [-1, 1],
       transform

--- a/test/plots/gistemp-anomaly.js
+++ b/test/plots/gistemp-anomaly.js
@@ -10,8 +10,7 @@ export default async function() {
       grid: true
     },
     color: {
-      type: "diverging",
-      reverse: true
+      scheme: "BuRd"
     },
     marks: [
       Plot.ruleY([0]),

--- a/test/plots/hadcrut-warming-stripes.js
+++ b/test/plots/hadcrut-warming-stripes.js
@@ -15,7 +15,6 @@ export default async function() {
       round: true
     },
     color: {
-      type: "diverging",
       scheme: "BuRd",
       symmetric: false
     },

--- a/test/plots/legend-color.js
+++ b/test/plots/legend-color.js
@@ -273,7 +273,6 @@ export function colorLegendImplicitLabel() {
 export function colorLegendDiverging() {
   return Plot.legend({
     color: {
-      type: "diverging",
       domain: [-0.1, 0.1],
       scheme: "PiYG",
       label: "Daily change"
@@ -285,7 +284,6 @@ export function colorLegendDiverging() {
 export function colorLegendDivergingPivot() {
   return Plot.legend({
     color: {
-      type: "diverging",
       domain: [1, 4],
       pivot: 3,
       scheme: "PiYG"
@@ -296,7 +294,6 @@ export function colorLegendDivergingPivot() {
 export function colorLegendDivergingPivotAsymmetric() {
   return Plot.legend({
     color: {
-      type: "diverging",
       symmetric: false,
       domain: [1, 4],
       pivot: 3,

--- a/test/plots/metro-inequality-change.js
+++ b/test/plots/metro-inequality-change.js
@@ -14,8 +14,7 @@ export default async function() {
       label: "↑ Inequality"
     },
     color: {
-      type: "diverging",
-      reverse: true,
+      scheme: "BuRd",
       symmetric: false
     },
     marks: [

--- a/test/plots/metro-unemployment-slope.js
+++ b/test/plots/metro-unemployment-slope.js
@@ -8,7 +8,6 @@ export default async function() {
       grid: true
     },
     color: {
-      type: "diverging",
       scheme: "buylrd",
       domain: [-0.5, 0.5]
     },

--- a/test/plots/seattle-precipitation-rule.js
+++ b/test/plots/seattle-precipitation-rule.js
@@ -3,13 +3,5 @@ import * as d3 from "d3";
 
 export default async function() {
   const data = await d3.csv("data/seattle-weather.csv", d3.autoType);
-  return Plot.plot({
-    color: {
-      scheme: "RdBu",
-      reverse: true
-    },
-    marks: [
-      Plot.ruleX(data, {x: "date", strokeOpacity: "precipitation"})
-    ]
-  });
+  return Plot.ruleX(data, {x: "date", strokeOpacity: "precipitation"}).plot();
 }

--- a/test/plots/seattle-temperature-band.js
+++ b/test/plots/seattle-temperature-band.js
@@ -10,8 +10,8 @@ export default async function() {
       transform: f => f * 9 / 5 + 32 // convert from Celsius
     },
     color: {
-      scheme: "RdBu",
-      reverse: true
+      type: "linear",
+      scheme: "BuRd"
     },
     marks: [
       Plot.ruleX(

--- a/test/plots/simpsons-ratings.js
+++ b/test/plots/simpsons-ratings.js
@@ -14,6 +14,7 @@ export default async function() {
       label: "Season"
     },
     color: {
+      type: "linear",
       scheme: "PiYG",
       unknown: "#ddd"
     },

--- a/test/plots/us-presidential-election-2020.js
+++ b/test/plots/us-presidential-election-2020.js
@@ -18,8 +18,7 @@ export default async function() {
       label: "↑ Total number of votes"
     },
     color: {
-      type: "diverging",
-      reverse: true,
+      scheme: "BuRd",
       symmetric: false
     },
     marks: [


### PR DESCRIPTION
I was thinking of cases like this, where a diverging scheme is specified, but the scale type is not specified and it defaults to _linear_.  It would be nice, when appropriate, to default to a _diverging_ scale instead so that it is symmetric around zero.

https://observablehq.com/@violetr/30daychartchallenge-day-13-correlation

I did this by checking for whether the _scheme_ is a diverging scheme, and whether a _pivot_ is specified or whether the _domain_ includes zero. The nice thing is that most of our tests that specify a diverging scale now merely need to specify a diverging scheme, though there were a couple tests that use a diverging scheme without a meaningful pivot (e.g., for temperature or IMDb rating where you want a diverging scheme simply for “low” and “high”).