### PR TITLE
remove spec from .mocharc.json

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,14 +1,5 @@
 {
   "require": ["module-alias/register.js"],
   "loader": "./loader.js",
-  "extensions": ["js", "ts"],
-  "spec": [
-    "test/**/*-test.*",
-    "test/plot.js"
-  ],
-  "watch-files": [
-    "bundle.js",
-    "test",
-    "src"
-  ]
+  "extensions": ["js", "ts"]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,12 @@ it("formatMonth(locale, format) does the right thing", () => {
 
 Plot’s unit tests are written with [Mocha](https://mochajs.org).
 
+If you like, you can also run Mocha in watch mode for a specific file, so that unit tests re-run automatically when you make changes. For example:
+
+```bash
+yarn run mocha --conditions=mocha --parallel --watch test/marks/bar-test.js
+```
+
 ### Snapshot tests
 
 Snapshot tests live in `test/plots` and are registered in [`test/plots/index.js`](./test/plots/index.js); see [`test/plots/aapl-bollinger.js`](./test/plots/aapl-bollinger.js) for example. Unlike unit tests which only test individual methods, snapshot tests actually visualize data—they’re more representative of how we expect people will use Plot. Snapshot tests can also serve as examples of how to use the Plot API, though note that some of the examples intentionally test edge case of the API and may not embody best practices. Each snapshot test defines a plot by exporting a default async function. For example, here’s a line chart using BLS unemployment data:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "test": "yarn test:typecheck && yarn test:lint && yarn test:mocha",
-    "test:mocha": "mkdir -p test/output && mocha --conditions=mocha",
+    "test:mocha": "mkdir -p test/output && mocha --conditions=mocha 'test/**/*-test.*' 'test/plot.js'",
     "test:lint": "eslint src test",
     "test:typecheck": "tsc --noEmit",
     "prepublishOnly": "rm -rf dist && rollup -c && tsc",


### PR DESCRIPTION
I’m not sure why this was added as part of TypeScript in #880, but having the spec in the .mocharc.json makes it harder to give Mocha a different spec from the command line. (It seems that Mocha ignores the spec on the command line in favor of the one in the .mocharc.json.) This changes makes it easier to run Mocha in watch mode on a custom spec, as shown in the CONTRIBUTING.md.