### PR TITLE
faster dodge

### DIFF
--- a/src/transforms/dodge.js
+++ b/src/transforms/dodge.js
@@ -73,11 +73,14 @@ function dodge(y, x, anchor, padding, options) {
         });
 
         // Find the best y-value where this circle can fit.
-        loop: for (const y of intervals.slice(0, k).sort(compare)) {
+        out: for (const y of intervals.slice(0, k).sort(compare)) {
           for (let j = 0; j < k; j += 2) {
-            if (y > intervals[j] && y < intervals[j + 1]) continue loop;
+            if (y > intervals[j] && y < intervals[j + 1]) {
+              continue out;
+            }
           }
-          Y[i] = y; break;
+          Y[i] = y;
+          break;
         }
 
         // Insert the placed circle into the interval tree.


### PR DESCRIPTION
algorithm unchanged, but using a fixed typed array makes it about 2x faster on a mildly dense chart
https://observablehq.com/@fil/dodge-performance-901

On my computer the problematic `Plot.dot(olympians, Plot901.dodgeX({y: "sport"})).plot()` is now solved (in Chrome) in 12s instead of a whopping 205s with the base branch. Safari needs 17s and Firefox 15s. Still not usable for this particular case, but it expands the range of problems for which it's going to be tolerable.