### PR TITLE
fix ramp legend font-variant

### DIFF
--- a/src/legends/ramp.js
+++ b/src/legends/ramp.js
@@ -149,14 +149,16 @@ export function legendRamp(color, {
       .attr("font-family", null)
       .attr("font-variant", impliedString(fontVariant, "normal"))
       .call(tickAdjust)
-      .call(g => g.select(".domain").remove())
-      .call(label === undefined ? () => {} : g => g.append("text")
-          .attr("x", marginLeft)
-          .attr("y", marginTop + marginBottom - height - 6)
-          .attr("fill", "currentColor") // TODO move to stylesheet?
-          .attr("text-anchor", "start")
-          .attr("font-weight", "bold")
-          .text(label));
+      .call(g => g.select(".domain").remove());
+
+  if (label !== undefined) {
+    svg.append("text")
+        .attr("x", marginLeft)
+        .attr("y", marginTop - 6)
+        .attr("fill", "currentColor") // TODO move to stylesheet?
+        .attr("font-weight", "bold")
+        .text(label);
+  }
 
   return svg.node();
 }

--- a/test/output/carsHexbin.html
+++ b/test/output/carsHexbin.html
@@ -26,8 +26,8 @@
       </g>
       <g class="tick" opacity="1" transform="translate(240.5,0)">
         <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">5,000</text>
-      </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">weight (lb)</text>
-    </g>
+      </g>
+    </g><text x="0" y="12" fill="currentColor" font-weight="bold">weight (lb)</text>
   </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-2 {

--- a/test/output/carsJitter.html
+++ b/test/output/carsJitter.html
@@ -26,8 +26,8 @@
       </g>
       <g class="tick" opacity="1" transform="translate(192.5,0)">
         <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">200</text>
-      </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">power (hp)</text>
-    </g>
+      </g>
+    </g><text x="0" y="12" fill="currentColor" font-weight="bold">power (hp)</text>
   </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="350" viewBox="0 0 640 350" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-2 {

--- a/test/output/colorLegendDiverging.svg
+++ b/test/output/colorLegendDiverging.svg
@@ -29,6 +29,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">+10%</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Daily change</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Daily change</text>
 </svg>

--- a/test/output/colorLegendDivergingSqrt.svg
+++ b/test/output/colorLegendDivergingSqrt.svg
@@ -29,6 +29,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">+10%</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Daily change</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Daily change</text>
 </svg>

--- a/test/output/colorLegendImplicitLabel.svg
+++ b/test/output/colorLegendImplicitLabel.svg
@@ -29,6 +29,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(194.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">80</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">thing</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">thing</text>
 </svg>

--- a/test/output/colorLegendLabelBoth.svg
+++ b/test/output/colorLegendLabelBoth.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Legend</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Legend</text>
 </svg>

--- a/test/output/colorLegendLabelLegend.svg
+++ b/test/output/colorLegendLabelLegend.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Legend</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Legend</text>
 </svg>

--- a/test/output/colorLegendLabelScale.svg
+++ b/test/output/colorLegendLabelScale.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Scale</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Scale</text>
 </svg>

--- a/test/output/colorLegendMargins.svg
+++ b/test/output/colorLegendMargins.svg
@@ -23,6 +23,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(350.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
-    </g><text x="150" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">I feel blue</text>
-  </g>
+    </g>
+  </g><text x="150" y="12" fill="currentColor" font-weight="bold">I feel blue</text>
 </svg>

--- a/test/output/colorLegendOrdinalRampTickSize.svg
+++ b/test/output/colorLegendOrdinalRampTickSize.svg
@@ -43,6 +43,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(222.5,0)">
       <line stroke="currentColor" y2="0"></line><text fill="currentColor" y="3" dy="0.71em">≥70</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Age (years)</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Age (years)</text>
 </svg>

--- a/test/output/colorLegendQuantile.svg
+++ b/test/output/colorLegendQuantile.svg
@@ -40,6 +40,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(206.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">7,201</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Inferno</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Inferno</text>
 </svg>

--- a/test/output/colorLegendQuantileImplicit.svg
+++ b/test/output/colorLegendQuantileImplicit.svg
@@ -40,6 +40,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(206.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">7,201</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Inferno</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Inferno</text>
 </svg>

--- a/test/output/colorLegendQuantize.svg
+++ b/test/output/colorLegendQuantize.svg
@@ -44,6 +44,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(210.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">140</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">quantize scale</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">quantize scale</text>
 </svg>

--- a/test/output/colorLegendQuantizeDescending.svg
+++ b/test/output/colorLegendQuantizeDescending.svg
@@ -44,6 +44,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(210.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">20</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">quantize descending</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">quantize descending</text>
 </svg>

--- a/test/output/colorLegendQuantizeDescendingReversed.svg
+++ b/test/output/colorLegendQuantizeDescendingReversed.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(192.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">2</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">quantize descending reversed</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">quantize descending reversed</text>
 </svg>

--- a/test/output/colorLegendQuantizeRange.svg
+++ b/test/output/colorLegendQuantizeRange.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(192.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">115.4</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">quantize scale</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">quantize scale</text>
 </svg>

--- a/test/output/colorLegendQuantizeReverse.svg
+++ b/test/output/colorLegendQuantizeReverse.svg
@@ -44,6 +44,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(210.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">80</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">quantize reversed</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">quantize reversed</text>
 </svg>

--- a/test/output/colorLegendThreshold.svg
+++ b/test/output/colorLegendThreshold.svg
@@ -52,6 +52,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(216.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">9</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Viridis</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Viridis</text>
 </svg>

--- a/test/output/colorLegendThresholdTickSize.svg
+++ b/test/output/colorLegendThresholdTickSize.svg
@@ -48,6 +48,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(213.5,0)">
       <line stroke="currentColor" y2="0" y1="-10"></line><text fill="currentColor" y="3" dy="0.71em">9.5</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Unemployment rate (%)</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Unemployment rate (%)</text>
 </svg>

--- a/test/output/colorSchemesQuantitative.html
+++ b/test/output/colorSchemesQuantitative.html
@@ -14,7 +14,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA2UlEQVQ4jXWLy41DMQwDhzK2nxST/jt54h4s2zKSHAQOP9L79ecQRMCQCMHyocqKo/GIvtXWsf3a6upXNxrvPKL5QCvbGq2LlgUaQcQ4+Vg8rk5jFI/iaFx5+cVXvjr1LA6rZW2DmldAqTRAax+TS+dPYwLUji+MQIFRZcLM3AhLhxGGD03A5jCQ25v0VPv2aR81PJvnPTZJTl1+a8uzbyY/mcfn0trl2cysNpnVVZ5ts7q8u/zR5xe92Vf+6+yz98rq0oedxs1Tv5PnLz4dduPSTGxvPrk3/wOC4FZ8+BQyxQAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">brbg</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">brbg</text>
   </svg><svg class="plot-2" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-2 {
@@ -31,7 +31,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA1klEQVQ4jXWOQZbDMAhDJfli3ff+xwFmAcY4zbw+KumLkPCDb0iCKEgLkrAoSDWDa/I5XK+cEiRCa2ZB6+7YbGY+dPb/K1fdlcBVemX2u8991jcfnzp3ee5291RBzPzT8WYUQeJkTk5IaI/aPXsonkoCKI7OOSTb5wSA9EEAiPRTEf0Dj48YHn7+Y3uvHYe3VhdevZdPFsU9XubBbXY+s6UvZmGn9+zM68bI5laseD8zco1vXzc6e7T/UYvO7refah6InW3z7KL87t9yNHeE3ezs5zPP7g/alWNv64eNqAAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">prgn</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">prgn</text>
   </svg><svg class="plot-3" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-3 {
@@ -48,7 +48,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA0UlEQVQ4jW2NQRLDMAgDJdIX9mH9caQeMBhncvBotUDCH78OBoJEMHAN7hezExEPP3tkJwNxpWO5q5LdeeVeMtudPsDPY/4JYM4ft7wCmG79F82rL89Ij+baZXIU1w6BmnHu7QSHI8b+6bID5GaQAPHej0R3FyNzdtMnz4QBGt3oZQ1Ai8pV15gLtvas+Yaac0e4M33DeOSaNzt53pzvxenpBGn3u+fTJ9/WvpeW17jT6SXIHs4750x+YcODy7tYOLuxeGfOsb519tybbtx73/wBiwBVtFSSoDIAAAAASUVORK5CYII="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">piyg</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">piyg</text>
   </svg><svg class="plot-4" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-4 {
@@ -65,7 +65,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA0ElEQVQ4jX2OwXHEMAwDAaieVHL9d3Mi8pBkkraTB4eLJewRf/CxJJADfQvS2FugBkSBWj453cnp1N0QJBYWNLg648mrx/cslm96p3VLXt8k1/c8btWfNx8eJZOlv9+vm3t0ALHfz78oZJ+EdqYIEq2zcvLr4LAXw40Bg4gXDtDRNrzZAWAmewI+ee5ZzJjFTSBe+NV9gZjwreft4QlHcTunW77n+8TFcbLTR8TmuLhvI7x3eHkfXjt8GHkz9q1uwD49ZP/iMv/dWgcI8w+/5hefJCvShWv1kAAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">puor</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">puor</text>
   </svg><svg class="plot-5" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-5 {
@@ -82,7 +82,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA2ElEQVQ4jXWLwZEDMAgDV1BIykv/BRjuYWxjz+XBSFoJffmkC1ziVfvJhduzsfK2emHFzFp+Tr68YS5kwnzm1cl7N7nc9mb3bsjs2pw8vZr/xaf6lbmyI+vMoTjWsjm0Hjt/mCEdPtVA7VeLTc21VzsTyMjGUgJKdxYpkRhIJCJh6puT44FYOSFeTQjy+My9X/4/HbFyY+VHHL78aD+bBcVz85UvFmy293F29/buo/Xx8H3V5cMzk4jYfGqQ2XwkGVF97IuMK89NkDEql45R3Xi6ftWPlw/+AP61XqZckQ8kAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">rdbu</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">rdbu</text>
   </svg><svg class="plot-6" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-6 {
@@ -99,7 +99,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApElEQVQ4jaWOyxGDMBBDn7SFpLz0XwA4h8XxJ0CcyUEjPWnHoCePEoKQmN2XvQhPNz6y6y58dHbHkxQ1G4eQhSO5bop+y17h9817DyN7uGmcWV2+6tNjYAYO5L4LOHp8ww7w2OH2Fjbok/O+5ew71iGrZWUuqDGiDE7uQKkqJJfKpXmp3rTPvO+n3PdnecVX8xnP+rZv23a7X9380618d+W/ftELRnlxXnkBnbYAAAAASUVORK5CYII="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">rdgy</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">rdgy</text>
   </svg><svg class="plot-7" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-7 {
@@ -116,7 +116,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAwklEQVQ4jZWQSY7EMAwDi/Jf+uf9TItzcLzFBhpzEEQW6QCRvnwcAdto9wpxdALi4bp6bW/HLiJCo6PQwoRK65687xg55Z0Jlg4XzustnZXnpzu/aCK2N+uxVN6Hu2uNAx1Hnkxx2dr9pnUwK4DZdd9cNi0f+jaeOglsDZ7oyUW6ZY2J3DSPZ/H3sSFt6mBuOz21/fipq01m73v2s/E69MpfOtdv/R5feZL1zFxn7vTWcRrXXPTOO/M/GNU4c3aqYfF/AzFBDLI2NnAAAAAASUVORK5CYII="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">rdylbu</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">rdylbu</text>
   </svg><svg class="plot-8" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-8 {
@@ -133,7 +133,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA0ElEQVQ4jW2QSY6FMAxEn8Nd+uZ9TFx/4SEDEYpqBhT7509jwHZs1zaMT2fASN+u2rZt42OMYd2xYYtn2BPdr184Ouc5M4Olw8Xn2FJedqhtd0b7c7teUmDsv/5+mfk+u13yom1FO3Ri9YsnqnV4ag4iuKC1AJkAgvcDjpBKO5LCw3GVF9yLo/Rmp7jLe+vLbtPF0aLPfJ5XwkW+q3R4r89s7b1XjP7qvRLugd2R9t6auzKn/6Nzn9pPnbz27vFdl5Bry0srPTmbp9xs3iWr8wPcXFevq8XGRAAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">rdylgn</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">rdylgn</text>
   </svg><svg class="plot-9" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-9 {
@@ -150,7 +150,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA50lEQVQ4jXWQSXLEMAwDG9TP8tD8VEQOpBZ7JgcVgAapsqxf/ThCxIAIMVoj2Kx8657pboDivXOyLlZzt/dmuvryn93XM5YXxPEaQKj4aBaCIRTdDcFmcfnF4+HPfT0bR+uuT3507a+H3jxAev+cM6cvfM3rnbWzJUDNntlwKaWUWm7vyvb2YBJfzNg1m4t5zUDaZN+RhqTVVE/PGKa1u9zdk09DWq3P/u7mP/PTMPPLXl45z97mufZUmv1NKWZWn6k+bPXFnCJnqZM+wrM8nZlcPwCYoM5KUD9GWVzTxPJpYrZ+yfHKfyPr9lDWJbNPAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">spectral</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">spectral</text>
   </svg><svg class="plot-10" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-10 {
@@ -167,7 +167,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA2ElEQVQ4jY2OwXEFMQxCQZ70k5bSfw0SOViyZP/LP2iAB95Z/vz+ibZw3VowW6AZPrpkp19zV52l7zM+2ZieuSfI9rvPzJ3t4oQ9fA1v7Dy1rvr19hfH55bPe+6dXRxYHP9AXL664ja+0exWAhcjAcP0t9aeAAht5fAQKF0ZEogAJSB7qHKcvNlWRLOdA5QD0RkKKIqlRgDJdJhDk4cD3m+Pemd5v5OXJvM4WW8ePr7i2jlZuJq/m9DpI3Q24TpdxOw+z8sLnVUKeAiu9BI8sHsJXiw1njz1HzZ1S5at/iywAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">burd</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">burd</text>
   </svg><svg class="plot-11" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-11 {
@@ -184,7 +184,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAxElEQVQ4jY2QO3IEMAxCAZ8oTW6a41qksOX/zmyhAT2wC/Hn988UwUJAAguROyVg2wkWNf2SaWE6uQiNTKMrzclO5lf2xRQ+ON++dbFzpsf8i4SI3Y8Mg5XuSXT+HtIQANHLbogenjTEAGGQ0VmAiN7pHjH5MUjv6eGHuimylz4Wbt8sfRzZqmsWO/PJPnjXkxuoAedemzr89tX7m+r+Nv82nKzrya+8d9Ys1n4Yrrh4hPs5Gmun2nV2mt/OOTr7+OS+O/9B2ELbANj+6QAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">buylrd</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">buylrd</text>
   </svg><svg class="plot-12" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-12 {
@@ -201,7 +201,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAkUlEQVQ4jaWQwQ6DMAxDvf//4B0m5e1AS9KQrKBJSNR+dmh4vT8AEkLjUadBUtJII9drhvlE/3MfINzDdZdb/Ss3YtY7NrMxNzxna85mN8yzlDPmjA2vZmYuPEeRa7v+P879wzeXzLl/0JkXmmWfxHbdbafxzM8qO65VsOypYWr4oe3CD2Y/tC3ePAOSZXb//QWX9h3CsjlyFgAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">blues</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">blues</text>
   </svg><svg class="plot-13" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-13 {
@@ -218,7 +218,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAnUlEQVQ4jZWQwQrDMAxD3/7/e8cuQ+qhxVESB7ZDwZae5NDX5/u2MQC2gdqwY24YY3DMT2Yken/OOtiRs71kZn3V6qbV+p2mzrN5nNK0MTp2CM1dE6MtI4++vKOOj1n5hqnrxN99xVSGnTvuoCPT9VBs3srelame8G3Ht+49o5PP7x3/7Bx8FrZ2jZnowMbaNTT6UsuO+wczGO3sul+hF1R+lzbaKQAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">greens</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">greens</text>
   </svg><svg class="plot-14" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-14 {
@@ -235,7 +235,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAARklEQVQ4jbWOMQ4AMAgC6f//LF06NWqk1sEgByYukgSAI6OqZtX9h49YxtVOZczsOfeyqK/yaq72ujedn2+e+em94rvM4xvdyaofV1ewywAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">greys</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">greys</text>
   </svg><svg class="plot-15" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-15 {
@@ -252,7 +252,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAl0lEQVQ4jZ1SURbDMAii9z/yWu2HMaKxWbevqAiiL8f5uRQAVBX2Ah4YAAyEMEAHoCUf6cpPec9V91Ewn8sY+02xazGXYst1aszaxKMWWgUjLirWvVjrmddwZIP5zi2289NoCN/mt/fN7tjsk24rWmrGSTOE9dgD98YsSMx7ik3z/3h6ePTT8WNHSNxg1XnTX/5C6v+ueQMBXBvb4i5ZxwAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">purples</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">purples</text>
   </svg><svg class="plot-16" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-16 {
@@ -269,7 +269,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAmklEQVQ4jY1SSxYDIQhL73/ZbrpNuhCEQbBdzDPk51Pnpc9bkAAIkH0jxsFrzwyt5g6ueIdZD42Nv6wcPPSZ0clbfuirmdvcakN3u0/fpVaruejd78MfPHVwShk1vpnD1pS5lFkYgS3jGA33z8qWD0wkLuGWB0AJQvB2lNW3/vpTyznYdULbS8sz6b4/8dTpfuvn4Gfx+yzd9S/BcQKTHhq9XAAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">reds</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">reds</text>
   </svg><svg class="plot-17" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-17 {
@@ -286,7 +286,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAiklEQVQ4jZ2QOxIDIQxDxf2PmjqtlYL1B6Nlk1SSn2wNw+D7RYAAiVUBzVflQy41vN1k1pjp/MroXbWXlbU5+gT/i/3qv2Cmsmflxvcu1izYfsP6x8pbdmWeXc5oXHaUTo+ptrPu6buCxVMgmHukt9ifrM7KG8odnDWNm5G3ON/c5SdOjjb3/Dx/AOLs5ro4jjvpAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">oranges</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">oranges</text>
   </svg><svg class="plot-18" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-18 {
@@ -303,7 +303,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAABH0lEQVQ4jX2QQW4bUQxDn6hJ6sTtuosse/8jSuzi64/HblADAvlIDjDj+PP7y0f+4tCdQz9J3Tnyk9Qd6YPMT6QPlDekG5E3QjeUP4h8B43mO6E3yDm9QR44D9CBM4cTS0tTOAUpWsIZkwVW4ARn0BlYDDPedILlyT1+a5+MevKG7KWzQeusWv7M6uziGx9RxOxCRUQ/qU4uNHtFo9lo83dKk5csWT53TpPDYvW7S17OTeJ/2Zv90OkOb57s9Bduo531o1c/WBddf+32Rn7mKM6d2kQbFUsbokw00Ib6j5ahrzr+dfPEL88Nd4F79GTo8rrTQ8/umtepq6teXZXpnr5N1cW316uM757nPBt7vfZk7Z0t7/mM7c3lDMTy+/cXwM9vrI9SuXIAAAAASUVORK5CYII="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">turbo</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">turbo</text>
   </svg><svg class="plot-19" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-19 {
@@ -320,7 +320,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAuklEQVQ4jYWRyxGDMAwF98mtpYT0X4qVg2VZNgEOzPsthgF99HVkyERVTCAhM5AgVajs25Z5+oMrm0tgbNvZ1ewSKHx2kyVZz1wZwJY/t0u2J+6fastP7NZxz7+dt3neWL89Nzfq5mVfuW46OWZ/6uAkj9+69vF512bp92wcuejYwteLp65fcss8tla9HGP2s+sYoerJL138xjKeNfYeu0cf9wXbqL2v89LP9yRYaIKGwgtDkRXZwg/3A1HoiQrmmp1VAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">viridis</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">viridis</text>
   </svg><svg class="plot-20" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-20 {
@@ -337,7 +337,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAvklEQVQ4jW2SSwLEMAhCgc79r+ws/Leu8gQ0TVICPyMIkAAEZzlTAB6QAqv2dWrNntXSn+WXh+QHRPQguLQHMhVnTtDQvZPW7KcYTAbDHaaOtYqILLbH7EvGkUVlJ1c250ftbFs7+nq+1T7t2ytnw7djHzuyVrO+2c35HZOZGaZuPT/ryFOtMWeomRfLf8dkKH0A5TXvNS8qOC6H6kfgerjUdh0HPHQtf9XL00vToQ/moYVupc/8V7Olac2Y9R/4sC65xxNF4gAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">magma</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">magma</text>
   </svg><svg class="plot-21" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-21 {
@@ -354,7 +354,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAzElEQVQ4jZWT0a7DIAxDjw33//+42QNJCt007T6g2McJILUIZgiBBBhhkFurtEb7rgcbSMZbr4tjXKw8K/NThzsvb5RMm1fdcGmVZ/OgR7UqB8HWx8b4P+ssPmTRc60BKfJO90yx9yy+sNjOjnVO6zj3PGY2n/WYKfajlgPrun2zQMV9ZtL1lfHscYCvnzV+93jtx5EH69eP/Li1lM9B95JTO9euTdjg8WC7H4SqZ3R/tP9UZ+qsmsnmYpuXJvhvVU2UTJpYc71PTezBC2/ibqA5x/tYAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">inferno</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">inferno</text>
   </svg><svg class="plot-22" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-22 {
@@ -371,7 +371,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAvklEQVQ4jYWSS3IEIQxDnz2bbHLunHpKs2hjBE1PFhSyPraLIn5//vRS8KKOkiTIqgdOMXGdaAwp5zBPYRmGzoZ2DuMnNzUIDW73MD3jjq0GMk63rBYRlS2cAdHYbxFpOB5w7tp1vMeNW7KnHI/6f/nOhuBb3vbiQT/xs+eWt1nY/t4Dm9v84qH7c5i3aLl7rn1PHmxm652ncXOp+jArz3iTrcb8unE01sKBRo8EFa/63LrxYfWle0a1k1KQbz5ggaELI65ogAAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">plasma</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">plasma</text>
   </svg><svg class="plot-23" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-23 {
@@ -388,7 +388,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApklEQVQ4jX1R0RXEMAgCJ7mVbv9hvI+q0WDvoy8IiDYhPl8HDc9HAHEK5ooJBjwYZNTBE7CGB0+0jPShfEbVrDICl1czxNt84i3sf7ScxzF7m3drc0+qXnjRCKDdk/ibF9ed5r6QXja/zh7+mKEZjzYz+s7KyX+99CrnOze83t7CF97bO7loVnX2XlzmDr3nvNS49a1ncmePORer79RY8Dm97hx0/AA3bzctFH85ygAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">cividis</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">cividis</text>
   </svg><svg class="plot-24" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-24 {
@@ -405,7 +405,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA4klEQVQ4jW2TSQ7DMAwDZ+j+/8vqwfKStAeBQ1owAoQWqBhEYgiiIQRNs5s1eJ2t4Q9zcy4fN9NcK7u0dPoIOnceTDO9R2dcWYGcswBWc6FTCWh1Vth7bt96cfzVN5+BwfEDfnRYBCYDw4v32LnHrymfnvzRMCqbs7J2bz2bo7O+yZMvLwP9zGz7gXzQAdcOy7e+fTkgKw+kM0NlZaGWbyahEkqpLG+fzd7M7qyd2ZvVrdlDrrx71B2qq2OrT9796vqyO9RVtx7s5uO72g++dX+GEL28XX+b7afhyR7v2/lvlS+ApkP+iM1IhQAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">cubehelix</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">cubehelix</text>
   </svg><svg class="plot-25" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-25 {
@@ -422,7 +422,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApElEQVQ4jZWMyxFDMQgDJSpLRSksRVo54A/G+E1y8CBWa/h+fUQABoIiDACxTwPhDoLjPObhmKp+zWtWdHX0O1PoQqYmO6fWX44b3s/M5UQWb/geu8Wzk/t6toOjc/S8ZmJsIQ+vPe/VDap2fuYPz/7pkBiS57sMUHdGFjszzCwCstGlTOx/LfNqZ+p8b8w9r3vbWPBIyAqW33Ts4jjHyMjc5v4FFqjP+wXb8A8AAAAASUVORK5CYII="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">warm</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">warm</text>
   </svg><svg class="plot-26" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-26 {
@@ -439,7 +439,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAtklEQVQ4jY2SSw7DMAhE3+RkPVEP1kN2ujDGkNhSFxbzA6QQvV8fWwIukBhYWJ2jC08u4aJR9fTU8xu852z8qrHRS73qjJ3PzSf7JiY1eiY+011bM33TCpej12WHY4eTc9JKf/Kc69Srt/AzM963Zw5+fZo6Ves58X14YvQpM4tLBjaY3q+YrX855jpqgWNH4uInB6TKVx2nn9hILMzC43cYdfKeoXtxwu4NvXHivI+MjlyeWPwAkPjY+7Bui08AAAAASUVORK5CYII="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">cool</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">cool</text>
   </svg><svg class="plot-27" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-27 {
@@ -456,7 +456,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApUlEQVQ4jaVSQQ7DMAxi/3/wLhvsEMfGiXtapSqAAatVXu/PV8J6FhCcJ05NycOeiUfNehXFiSHbE3rboZ7PrKzHZ7vv0Fy3HI9McYGWp7a2vITzynH0Lz55J/+c5b0nPRz0yU/rZH2nBDU/L49nFTpF++c8fGze4tW/NarzPPGgX6dhDtqFJ/7PG3f60KS4o4EbZ2HkLDBvDaw+17wDtJnQOTFmf9Q+Q35w0pS+AAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">bugn</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">bugn</text>
   </svg><svg class="plot-28" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-28 {
@@ -473,7 +473,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApUlEQVQ4jZWQSRIDMQgDO/9/cC6JNAd7MF6YVA4uhCQW83p/vrYBjA0G9tzQeXfgyN39zRf1Sdt6hG/RE869ZzzXzP2K2nXen349zOepRzGbVe/LVDkbb9CBM1iOWipOs97ygUkz++ej7sYueBSHLbF/euY9qv2Onsd9Exc38eijkzflcbtdc9ZsLAWfNVvD0/F4QjdGM0fGTZOFWaKNGPH255j1C7yIFbeqeGCeAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">bupu</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">bupu</text>
   </svg><svg class="plot-29" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-29 {
@@ -490,7 +490,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAArklEQVQ4jXVQQQ7DMAgj///sbrtMeIc4YCBRK2GMbWjX9/cBDLbf85gZ7nhrBRsM4tWcbZ2YHXti5hT344aX93pP7J23o+CsPROS4cMj+dT74YvGzJvWw2PpiX5ddCt0ZV60q1RghX9yJ4+VOQ5mcKY7zmzsLXzfV/mOs0fj2LvOULWefPUoL9ibnxw6B8Ref+QcbIPvs9RHz49WjV05j5+lGh6XvGevntA1z9H/AaAq9dkQqjhOAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">gnbu</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">gnbu</text>
   </svg><svg class="plot-30" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-30 {
@@ -507,7 +507,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAoElEQVQ4jaWSOw7DMAxD2ftftXs2soPUWJSVpECHQPEjKX9fOt4CBEiISvi4V9f1mJs4Z9+dZ+tDX0PNXOWMX/l/GWP2/P0R4MC51inOHANX5aaXM0tuXsHmiX+0+ZcnsrA+av447qoXjauf6zz1LVc8OxMkDiz9G2t616Yq5XUNXM5jmznGVwsWW9e6JshqvtLI4Dxm5KvOqvRUljncsw8WXwieRVb+eQAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">orrd</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">orrd</text>
   </svg><svg class="plot-31" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-31 {
@@ -524,7 +524,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAuklEQVQ4jY1TQRIDIQyi/39wD52BHiSKWe30FCRA4qz70vsjCQAECYAANQwBarj0t/4RA5B27KiJ92z7BzmzlH5jhH9qTvrQ8KYxZuolsOUzc+xlegV7tOqhX3OogWtO4a5laCuL2RfA2JHe8TRnZve5cbc+Z9wn8NTueL+3ObQ6swSJ3rs4hq56z6rQDp7+1q4iBHouIdFvbHmSQ+NgHUS/RfohPM+lh+euH6k0iZP753zh+Is/+IL/AtKqCZxDtul4AAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">pubugn</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">pubugn</text>
   </svg><svg class="plot-32" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-32 {
@@ -541,7 +541,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAqklEQVQ4jY2SwQ7DIAxDvf//4B0m5e1ACk6g3aQiHNtxiuDF+wNIEhq7BBJC+Ukgkh8lR5/nbH0lY3nA+ykzLn+Z1/g9v2Y/4dAvvfIxceqGq75w2Fk2znDkOWJ6nSdnVT0OudHOFok9r+Jdm1z2XfXKSc76b3tueJqH/p/Ol716sHyaH7Bltaomu1cVjnyrXA9ucuc6Fn/ghs/qiWPT6VrZ/+Mg8rK7vvAXGugHsfUHYr8AAAAASUVORK5CYII="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">pubu</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">pubu</text>
   </svg><svg class="plot-33" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-33 {
@@ -558,7 +558,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAuElEQVQ4jX1Syw7DMAwi//+7k6ZdoIeQBLvRpErYgMmr4/v5SQIAYSIgCZgfIBnNT+o/n3lFd274Dtc81N2z0flMj0422wybLgG8ZNIHKVlvDoyczYXuvaHpvR7OXXkjPLd6OPPeC6PkGCkM72d47bcefNNKTW7vPp/5OsPQ6ftuvOh3oe+S8XaH0/IGCq1fXpyZ9M06NAgsvPtVN64iLjzOjP99pp5c+OaOUXwlBxV3ra7x6n9j9T3pGQylwGAEfQAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">purd</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">purd</text>
   </svg><svg class="plot-34" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-34 {
@@ -575,7 +575,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApklEQVQ4jY2SOw7DMAxD2fsft0M3vQ6WZVqwgwwBxZ8MAfnw+yKQJAnykySKs/E2wyvOk79pp9w9i+vld+2J66oR3TOMyU8aUmjdHPdMR7oerRcI107dYOQs4x61x+60zNxPZXweSO0ZPdf2OT0auo8UedfUorrmZzdgZdoc+Ubkv9GzhVq8suqYnqN2H5GaVtdz00vu8/JsxyVzytcd2+5T/9BN/ANROsvDP7wZzQAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">rdpu</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">rdpu</text>
   </svg><svg class="plot-35" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-35 {
@@ -592,7 +592,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAuklEQVQ4jX2TSRYEIQhDw/1P2Icpfi9ABYtXK5IQcEANfiAkuQBJKDgCP7h4mpb81BQ+5rIycehlVa7YNMkzsiPywk/ett5iegLbxtXjRG3NBbfOB+25etZ+z91/r2Gvns9dv85X+N3/5Xmd9+QW/opfGCSczictLzZ4bIYcFn7FMqxVdw8PvwY9DNfaYWafNX14ICBrD2vwDZzxolLP3Mb4xjSe/y45eHr8/MmFly7vmvz48fN3d4+If66U7Y0gAHi6AAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">ylgnbu</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">ylgnbu</text>
   </svg><svg class="plot-36" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-36 {
@@ -609,7 +609,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAnElEQVQ4jaWTUQ7DMAhDvfufc9fg7WNAgCRSp6kfNsa2kNq+4I2EkElCcoTF+75w95D6zC9veuA6452MfT4ghbvpU9PilOuYO79+6Eb3W/WfsqPH+HLzThtZ47l+8mz9k8cb9Tnuy1y5N/yrv9wR+R/0HXXR+27qm2ZL4+DDxlzu2vMn/h/G75Dfo+908yXveNOUfa7Z7teGJ3/HD8C0M41UATiVAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">ylgn</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">ylgn</text>
   </svg><svg class="plot-37" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-37 {
@@ -626,7 +626,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAoklEQVQ4jY2QSxbFMAhCyf7X2W1AB/kotva9QU6Qi9ZmSJcAASIAxbGagNTUnS4z3rR+Mfqt8g0RMs6Y0fqZJS563k7NNKzrY5fPXMXLtZ4ZyrLaucMiJ/PnET0/n9TzkgAi6c1w+me0sDN/6TVHj3x4e6fs7V6dHSpLN7V+r/KpmXQ8RWTWumD1jO16zUDJWT1AvLOj//KGMdsFTa/x8Zm7ATvR4KH2ZvpqAAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">ylorbr</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">ylorbr</text>
   </svg><svg class="plot-38" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-38 {
@@ -643,7 +643,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAkklEQVQ4jY1SyREDMQgT/beWmlAeDhtZIzt5MIAOPAtb5IsgATT2TIBWb9lq96dZN1/Efte8aXwu+z881e1c4oOmaZ4D9uAw7NyvzzXPwwvned4arWbVGs6AaWbAafOoHEcjmd4vj3Izk583N53+ttaP9nTCW6yTVT4jynqgR7uttPJZxg9bL3R19e01iIxbnPg3iRO1tm9FEn0AAAAASUVORK5CYII="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">ylorrd</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">ylorrd</text>
   </svg><svg class="plot-39" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-39 {
@@ -660,7 +660,7 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAABBklEQVQ4jW2SwXHkMBADGzMb2EV0gTnGHcAPUhK99gPVaFD6sKj//77SiI5ojkQ08Lo36FzOndfVA00eJzvwIrRybDsKjSlCy3s3de0yLVNsXuHoMqWhZCSjGpBBm5fX3k7W8U2d/Owf6b96dn+YDinjDq6QBleWd3CB7+3qF3VzbtcPTgtX7W2z6kkXrj62JtVYTx+JUXgD7w+OWA68dx+0u3ij5YjR6cVEDLW3WtnbZLnTt/vyFM7qn8zNxi6SJl77T66LzHWhaeI6Lxdc6HC5YBZlrW1WlwuN7rP61UEjytobqx9P6NeTM9RknTn7n1DO9hzuj+71jX340fO4PChrJ7O2g9/scjRovHTSrgAAAABJRU5ErkJggg=="></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">rainbow</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">rainbow</text>
   </svg><svg class="plot-40" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-40 {
@@ -677,5 +677,5 @@
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA50lEQVQ4jX2SQXIFQQhCAedg//5nGjUL9dudVGVB8YBdt8zPJyEHzAELZDvMkYevao+rC6Rldc9slcNy+UmE3fIvoxndtwvN5VcWu2P37WLzrVeES3BONyy81GZqJcEhOO3uYeuzo3LgF+d0hsj10ewRd5853YOIzXnxU/mUl6MZ3WP6fx6VzeUCe2czv9x6BblAJ+jLckEvj3xKfXJ3b47DZ/+e5sXmOWcKi1wfzR5x95mwCDxRPtly+cnJp7wczege1c8l3L9fWewrYfftYvMfvZAcnDwsB7UbtZLq0Wh3D1uf/XzIH4rUWI81r8K+AAAAAElFTkSuQmCC"></image>
-    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"><text x="0" y="-22" fill="currentColor" text-anchor="start" font-weight="bold">sinebow</text></g>
+    <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g><text x="0" y="12" fill="currentColor" font-weight="bold">sinebow</text>
   </svg></div>

--- a/test/output/hexbinR.html
+++ b/test/output/hexbinR.html
@@ -26,8 +26,8 @@
       </g>
       <g class="tick" opacity="1" transform="translate(198.5,0)">
         <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">15</text>
-      </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Proportion of each sex (%)</text>
-    </g>
+      </g>
+    </g><text x="0" y="12" fill="currentColor" font-weight="bold">Proportion of each sex (%)</text>
   </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="320" viewBox="0 0 960 320" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-2 {

--- a/test/output/opacityLegend.svg
+++ b/test/output/opacityLegend.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Quantitative</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Quantitative</text>
 </svg>

--- a/test/output/opacityLegendColor.svg
+++ b/test/output/opacityLegendColor.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Linear</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Linear</text>
 </svg>

--- a/test/output/opacityLegendLinear.svg
+++ b/test/output/opacityLegendLinear.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Linear</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Linear</text>
 </svg>

--- a/test/output/opacityLegendLog.svg
+++ b/test/output/opacityLegendLog.svg
@@ -44,6 +44,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Log</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Log</text>
 </svg>

--- a/test/output/opacityLegendRange.svg
+++ b/test/output/opacityLegendRange.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">1.0</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Range</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Range</text>
 </svg>

--- a/test/output/opacityLegendSqrt.svg
+++ b/test/output/opacityLegendSqrt.svg
@@ -32,6 +32,6 @@
     </g>
     <g class="tick" opacity="1" transform="translate(240.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">1.0</text>
-    </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">Sqrt</text>
-  </g>
+    </g>
+  </g><text x="0" y="12" fill="currentColor" font-weight="bold">Sqrt</text>
 </svg>

--- a/test/output/simpsonsViews.html
+++ b/test/output/simpsonsViews.html
@@ -36,8 +36,8 @@
       </g>
       <g class="tick" opacity="1" transform="translate(200.5,0)">
         <line stroke="currentColor" y2="6" y1="-10"></line><text fill="currentColor" y="9" dy="0.71em">25</text>
-      </g><text x="0" y="-16" fill="currentColor" text-anchor="start" font-weight="bold">season</text>
-    </g>
+      </g>
+    </g><text x="0" y="12" fill="currentColor" font-weight="bold">season</text>
   </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-2 {


### PR DESCRIPTION
The label for a ramp legend was erroneously inheriting the tabular-nums font-variant needed for axis ticks. This fixes it by making it a sibling rather than a child of the axis. I guess there’s the same bug with axis labels (which very rarely include numbers, so we didn’t notice).

Before
<img width="267" alt="Screen Shot 2022-06-02 at 11 50 35 AM" src="https://user-images.githubusercontent.com/230541/171705072-5d0c2e79-62c9-4594-bf20-f3a63a04c071.png">

After
<img width="269" alt="Screen Shot 2022-06-02 at 11 50 05 AM" src="https://user-images.githubusercontent.com/230541/171704679-b35b4177-c634-4b91-a911-d915d7847d31.png">
