### PR TITLE
Change .append() to .appendChild()

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -222,11 +222,18 @@ export function plot(options = {}) {
   if (caption != null || legends.length > 0) {
     figure = document.createElement("figure");
     figure.style.maxWidth = "initial";
-    figure.append(...legends, svg);
+    if (legends.length > 0) {
+      figure.appendChild(...legends);
+    }
+    figure.appendChild(svg);
     if (caption != null) {
       const figcaption = document.createElement("figcaption");
-      figcaption.append(caption);
-      figure.append(figcaption);
+      if (!isObject(caption)) {
+        figcaption.innerHTML = caption;
+      } else {
+        figcaption.appendChild(caption);
+      }
+      figure.appendChild(figcaption);
     }
   }
 

--- a/src/plot.js
+++ b/src/plot.js
@@ -222,17 +222,11 @@ export function plot(options = {}) {
   if (caption != null || legends.length > 0) {
     figure = document.createElement("figure");
     figure.style.maxWidth = "initial";
-    if (legends.length > 0) {
-      figure.appendChild(...legends);
-    }
+    if (legends.length > 0) figure.appendChild(...legends);
     figure.appendChild(svg);
     if (caption != null) {
       const figcaption = document.createElement("figcaption");
-      if (!isObject(caption)) {
-        figcaption.innerHTML = caption;
-      } else {
-        figcaption.appendChild(caption);
-      }
+      typeof caption === "object" ? figcaption.appendChild(caption) : (figcaption.innerHTML = caption);
       figure.appendChild(figcaption);
     }
   }


### PR DESCRIPTION
**Reason for change**
While using Plot with external frameworks that have their own Dom implementations, it's possible the framework's Dom implementation doesn't support the newer Dom.append() method. This pull requests addresses the instance where plot uses Dom.append() to add a legend or a caption by using the Dom.appendChild() method.

**Testing with Salesforce's Lightning Web Component (LWC) framework**
I found this issue while trying to use Plot inside of Salesforce.com to create customized visualizations that Salesforce isn't capable of out of the box. I was able to successfully use Plot version 0.5.0 with no issues other than when I tried to add either a legend or a caption.

To test this PR, I built a dist after running tests and uploaded dist/plot.umd.js to Salesforce and added both a legend and caption to my visualizations. Here is a sample screenshot

![image](https://user-images.githubusercontent.com/643517/175784080-fd56b3d9-b43c-49c9-b55c-f8fbfb0460ae.png)


This contribution addresses the topic raised in [this community post](https://talk.observablehq.com/t/using-plot-externally-unable-to-add-legend/6710).

