### PR TITLE
facet requires the data to be specified

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -51,6 +51,7 @@ export function plot(options = {}) {
     const {x, y} = facet;
     if (x != null || y != null) {
       const facetData = arrayify(facet.data);
+      if (facetData == null) throw new Error("facet requires the data to be specified");
       facetChannels = {};
       if (x != null) {
         const fx = Channel(facetData, {value: x, scale: "fx"});

--- a/src/plot.js
+++ b/src/plot.js
@@ -51,7 +51,7 @@ export function plot(options = {}) {
     const {x, y} = facet;
     if (x != null || y != null) {
       const facetData = arrayify(facet.data);
-      if (facetData == null) throw new Error("facet requires the data to be specified");
+      if (facetData == null) throw new Error("facet specification requires a data property");
       facetChannels = {};
       if (x != null) {
         const fx = Channel(facetData, {value: x, scale: "fx"});

--- a/src/plot.js
+++ b/src/plot.js
@@ -51,7 +51,7 @@ export function plot(options = {}) {
     const {x, y} = facet;
     if (x != null || y != null) {
       const facetData = arrayify(facet.data);
-      if (facetData == null) throw new Error("facet specification requires a data property");
+      if (facetData == null) throw new Error("missing facet data");
       facetChannels = {};
       if (x != null) {
         const fx = Channel(facetData, {value: x, scale: "fx"});


### PR DESCRIPTION
Note: is it explicit enough, given that a common error is people who see the pattern `{facet: {data, x: "category"} }` and replace `data` with their own variable name, resulting in `{facet: {data2, x: "category"} }`?

another wording might be `the values to facet must be specified as the data property`, or something to that effect.