### PR TITLE
esbuild loader

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,6 @@
 {
-  "require": ["module-alias/register.js", "ts-node/register"],
-  "loader": "ts-node/esm",
+  "require": ["module-alias/register.js"],
+  "loader": "@esbuild-kit/esm-loader",
   "extensions": ["js", "ts"],
   "spec": [
     "test/**/*-test.*",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
+    "@esbuild-kit/esm-loader": "^2.4.0",
     "@rollup/plugin-commonjs": "22",
     "@rollup/plugin-json": "4",
     "@rollup/plugin-node-resolve": "13",
@@ -59,7 +60,6 @@
     "module-alias": "2",
     "rollup": "2",
     "rollup-plugin-terser": "7",
-    "ts-node": "^10.8.0",
     "tslib": "^2.4.0",
     "typescript": "^4.6.4",
     "typescript-module-alias": "^1.0.2",

--- a/src/axes.js
+++ b/src/axes.js
@@ -1,6 +1,6 @@
 import {extent} from "d3";
 import {AxisX, AxisY} from "./axis.js";
-import {formatDefault} from "./format.js";
+import {formatDefault} from "./format";
 import {isOrdinalScale, isTemporalScale, scaleOrder} from "./scales.js";
 import {position, registry} from "./scales/index.js";
 

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,7 +1,7 @@
 import {axisTop, axisBottom, axisRight, axisLeft, format, utcFormat} from "d3";
 import {create} from "./context.js";
-import {formatIsoDate} from "./format.js";
-import {radians} from "./math.js";
+import {formatIsoDate} from "./format";
+import {radians} from "./math";
 import {boolean, take, number, string, keyword, maybeKeyword, constant, isTemporal} from "./options.js";
 import {applyAttr, impliedString} from "./style.js";
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {format as isoFormat} from "isoformat";
 import {string} from "./options.js";
-import {memoize1} from "./memoize.js";
+import {memoize1} from "./memoize";
 
 const numberFormat = memoize1<Intl.NumberFormat>((locale: string | string[] | undefined) => new Intl.NumberFormat(locale));
 const monthFormat = memoize1<Intl.DateTimeFormat>((locale: string | string[] | undefined, month: "numeric" | "2-digit" | "long" | "short" | "narrow" | undefined) => new Intl.DateTimeFormat(locale, {timeZone: "UTC", month}));

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,6 @@ export {window, windowX, windowY} from "./transforms/window.js";
 export {select, selectFirst, selectLast, selectMaxX, selectMaxY, selectMinX, selectMinY} from "./transforms/select.js";
 export {stackX, stackX1, stackX2, stackY, stackY1, stackY2} from "./transforms/stack.js";
 export {treeNode, treeLink} from "./transforms/tree.js";
-export {formatIsoDate, formatWeekday, formatMonth} from "./format.js";
+export {formatIsoDate, formatWeekday, formatMonth} from "./format";
 export {scale} from "./scales.js";
 export {legend} from "./legends.js";

--- a/src/marks/area.js
+++ b/src/marks/area.js
@@ -1,6 +1,6 @@
 import {area as shapeArea} from "d3";
 import {create} from "../context.js";
-import {Curve} from "../curve.js";
+import {Curve} from "../curve";
 import {first, indexOf, maybeZ, second} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyGroupedChannelStyles, groupIndex} from "../style.js";

--- a/src/marks/arrow.js
+++ b/src/marks/arrow.js
@@ -1,5 +1,5 @@
 import {create} from "../context.js";
-import {radians} from "../math.js";
+import {radians} from "../math";
 import {constant} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransform} from "../style.js";

--- a/src/marks/delaunay.js
+++ b/src/marks/delaunay.js
@@ -1,6 +1,6 @@
 import {group, path, select, Delaunay} from "d3";
 import {create} from "../context.js";
-import {Curve} from "../curve.js";
+import {Curve} from "../curve";
 import {constant, maybeTuple, maybeZ} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyChannelStyles, applyDirectStyles, applyFrameAnchor, applyIndirectStyles, applyTransform} from "../style.js";

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -1,6 +1,6 @@
 import {path, symbolCircle} from "d3";
 import {create} from "../context.js";
-import {positive} from "../defined.js";
+import {positive} from "../defined";
 import {identity, maybeFrameAnchor, maybeNumberChannel, maybeTuple} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyChannelStyles, applyDirectStyles, applyFrameAnchor, applyIndirectStyles, applyTransform} from "../style.js";

--- a/src/marks/image.js
+++ b/src/marks/image.js
@@ -1,5 +1,5 @@
 import {create} from "../context.js";
