### PR TITLE
faster array manipulations

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -127,7 +127,13 @@ export function maybeZ({z, fill, stroke} = {}) {
 
 // Returns a Uint32Array with elements [0, 1, 2, … data.length - 1].
 export function range(data) {
-  return Uint32Array.from(data, indexOf);
+  const n = data.length;
+  if (n !== undefined) {
+    const r = new Uint32Array(n);
+    for (let i = 0; i < n; ++i) r[i] = i;
+    return r;
+  }
+  return Uint32Array.from(data, indexOf); // seems unnecessary given that all calls to this function have been arrayified
 }
 
 // Returns a filtered range of data given the test function.

--- a/src/options.js
+++ b/src/options.js
@@ -128,12 +128,9 @@ export function maybeZ({z, fill, stroke} = {}) {
 // Returns a Uint32Array with elements [0, 1, 2, … data.length - 1].
 export function range(data) {
   const n = data.length;
-  if (n !== undefined) {
-    const r = new Uint32Array(n);
-    for (let i = 0; i < n; ++i) r[i] = i;
-    return r;
-  }
-  return Uint32Array.from(data, indexOf); // seems unnecessary given that all calls to this function have been arrayified
+  const r = new Uint32Array(n);
+  for (let i = 0; i < n; ++i) r[i] = i;
+  return r;
 }
 
 // Returns a filtered range of data given the test function.


### PR DESCRIPTION
This follows on the issue described by @yurivish in https://github.com/observablehq/plot/pull/801#issuecomment-1119103573

I had also noted that Array.from is slow: https://observablehq.com/@fil/array-from-is-slower-than-expected

My understanding (after @mythmon showed me how to use a browser ;-) ) is that Array.from treats the data as an iterator, using the ->next method until completion, which means 1) it's necessarily slower than a tight loop and 2) it doesn't know how much memory to allocate (I speculate).

So when data is an array (it might not always be the case, iterators still have to be supported? though it seems that in all cases the data we pass to this function has already been arrayified), it might be worth using the faster path to populate it with indices.

Same story with type coercion (#863).