### PR TITLE
Document "mode" for group transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1784,6 +1784,7 @@ The following aggregation methods are supported:
 * *max-index* - the zero-based index of the maximum value
 * *mean* - the mean value (average)
 * *median* - the median value
+* *mode* - the value with the most occurrences
 * *pXX* - the percentile value, where XX is a number in [00,99]
 * *deviation* - the standard deviation
 * *variance* - the variance per [Welford’s algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm)


### PR DESCRIPTION
As far as I can tell, the `group` transform [accepts `"mode"` as an aggregation method](https://github.com/observablehq/plot/blob/08d3311f15dd628285c132997dee57b864e6aa58/src/transforms/group.js#L218).

This PR adds `"mode"` to the `README` in the list of aggregation methods for the `group` transform.

I'm not a statistics whiz, so I copied the `"mode"` entry from elsewhere with the assumption that it works the same.