-import {positive} from "../defined.js";
+import {positive} from "../defined";
 import {maybeFrameAnchor, maybeNumberChannel, maybeTuple, string} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransform, applyAttr, impliedString, applyFrameAnchor} from "../style.js";

--- a/src/marks/line.js
+++ b/src/marks/line.js
@@ -1,6 +1,6 @@
 import {line as shapeLine} from "d3";
 import {create} from "../context.js";
-import {Curve} from "../curve.js";
+import {Curve} from "../curve";
 import {indexOf, identity, maybeTuple, maybeZ} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyGroupedChannelStyles, groupIndex} from "../style.js";

--- a/src/marks/link.js
+++ b/src/marks/link.js
@@ -1,6 +1,6 @@
 import {path} from "d3";
 import {create} from "../context.js";
-import {Curve} from "../curve.js";
+import {Curve} from "../curve";
 import {Mark} from "../plot.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransform} from "../style.js";
 import {markers, applyMarkers} from "./marker.js";

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -1,7 +1,7 @@
 import {namespaces} from "d3";
 import {create} from "../context.js";
-import {nonempty} from "../defined.js";
-import {formatDefault} from "../format.js";
+import {nonempty} from "../defined";
+import {formatDefault} from "../format";
 import {indexOf, identity, string, maybeNumberChannel, maybeTuple, numberChannel, isNumeric, isTemporal, keyword, maybeFrameAnchor, isTextual, isIterable} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyAttr, applyTransform, impliedString, applyFrameAnchor} from "../style.js";

--- a/src/marks/vector.js
+++ b/src/marks/vector.js
@@ -1,5 +1,5 @@
 import {create} from "../context.js";
-import {radians} from "../math.js";
+import {radians} from "../math";
 import {maybeFrameAnchor, maybeNumberChannel, maybeTuple, keyword, identity} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyChannelStyles, applyDirectStyles, applyFrameAnchor, applyIndirectStyles, applyTransform} from "../style.js";

--- a/src/plot.js
+++ b/src/plot.js
@@ -2,7 +2,7 @@ import {cross, difference, groups, InternMap, select} from "d3";
 import {Axes, autoAxisTicks, autoScaleLabels} from "./axes.js";
 import {Channel, channelObject, channelDomain, valueObject} from "./channel.js";
 import {Context, create} from "./context.js";
-import {defined} from "./defined.js";
+import {defined} from "./defined";
 import {Dimensions} from "./dimensions.js";
 import {Legends, exposeLegends} from "./legends.js";
 import {arrayify, isDomainSort, isScaleOptions, keyword, map, range, second, where, yes} from "./options.js";
@@ -11,7 +11,7 @@ import {position, registry as scaleRegistry} from "./scales/index.js";
 import {applyInlineStyles, maybeClassName, maybeClip, styles} from "./style.js";
 import {basic, initializer} from "./transforms/basic.js";
 import {maybeInterval} from "./transforms/interval.js";
