### PR TITLE
Added an optional css class to the x/y axes

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -18,6 +18,7 @@ export class AxisX {
     label,
     labelAnchor,
     labelOffset,
+    axisClass,
     line,
     tickRotate,
     ariaLabel,
@@ -34,6 +35,7 @@ export class AxisX {
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "left", "right"]);
     this.labelOffset = number(labelOffset);
+    this.axisClass = boolean(axisClass);
     this.line = boolean(line);
     this.tickRotate = number(tickRotate);
     this.ariaLabel = string(ariaLabel);
@@ -64,6 +66,7 @@ export class AxisX {
       label,
       labelAnchor,
       labelOffset,
+      axisClass,
       line,
       name,
       tickRotate
@@ -72,6 +75,7 @@ export class AxisX {
     const offsetSign = axis === "top" ? -1 : 1;
     const ty = offsetSign * offset + (axis === "top" ? marginTop : height - marginBottom);
     return create("svg:g", context)
+        .call(applyCssClass, this, 'axis')
         .call(applyAria, this)
         .attr("transform", `translate(${offsetLeft},${ty})`)
         .call(createAxis(axis === "top" ? axisTop : axisBottom, x, this))
@@ -84,6 +88,7 @@ export class AxisX {
           : fy ? gridFacetX(index, fy, -ty)
           : gridX(offsetSign * (marginBottom + marginTop - height)))
         .call(!label ? () => {} : g => g.append("text")
+            .call(applyCssClass, this, 'axis-label')
             .attr("fill", "currentColor")
             .attr("transform", `translate(${
                 labelAnchor === "center" ? (width + marginLeft - marginRight) / 2
@@ -112,6 +117,7 @@ export class AxisY {
     label,
     labelAnchor,
     labelOffset,
+    axisClass,
     line,
     tickRotate,
     ariaLabel,
@@ -128,6 +134,7 @@ export class AxisY {
     this.label = string(label);
     this.labelAnchor = maybeKeyword(labelAnchor, "labelAnchor", ["center", "top", "bottom"]);
     this.labelOffset = number(labelOffset);
+    this.axisClass = boolean(axisClass);
     this.line = boolean(line);
     this.tickRotate = number(tickRotate);
     this.ariaLabel = string(ariaLabel);
@@ -156,6 +163,7 @@ export class AxisY {
       label,
       labelAnchor,
       labelOffset,
+      axisClass,
       line,
       name,
       tickRotate
@@ -164,6 +172,7 @@ export class AxisY {
     const offsetSign = axis === "left" ? -1 : 1;
     const tx = offsetSign * offset + (axis === "right" ? width - marginRight : marginLeft);
     return create("svg:g", context)
+        .call(applyCssClass, this, "axis")
         .call(applyAria, this)
         .attr("transform", `translate(${tx},${offsetTop})`)
         .call(createAxis(axis === "right" ? axisRight : axisLeft, y, this))
@@ -176,6 +185,7 @@ export class AxisY {
           : fx ? gridFacetY(index, fx, -tx)
           : gridY(offsetSign * (marginLeft + marginRight - width)))
         .call(!label ? () => {} : g => g.append("text")
+            .call(applyCssClass, this, 'axis-label')
             .attr("fill", "currentColor")
             .attr("font-variant", fontVariant == null ? null : "normal")
             .attr("transform", `translate(${labelOffset * offsetSign},${
@@ -202,6 +212,15 @@ function applyAria(selection, {
 }) {
   applyAttr(selection, "aria-label", ariaLabel);
   applyAttr(selection, "aria-description", ariaDescription);
+}
+
+function applyCssClass(selection, {
+  name,
+  axisClass,
+}, cssClass) {
+  if(axisClass === true) {
+    applyAttr(selection, "class", `${name}-${cssClass}`);
+  }
 }
 
 function gridX(y2) {

--- a/test/plots/aapl-bollinger.js
+++ b/test/plots/aapl-bollinger.js
@@ -4,8 +4,12 @@ import * as d3 from "d3";
 export default async function() {
   const AAPL = await d3.csv("data/aapl.csv", d3.autoType);
   return Plot.plot({
+    x: {
+      axisClass: true
+    },
     y: {
-      grid: true
+      grid: true,
+      axisClass: true
     },
     marks: [
       Plot.areaY(AAPL, Plot.map({y1: bollinger(20, -2), y2: bollinger(20, 2)}, {x: "Date", y: "Close", fillOpacity: 0.2})),


### PR DESCRIPTION
This is my first PR! 🙂

Related. https://github.com/observablehq/plot/issues/6

This PR introduces optional CSS classes for the `x` and `y` axes.

```
Plot.plot({
    x: {
      axisClass: true
    },
    y: {
      axisClass: true
});
```

If `axisClass` is _not_ defined or is `false`, then no CSS classes get added to the plot. I kind of like the current clean tree of attributes that Plot creates by default. So I considered maintaining this and only adding CSS classes for axes if specifically opted in.

If `axisClass` has been defined then it inserts the following classes. Note: Only the classes for the y-axis are shown below, but it's exactly the same for the x-axis if CSS classes are enabled.

```
<g class="y-axis" aria-label="y-axis" aria-description="↑ Close" transform="translate(40,0)" fill="none" text-anchor="end" font-variant="tabular-nums">
  <g class="tick" opacity="1" transform="translate(0,358.4133255882662)"><line stroke="currentColor" x2="-6"></line><line stroke="currentColor" x2="580" stroke-opacity="0.1"></line><text fill="currentColor" x="-9" dy="0.32em">60</text></g>

  ...

  <text class="y-axis-label" fill="currentColor" font-variant="normal" transform="translate(-40,20)" dy="-1em" text-anchor="start">↑ Close</text>
</g>
```

FYI - I've not added any docs for this PR yet. If it looks like it will be accepted then I'll update it of course.