### PR TITLE
disable default sort when explicitly ordering

### DIFF
--- a/src/transforms/basic.js
+++ b/src/transforms/basic.js
@@ -46,7 +46,7 @@ function filterTransform(value) {
 }
 
 export function reverse(options) {
-  return basic(options, reverseTransform);
+  return {...basic(options, reverseTransform), sort: null};
 }
 
 function reverseTransform(data, facets) {
@@ -54,11 +54,11 @@ function reverseTransform(data, facets) {
 }
 
 export function shuffle({seed, ...options} = {}) {
-  return basic(options, sortValue(seed == null ? Math.random : randomLcg(seed)));
+  return {...basic(options, sortValue(seed == null ? Math.random : randomLcg(seed))), sort: null};
 }
 
 export function sort(value, options) {
-  return basic(options, sortTransform(value));
+  return {...basic(options, sortTransform(value)), sort: null};
 }
 
 function sortTransform(value) {


### PR DESCRIPTION
The Plot.reverse, Plot.sort, and Plot.shuffle transforms weren’t setting the **sort** option, and hence the dot mark’s default sort by descending *r* was still having an effect. Now these transforms set the **sort** option to null, explicitly disabling any default sort implemented by marks.