-import {consumeWarnings} from "./warnings.js";
+import {consumeWarnings} from "./warnings";
 
 export function plot(options = {}) {
   const {facet, style, caption, ariaLabel, ariaDescription} = options;

--- a/src/scales.js
+++ b/src/scales.js
@@ -7,7 +7,7 @@ import {isDivergingScheme} from "./scales/schemes.js";
 import {ScaleTime, ScaleUtc} from "./scales/temporal.js";
 import {ScaleOrdinal, ScalePoint, ScaleBand, ordinalImplicit} from "./scales/ordinal.js";
 import {isSymbol, maybeSymbol} from "./symbols.js";
-import {warn} from "./warnings.js";
+import {warn} from "./warnings";
 
 export function Scales(channelsByScale, {
   inset: globalInset = 0,

--- a/src/scales/diverging.js
+++ b/src/scales/diverging.js
@@ -7,7 +7,7 @@ import {
   scaleDivergingPow,
   scaleDivergingSymlog
 } from "d3";
-import {positive, negative} from "../defined.js";
+import {positive, negative} from "../defined";
 import {quantitativeScheme} from "./schemes.js";
 import {registry, color} from "./index.js";
 import {inferDomain, Interpolator, flip, interpolatePiecewise} from "./quantitative.js";

--- a/src/scales/ordinal.js
+++ b/src/scales/ordinal.js
@@ -1,6 +1,6 @@
 import {InternSet, extent, quantize, reverse as reverseof, sort, symbolsFill, symbolsStroke} from "d3";
 import {scaleBand, scaleOrdinal, scalePoint, scaleImplicit} from "d3";
-import {ascendingDefined} from "../defined.js";
+import {ascendingDefined} from "../defined";
 import {isNoneish, map} from "../options.js";
 import {maybeInterval} from "../transforms/interval.js";
 import {maybeSymbol} from "../symbols.js";

--- a/src/scales/quantitative.js
+++ b/src/scales/quantitative.js
@@ -23,7 +23,7 @@ import {
   scaleIdentity,
   ticks
 } from "d3";
-import {positive, negative, finite} from "../defined.js";
+import {positive, negative, finite} from "../defined";
 import {arrayify, constant, order, slice} from "../options.js";
 import {ordinalRange, quantitativeScheme} from "./schemes.js";
 import {maybeInterval} from "../transforms/interval.js";

--- a/src/style.js
+++ b/src/style.js
@@ -1,8 +1,8 @@
 import {group, namespaces} from "d3";
-import {defined, nonempty} from "./defined.js";
-import {formatDefault} from "./format.js";
+import {defined, nonempty} from "./defined";
+import {formatDefault} from "./format";
 import {string, number, maybeColorChannel, maybeNumberChannel, isNoneish, isNone, isRound, keyof} from "./options.js";
-import {warn} from "./warnings.js";
+import {warn} from "./warnings";
 
 export const offset = typeof window !== "undefined" && window.devicePixelRatio > 1 ? 0 : 0.5;
 

--- a/src/transforms/basic.js
+++ b/src/transforms/basic.js
@@ -1,5 +1,5 @@
 import {randomLcg} from "d3";
-import {ascendingDefined, descendingDefined} from "../defined.js";
+import {ascendingDefined, descendingDefined} from "../defined";
 import {arrayify, isDomainSort, isOptions, maybeValue, valueof} from "../options.js";
 
 // If both t1 and t2 are defined, returns a composite transform that first

--- a/src/transforms/dodge.js
+++ b/src/transforms/dodge.js
@@ -1,5 +1,5 @@
 import IntervalTree from "interval-tree-1d";
-import {finite, positive} from "../defined.js";
+import {finite, positive} from "../defined";
 import {identity, number, valueof} from "../options.js";
 import {coerceNumbers} from "../scales.js";
 import {initializer} from "./basic.js";

--- a/src/transforms/group.js
+++ b/src/transforms/group.js
@@ -1,5 +1,5 @@
 import {group as grouper, sort, sum, deviation, min, max, mean, median, mode, variance, InternSet, minIndex, maxIndex, rollup} from "d3";
-import {ascendingDefined} from "../defined.js";
+import {ascendingDefined} from "../defined";
 import {valueof, maybeColorChannel, maybeInput, maybeTuple, maybeColumn, column, first, identity, take, labelof, range, second, percentile} from "../options.js";
 import {basic} from "./basic.js";
 

--- a/src/transforms/normalize.js
+++ b/src/transforms/normalize.js
@@ -1,5 +1,5 @@
 import {extent, deviation, max, mean, median, min, sum} from "d3";
-import {defined} from "../defined.js";
+import {defined} from "../defined";
 import {percentile, take} from "../options.js";
 import {mapX, mapY} from "./map.js";
 

--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -1,5 +1,5 @@
 import {InternMap, cumsum, group, groupSort, greatest, max, min, rollup, sum} from "d3";
-import {ascendingDefined} from "../defined.js";
+import {ascendingDefined} from "../defined";
 import {field, column, maybeColumn, maybeZ, mid, range, valueof, maybeZero, one} from "../options.js";
 import {basic} from "./basic.js";
 

--- a/src/transforms/tree.js
+++ b/src/transforms/tree.js
@@ -1,5 +1,5 @@
 import {stratify, tree} from "d3";
-import {ascendingDefined} from "../defined.js";
+import {ascendingDefined} from "../defined";
 import {column, identity, isObject, one, valueof} from "../options.js";
 import {basic} from "./basic.js";
 

--- a/src/transforms/window.js
+++ b/src/transforms/window.js
@@ -1,6 +1,6 @@
 import {mapX, mapY} from "./map.js";
 import {deviation, max, min, median, mode, variance} from "d3";
-import {warn} from "../warnings.js";
+import {warn} from "../warnings";
 import {percentile} from "../options.js";
 
 export function windowX(windowOptions = {}, options) {

--- a/test/marks/memoize-test.js
+++ b/test/marks/memoize-test.js
@@ -1,4 +1,4 @@
-import {memoize1} from "../../src/memoize.js";
+import {memoize1} from "../../src/memoize";
 import assert from "assert";
 
 it("memoize1(compute) returns the cached value with repeated calls", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,5 @@
       "@observablehq/plot": ["./src/index.js"]
     }
   },
-  "ts-node": { "files": true },
   "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,21 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@cspotcode/source-map-support@^0.8.0":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
-  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+"@esbuild-kit/core-utils@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/core-utils/-/core-utils-2.0.2.tgz#2b12beb95252ab4a207de16cd2dafcb4de1e1f86"
+  integrity sha512-clNYQUsqtc36pzW5EufMsahcbLG45EaW3YDyf0DlaS0eCMkDXpxIlHwPC0rndUwG6Ytk9sMSD5k1qHbwYEC/OQ==
   dependencies:
-    "@jridgewell/trace-mapping" "0.3.9"
+    esbuild "~0.14.47"
+    source-map-support "^0.5.21"
+
+"@esbuild-kit/esm-loader@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/esm-loader/-/esm-loader-2.4.0.tgz#feaa94aeedb2b95cb2b30c77160629fdf2be941e"
+  integrity sha512-zS720jXh06nfg5yAzm6oob4sWN9VTP2E1SonhFgEb6zCBswa4S8fOQ/4Bksz1flDgn56NPqoTTDn2XmWRyMG9Q==
+  dependencies:
+    "@esbuild-kit/core-utils" "^2.0.0"
+    get-tsconfig "^4.1.0"
 
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
@@ -116,14 +125,6 @@
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
-
-"@jridgewell/trace-mapping@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
-  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
@@ -227,26 +228,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
-
-"@tsconfig/node10@^1.0.7":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
-  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
-
-"@tsconfig/node12@^1.0.7":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
-  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
-
-"@tsconfig/node14@^1.0.0":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
-  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
-
-"@tsconfig/node16@^1.0.2":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
-  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
 "@types/d3-array@*":
   version "3.0.3"
@@ -656,17 +637,12 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.1.1:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
-  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
-
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1:
+acorn@^8.5.0, acorn@^8.7.1:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
@@ -737,11 +713,6 @@ are-we-there-yet@^2.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
-
-arg@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
-  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -958,11 +929,6 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
-
-create-require@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
-  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.2:
   version "7.0.3"
@@ -1309,11 +1275,6 @@ diff@5.0.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
-
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -1450,7 +1411,7 @@ esbuild-windows-arm64@0.14.48:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.48.tgz#762c0562127d8b09bfb70a3c816460742dd82880"
   integrity sha512-HHaOMCsCXp0rz5BT2crTka6MPWVno121NKApsGs/OIW5QC0ggC69YMGs1aJct9/9FSUF4A1xNE/cLvgB5svR4g==
 
-esbuild@^0.14.27:
+esbuild@^0.14.27, esbuild@~0.14.47:
   version "0.14.48"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.48.tgz#da5d8d25cd2d940c45ea0cfecdca727f7aee2b85"
   integrity sha512-w6N1Yn5MtqK2U1/WZTX9ZqUVb8IOLZkZ5AdHkT6x3cHDMVsYWC7WPdiLmx19w3i4Rwzy5LqsEMtVihG3e4rFzA==
@@ -1774,6 +1735,11 @@ get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-tsconfig@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.1.0.tgz#325fd5a58ee94596037263ce8b7db0ce8ac7b925"
+  integrity sha512-bhshxJhpfmeQ8x4fAvDqJV2VfGp5TfHdLpmBpNZZhMoVyfIrOippBW4mayC3DT9Sxuhcyl56Efw61qL28hG4EQ==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -2230,7 +2196,7 @@ make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1.1.1, make-error@^1.3.6:
+make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -2756,7 +2722,7 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
-source-map-support@~0.5.20:
+source-map-support@^0.5.21, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -2895,25 +2861,6 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-ts-node@^10.8.0:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.2.tgz#3185b75228cef116bf82ffe8762594f54b2a23f2"
-  integrity sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==
-  dependencies:
-    "@cspotcode/source-map-support" "^0.8.0"
-    "@tsconfig/node10" "^1.0.7"
-    "@tsconfig/node12" "^1.0.7"
-    "@tsconfig/node14" "^1.0.0"
-    "@tsconfig/node16" "^1.0.2"
-    acorn "^8.4.1"
-    acorn-walk "^8.1.1"
-    arg "^4.1.0"
-    create-require "^1.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    v8-compile-cache-lib "^3.0.1"
-    yn "3.1.1"
-
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -2985,11 +2932,6 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-v8-compile-cache-lib@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
-  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -3168,11 +3110,6 @@ yargs@16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
-
-yn@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This seems significantly faster than using ts-node.

A consequence is that we have to change the imports to drop the extension when using TypeScript. (We could import as .ts, but Rollup’s TypeScript plugin didn’t seem to support that.) Is that okay? Not sure what the trade-off is.