### PR TITLE
use duck test for marks

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -307,7 +307,7 @@ export function marks(...marks) {
 }
 
 function markify(mark) {
-  return mark instanceof Mark ? mark : new Render(mark);
+  return typeof mark?.render === "function" ? mark : new Render(mark);
 }
 
 class Render extends Mark {


### PR DESCRIPTION
This allows different versions of Plot to be composed, e.g.: https://observablehq.com/d/2f8e482dc7cc105f

The duck test for Mark here is limited: it only tests for a render method, but it will crash downstream if the filter or initialize methods are not defined. We could test for those, too, or provide default implementations, but I figure this is fine for now.