### PR TITLE
grid decoration mark

### DIFF
--- a/src/axes.js
+++ b/src/axes.js
@@ -27,14 +27,14 @@ export function Axes(
 // Mutates axis.ticks!
 // TODO Populate tickFormat if undefined, too?
 export function autoAxisTicks({x, y, fx, fy}, {x: xAxis, y: yAxis, fx: fxAxis, fy: fyAxis}) {
-  if (fxAxis) autoAxisTicksK(fx, fxAxis, 80);
-  if (fyAxis) autoAxisTicksK(fy, fyAxis, 35);
-  if (xAxis) autoAxisTicksK(x, xAxis, 80);
-  if (yAxis) autoAxisTicksK(y, yAxis, 35);
+  if (fxAxis) autoAxisTickFormatK(fx, fxAxis);
+  if (fyAxis) autoAxisTickFormatK(fy, fyAxis);
+  if (xAxis) autoAxisTicksK(x, xAxis, 80), autoAxisTickFormatK(x, xAxis);
+  if (yAxis) autoAxisTicksK(y, yAxis, 35), autoAxisTickFormatK(y, yAxis);
 }
 
 function autoAxisTicksK(scale, axis, k) {
-  if (axis.ticks === undefined) {
+  if (axis.ticks === undefined && !isOrdinalScale(scale)) {
     const interval = scale.interval;
     if (interval !== undefined) {
       const [min, max] = extent(scale.scale.domain());
@@ -44,9 +44,12 @@ function autoAxisTicksK(scale, axis, k) {
       axis.ticks = (max - min) / k;
     }
   }
-  // D3’s ordinal scales simply use toString by default, but if the ordinal
-  // scale domain (or ticks) are numbers or dates (say because we’re applying a
-  // time interval to the ordinal scale), we want Plot’s default formatter.
+}
+
+// D3’s ordinal scales simply use toString by default, but if the ordinal
+// scale domain (or ticks) are numbers or dates (say because we’re applying a
+// time interval to the ordinal scale), we want Plot’s default formatter.
+function autoAxisTickFormatK(scale, axis) {
   if (axis.tickFormat === undefined && isOrdinalScale(scale)) {
     axis.tickFormat = formatDefault;
   }

--- a/src/context.js
+++ b/src/context.js
@@ -1,7 +1,7 @@
 import {creator, select} from "d3";
 
-export function Context({document = window.document} = {}) {
-  return {document};
+export function Context({document = window.document} = {}, axes) {
+  return {axes, document};
 }
 
 export function create(name, {document}) {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export {delaunayLink, delaunayMesh, hull, voronoi, voronoiMesh} from "./marks/de
 export {Density, density} from "./marks/density.js";
 export {Dot, dot, dotX, dotY, circle, hexagon} from "./marks/dot.js";
 export {Frame, frame} from "./marks/frame.js";
+export {Grid, grid, gridX, gridY} from "./marks/grid.js";
 export {Hexgrid, hexgrid} from "./marks/hexgrid.js";
 export {Image, image} from "./marks/image.js";
 export {Line, line, lineX, lineY} from "./marks/line.js";

--- a/src/marks/grid.js
+++ b/src/marks/grid.js
@@ -1,0 +1,89 @@
+import {create} from "../context.js";
+import {isOptions, number} from "../options.js";
+import {Mark} from "../plot.js";
+import {applyDirectStyles, applyIndirectStyles, applyTransform} from "../style.js";
+
+const defaults = {
+  ariaLabel: "grid",
+  fill: "none",
+  stroke: "currentColor",
+  strokeOpacity: 0.1
+};
+
+export class Grid extends Mark {
+  constructor(options = {}, x, y) {
+    const {
+      ticks,
+      inset = 0,
+      insetTop = inset,
+      insetRight = inset,
+      insetBottom = inset,
+      insetLeft = inset
+    } = options;
+    super(undefined, undefined, options, defaults);
+    this.insetTop = number(insetTop);
+    this.insetRight = number(insetRight);
+    this.insetBottom = number(insetBottom);
+    this.insetLeft = number(insetLeft);
+    this.ticks = ticks;
+    this.x = x;
+    this.y = y;
+  }
+  render(index, scales, channels, dimensions, context) {
+    const {x, y} = scales;
+    const {marginTop, marginRight, marginBottom, marginLeft, width, height} = dimensions;
+    const {insetTop, insetRight, insetBottom, insetLeft, ticks} = this;
+    const {axes} = context;
+    const ax = this.x === "auto" ? !!x : this.x;
+    const ay = this.y === "auto" ? !!y : this.y;
+    if (ax && !x) throw new Error("missing scale: x");
+    if (ay && !y) throw new Error("missing scale: y");
+    const tx = !ax? [] : ticks !== undefined ? ticks : axes.x?.ticks;
+    const ty = !ay? [] : ticks !== undefined ? ticks : axes.y?.ticks;
+    return create("svg:g", context)
+        .call(applyIndirectStyles, this, scales, dimensions)
+        .call(applyTransform, this, {})
+        .call(g => g.selectAll()
+          .data(tickValues(x, tx))
+          .enter()
+          .append("line")
+            .call(applyDirectStyles, this)
+            .attr("x1", x)
+            .attr("x2", x)
+            .attr("y1", marginTop + insetTop)
+            .attr("y2", height - marginBottom - insetBottom))
+        .call(g => g.selectAll()
+          .data(tickValues(y, ty))
+          .enter()
+          .append("line")
+            .call(applyDirectStyles, this)
+            .attr("y1", y)
+            .attr("y2", y)
+            .attr("x1", marginLeft + insetLeft)
+            .attr("x2", width - marginRight - insetRight))
+      .node();
+  }
+}
+
+function tickValues(scale, ticks) {
+  return Array.isArray(ticks) ? ticks : scale.ticks(ticks);
+}
+
+function mergeOptions(ticks, options) {
+  return isOptions(ticks) ? ticks : {...options, ticks};
+}
+
+export function grid(ticks, options) {
+  options = mergeOptions(ticks, options);
+  return new Grid(options, "auto", "auto");
+}
+
+export function gridX(ticks, options) {
+  options = mergeOptions(ticks, options);
+  return new Grid(options, true, false);
+}
+
+export function gridY(ticks, options) {
+  options = mergeOptions(ticks, options);
+  return new Grid(options, false, true);
+}

--- a/src/plot.js
+++ b/src/plot.js
@@ -88,7 +88,7 @@ export function plot(options = {}) {
   const scales = ScaleFunctions(scaleDescriptors);
   const axes = Axes(scaleDescriptors, options);
   const dimensions = Dimensions(scaleDescriptors, axes, options);
-  const context = Context(options);
+  const context = Context(options, axes);
 
   autoScaleRange(scaleDescriptors, dimensions);
   autoAxisTicks(scaleDescriptors, axes);

--- a/test/output/anscombeQuartetGrid.svg
+++ b/test/output/anscombeQuartetGrid.svg
@@ -1,0 +1,331 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="240" viewBox="0 0 960 240" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis" aria-description="↑ y" transform="translate(40,0)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,188.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">4</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,154.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">6</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,120.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">8</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,86.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">10</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(0,52.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">12</text>
+    </g><text fill="currentColor" font-variant="normal" transform="translate(-40,30)" dy="-1em" text-anchor="start">↑ y</text>
+  </g>
+  <g aria-label="fx-axis" aria-description="series" transform="translate(0,30)" fill="none" text-anchor="middle">
+    <g class="tick" opacity="1" transform="translate(145.5,0)">
+      <line stroke="currentColor" y2="0"></line><text fill="currentColor" y="-9" dy="0em">1</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(375.5,0)">
+      <line stroke="currentColor" y2="0"></line><text fill="currentColor" y="-9" dy="0em">2</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(605.5,0)">
+      <line stroke="currentColor" y2="0"></line><text fill="currentColor" y="-9" dy="0em">3</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(835.5,0)">
+      <line stroke="currentColor" y2="0"></line><text fill="currentColor" y="-9" dy="0em">4</text>
+    </g><text fill="currentColor" transform="translate(490,-30)" dy="1em" text-anchor="middle">series</text>
+  </g>
+  <g aria-label="x-axis" transform="translate(42,210)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(17.8125,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">5</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(79.375,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(140.9375,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">15</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(202.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">20</text>
+    </g>
+  </g>
+  <g aria-label="x-axis" transform="translate(272,210)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(17.8125,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">5</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(79.375,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(140.9375,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">15</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(202.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">20</text>
+    </g>
+  </g>
+  <g aria-label="x-axis" transform="translate(502,210)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(17.8125,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">5</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(79.375,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(140.9375,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">15</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(202.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">20</text>
+    </g>
+  </g>
+  <g aria-label="x-axis" aria-description="x →" transform="translate(732,210)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(17.8125,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">5</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(79.375,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">10</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(140.9375,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">15</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(202.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">20</text>
+    </g><text fill="currentColor" transform="translate(227,30)" dy="-0.32em" text-anchor="end">x →</text>
+  </g>
+  <g aria-label="facet" transform="translate(42,0)">
+    <g aria-label="grid" fill="none" stroke="red" stroke-opacity="0.1" transform="translate(0.5,0.5)">
+      <line x1="5" x2="5" y1="30" y2="210"></line>
+      <line x1="17.3125" x2="17.3125" y1="30" y2="210"></line>
+      <line x1="29.625" x2="29.625" y1="30" y2="210"></line>
+      <line x1="41.9375" x2="41.9375" y1="30" y2="210"></line>
+      <line x1="54.25" x2="54.25" y1="30" y2="210"></line>
+      <line x1="66.5625" x2="66.5625" y1="30" y2="210"></line>
+      <line x1="78.875" x2="78.875" y1="30" y2="210"></line>
+      <line x1="91.1875" x2="91.1875" y1="30" y2="210"></line>
+      <line x1="103.5" x2="103.5" y1="30" y2="210"></line>
+      <line x1="115.8125" x2="115.8125" y1="30" y2="210"></line>
+      <line x1="128.125" x2="128.125" y1="30" y2="210"></line>
+      <line x1="140.4375" x2="140.4375" y1="30" y2="210"></line>
+      <line x1="152.75" x2="152.75" y1="30" y2="210"></line>
+      <line x1="165.0625" x2="165.0625" y1="30" y2="210"></line>
+      <line x1="177.375" x2="177.375" y1="30" y2="210"></line>
+      <line x1="189.6875" x2="189.6875" y1="30" y2="210"></line>
+      <line x1="202" x2="202" y1="30" y2="210"></line>
+    </g>
+    <g aria-label="grid" fill="none" stroke="blue" stroke-opacity="0.1" transform="translate(0.5,0.5)">
+      <line y1="205" y2="205" x1="0" x2="207"></line>
+      <line y1="196.5" y2="196.5" x1="0" x2="207"></line>
+      <line y1="188" y2="188" x1="0" x2="207"></line>
+      <line y1="179.5" y2="179.5" x1="0" x2="207"></line>
+      <line y1="171" y2="171" x1="0" x2="207"></line>
+      <line y1="162.5" y2="162.5" x1="0" x2="207"></line>
+      <line y1="154" y2="154" x1="0" x2="207"></line>
+      <line y1="145.5" y2="145.5" x1="0" x2="207"></line>
+      <line y1="137" y2="137" x1="0" x2="207"></line>
+      <line y1="128.5" y2="128.5" x1="0" x2="207"></line>
+      <line y1="120" y2="120" x1="0" x2="207"></line>
+      <line y1="111.49999999999999" y2="111.49999999999999" x1="0" x2="207"></line>
+      <line y1="103" y2="103" x1="0" x2="207"></line>
+      <line y1="94.5" y2="94.5" x1="0" x2="207"></line>
+      <line y1="86" y2="86" x1="0" x2="207"></line>
+      <line y1="77.5" y2="77.5" x1="0" x2="207"></line>
+      <line y1="69" y2="69" x1="0" x2="207"></line>
+      <line y1="60.5" y2="60.5" x1="0" x2="207"></line>
+      <line y1="52" y2="52" x1="0" x2="207"></line>
+      <line y1="43.50000000000001" y2="43.50000000000001" x1="0" x2="207"></line>
+      <line y1="35" y2="35" x1="0" x2="207"></line>
+    </g>
+    <g aria-label="dot" fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(0.5,0.5)">
+      <circle cx="78.875" cy="119.32000000000002" r="3"></circle>
+      <circle cx="54.25" cy="137.85" r="3"></circle>
+      <circle cx="115.8125" cy="127.14000000000001" r="3"></circle>
+      <circle cx="66.5625" cy="106.22999999999999" r="3"></circle>
+      <circle cx="91.1875" cy="114.39" r="3"></circle>
+      <circle cx="128.125" cy="86.67999999999999" r="3"></circle>
+      <circle cx="29.625" cy="132.92" r="3"></circle>
+      <circle cx="5" cy="183.57999999999998" r="3"></circle>
+      <circle cx="103.5" cy="71.72" r="3"></circle>
+      <circle cx="41.9375" cy="174.23000000000002" r="3"></circle>
+      <circle cx="17.3125" cy="159.44" r="3"></circle>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(272,0)">
+    <g aria-label="grid" fill="none" stroke="red" stroke-opacity="0.1" transform="translate(0.5,0.5)">
+      <line x1="5" x2="5" y1="30" y2="210"></line>
+      <line x1="17.3125" x2="17.3125" y1="30" y2="210"></line>
+      <line x1="29.625" x2="29.625" y1="30" y2="210"></line>
+      <line x1="41.9375" x2="41.9375" y1="30" y2="210"></line>
+      <line x1="54.25" x2="54.25" y1="30" y2="210"></line>
+      <line x1="66.5625" x2="66.5625" y1="30" y2="210"></line>
+      <line x1="78.875" x2="78.875" y1="30" y2="210"></line>
+      <line x1="91.1875" x2="91.1875" y1="30" y2="210"></line>
+      <line x1="103.5" x2="103.5" y1="30" y2="210"></line>
+      <line x1="115.8125" x2="115.8125" y1="30" y2="210"></line>
+      <line x1="128.125" x2="128.125" y1="30" y2="210"></line>
+      <line x1="140.4375" x2="140.4375" y1="30" y2="210"></line>
+      <line x1="152.75" x2="152.75" y1="30" y2="210"></line>
+      <line x1="165.0625" x2="165.0625" y1="30" y2="210"></line>
+      <line x1="177.375" x2="177.375" y1="30" y2="210"></line>
+      <line x1="189.6875" x2="189.6875" y1="30" y2="210"></line>
+      <line x1="202" x2="202" y1="30" y2="210"></line>
+    </g>
+    <g aria-label="grid" fill="none" stroke="blue" stroke-opacity="0.1" transform="translate(0.5,0.5)">
+      <line y1="205" y2="205" x1="0" x2="207"></line>
+      <line y1="196.5" y2="196.5" x1="0" x2="207"></line>
+      <line y1="188" y2="188" x1="0" x2="207"></line>
+      <line y1="179.5" y2="179.5" x1="0" x2="207"></line>
+      <line y1="171" y2="171" x1="0" x2="207"></line>
+      <line y1="162.5" y2="162.5" x1="0" x2="207"></line>
+      <line y1="154" y2="154" x1="0" x2="207"></line>
+      <line y1="145.5" y2="145.5" x1="0" x2="207"></line>
+      <line y1="137" y2="137" x1="0" x2="207"></line>
+      <line y1="128.5" y2="128.5" x1="0" x2="207"></line>
+      <line y1="120" y2="120" x1="0" x2="207"></line>
+      <line y1="111.49999999999999" y2="111.49999999999999" x1="0" x2="207"></line>
+      <line y1="103" y2="103" x1="0" x2="207"></line>
+      <line y1="94.5" y2="94.5" x1="0" x2="207"></line>
+      <line y1="86" y2="86" x1="0" x2="207"></line>
+      <line y1="77.5" y2="77.5" x1="0" x2="207"></line>
+      <line y1="69" y2="69" x1="0" x2="207"></line>
+      <line y1="60.5" y2="60.5" x1="0" x2="207"></line>
+      <line y1="52" y2="52" x1="0" x2="207"></line>
+      <line y1="43.50000000000001" y2="43.50000000000001" x1="0" x2="207"></line>
+      <line y1="35" y2="35" x1="0" x2="207"></line>
+    </g>
+    <g aria-label="dot" fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(0.5,0.5)">
+      <circle cx="78.875" cy="100.61999999999998" r="3"></circle>
+      <circle cx="54.25" cy="117.62" r="3"></circle>
+      <circle cx="115.8125" cy="107.41999999999999" r="3"></circle>
+      <circle cx="66.5625" cy="106.91" r="3"></circle>
+      <circle cx="91.1875" cy="98.58" r="3"></circle>
+      <circle cx="128.125" cy="118.30000000000001" r="3"></circle>
+      <circle cx="29.625" cy="151.79000000000002" r="3"></circle>
+      <circle cx="5" cy="203.29999999999998" r="3"></circle>
+      <circle cx="103.5" cy="100.78999999999998" r="3"></circle>
+      <circle cx="41.9375" cy="132.58" r="3"></circle>
+      <circle cx="17.3125" cy="175.42" r="3"></circle>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(502,0)">
+    <g aria-label="grid" fill="none" stroke="red" stroke-opacity="0.1" transform="translate(0.5,0.5)">
+      <line x1="5" x2="5" y1="30" y2="210"></line>
+      <line x1="17.3125" x2="17.3125" y1="30" y2="210"></line>
+      <line x1="29.625" x2="29.625" y1="30" y2="210"></line>
+      <line x1="41.9375" x2="41.9375" y1="30" y2="210"></line>
+      <line x1="54.25" x2="54.25" y1="30" y2="210"></line>
+      <line x1="66.5625" x2="66.5625" y1="30" y2="210"></line>
+      <line x1="78.875" x2="78.875" y1="30" y2="210"></line>
+      <line x1="91.1875" x2="91.1875" y1="30" y2="210"></line>
+      <line x1="103.5" x2="103.5" y1="30" y2="210"></line>
+      <line x1="115.8125" x2="115.8125" y1="30" y2="210"></line>
+      <line x1="128.125" x2="128.125" y1="30" y2="210"></line>
+      <line x1="140.4375" x2="140.4375" y1="30" y2="210"></line>
+      <line x1="152.75" x2="152.75" y1="30" y2="210"></line>
+      <line x1="165.0625" x2="165.0625" y1="30" y2="210"></line>
+      <line x1="177.375" x2="177.375" y1="30" y2="210"></line>
+      <line x1="189.6875" x2="189.6875" y1="30" y2="210"></line>
+      <line x1="202" x2="202" y1="30" y2="210"></line>
+    </g>
+    <g aria-label="grid" fill="none" stroke="blue" stroke-opacity="0.1" transform="translate(0.5,0.5)">
+      <line y1="205" y2="205" x1="0" x2="207"></line>
+      <line y1="196.5" y2="196.5" x1="0" x2="207"></line>
+      <line y1="188" y2="188" x1="0" x2="207"></line>
+      <line y1="179.5" y2="179.5" x1="0" x2="207"></line>
+      <line y1="171" y2="171" x1="0" x2="207"></line>
+      <line y1="162.5" y2="162.5" x1="0" x2="207"></line>
+      <line y1="154" y2="154" x1="0" x2="207"></line>
+      <line y1="145.5" y2="145.5" x1="0" x2="207"></line>
+      <line y1="137" y2="137" x1="0" x2="207"></line>
+      <line y1="128.5" y2="128.5" x1="0" x2="207"></line>
+      <line y1="120" y2="120" x1="0" x2="207"></line>
+      <line y1="111.49999999999999" y2="111.49999999999999" x1="0" x2="207"></line>
+      <line y1="103" y2="103" x1="0" x2="207"></line>
+      <line y1="94.5" y2="94.5" x1="0" x2="207"></line>
+      <line y1="86" y2="86" x1="0" x2="207"></line>
+      <line y1="77.5" y2="77.5" x1="0" x2="207"></line>
+      <line y1="69" y2="69" x1="0" x2="207"></line>
+      <line y1="60.5" y2="60.5" x1="0" x2="207"></line>
+      <line y1="52" y2="52" x1="0" x2="207"></line>
+      <line y1="43.50000000000001" y2="43.50000000000001" x1="0" x2="207"></line>
+      <line y1="35" y2="35" x1="0" x2="207"></line>
+    </g>
+    <g aria-label="dot" fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(0.5,0.5)">
+      <circle cx="78.875" cy="129.18" r="3"></circle>
+      <circle cx="54.25" cy="140.91" r="3"></circle>
+      <circle cx="115.8125" cy="39.42" r="3"></circle>
+      <circle cx="66.5625" cy="135.13" r="3"></circle>
+      <circle cx="91.1875" cy="123.23000000000002" r="3"></circle>
+      <circle cx="128.125" cy="105.72" r="3"></circle>
+      <circle cx="29.625" cy="152.64" r="3"></circle>
+      <circle cx="5" cy="164.37" r="3"></circle>
+      <circle cx="103.5" cy="117.45" r="3"></circle>
+      <circle cx="41.9375" cy="146.86" r="3"></circle>
+      <circle cx="17.3125" cy="158.59" r="3"></circle>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(732,0)">
+    <g aria-label="grid" fill="none" stroke="red" stroke-opacity="0.1" transform="translate(0.5,0.5)">
+      <line x1="5" x2="5" y1="30" y2="210"></line>
+      <line x1="17.3125" x2="17.3125" y1="30" y2="210"></line>
+      <line x1="29.625" x2="29.625" y1="30" y2="210"></line>
+      <line x1="41.9375" x2="41.9375" y1="30" y2="210"></line>
+      <line x1="54.25" x2="54.25" y1="30" y2="210"></line>
+      <line x1="66.5625" x2="66.5625" y1="30" y2="210"></line>
+      <line x1="78.875" x2="78.875" y1="30" y2="210"></line>
+      <line x1="91.1875" x2="91.1875" y1="30" y2="210"></line>
+      <line x1="103.5" x2="103.5" y1="30" y2="210"></line>
+      <line x1="115.8125" x2="115.8125" y1="30" y2="210"></line>
+      <line x1="128.125" x2="128.125" y1="30" y2="210"></line>
+      <line x1="140.4375" x2="140.4375" y1="30" y2="210"></line>
+      <line x1="152.75" x2="152.75" y1="30" y2="210"></line>
+      <line x1="165.0625" x2="165.0625" y1="30" y2="210"></line>
+      <line x1="177.375" x2="177.375" y1="30" y2="210"></line>
+      <line x1="189.6875" x2="189.6875" y1="30" y2="210"></line>
+      <line x1="202" x2="202" y1="30" y2="210"></line>
+    </g>
+    <g aria-label="grid" fill="none" stroke="blue" stroke-opacity="0.1" transform="translate(0.5,0.5)">
+      <line y1="205" y2="205" x1="0" x2="207"></line>
+      <line y1="196.5" y2="196.5" x1="0" x2="207"></line>
+      <line y1="188" y2="188" x1="0" x2="207"></line>
+      <line y1="179.5" y2="179.5" x1="0" x2="207"></line>
+      <line y1="171" y2="171" x1="0" x2="207"></line>
+      <line y1="162.5" y2="162.5" x1="0" x2="207"></line>
+      <line y1="154" y2="154" x1="0" x2="207"></line>
+      <line y1="145.5" y2="145.5" x1="0" x2="207"></line>
+      <line y1="137" y2="137" x1="0" x2="207"></line>
+      <line y1="128.5" y2="128.5" x1="0" x2="207"></line>
+      <line y1="120" y2="120" x1="0" x2="207"></line>
+      <line y1="111.49999999999999" y2="111.49999999999999" x1="0" x2="207"></line>
+      <line y1="103" y2="103" x1="0" x2="207"></line>
+      <line y1="94.5" y2="94.5" x1="0" x2="207"></line>
+      <line y1="86" y2="86" x1="0" x2="207"></line>
+      <line y1="77.5" y2="77.5" x1="0" x2="207"></line>
+      <line y1="69" y2="69" x1="0" x2="207"></line>
+      <line y1="60.5" y2="60.5" x1="0" x2="207"></line>
+      <line y1="52" y2="52" x1="0" x2="207"></line>
+      <line y1="43.50000000000001" y2="43.50000000000001" x1="0" x2="207"></line>
+      <line y1="35" y2="35" x1="0" x2="207"></line>
+    </g>
+    <g aria-label="dot" fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(0.5,0.5)">
+      <circle cx="54.25" cy="144.14000000000001" r="3"></circle>
+      <circle cx="54.25" cy="158.07999999999998" r="3"></circle>
+      <circle cx="54.25" cy="124.93" r="3"></circle>
+      <circle cx="54.25" cy="105.72" r="3"></circle>
+      <circle cx="54.25" cy="112.00999999999999" r="3"></circle>
+      <circle cx="54.25" cy="136.32" r="3"></circle>
+      <circle cx="54.25" cy="166.75" r="3"></circle>
+      <circle cx="189.6875" cy="43.50000000000001" r="3"></circle>
+      <circle cx="54.25" cy="161.48000000000002" r="3"></circle>
+      <circle cx="54.25" cy="121.53" r="3"></circle>
+      <circle cx="54.25" cy="138.87" r="3"></circle>
+    </g>
+  </g>
+</svg>

--- a/test/plots/anscombe-quartet-grid.js
+++ b/test/plots/anscombe-quartet-grid.js
@@ -1,0 +1,21 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export default async function() {
+  const anscombe = await d3.csv("data/anscombe.csv", d3.autoType);
+  return Plot.plot({
+    nice: true,
+    inset: 5,
+    width: 960,
+    height: 240,
+    facet: {
+      data: anscombe,
+      x: "series"
+    },
+    marks: [
+      Plot.gridX(20, {stroke: "red"}),
+      Plot.gridY(20, {stroke: "blue"}),
+      Plot.dot(anscombe, {x: "x", y: "y"})
+    ]
+  });
+}

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -7,6 +7,7 @@ export {default as aaplMonthly} from "./aapl-monthly.js";
 export {default as aaplVolume} from "./aapl-volume.js";
 export {default as aaplVolumeRect} from "./aapl-volume-rect.js";
 export {default as anscombeQuartet} from "./anscombe-quartet.js";
+export {default as anscombeQuartetGrid} from "./anscombe-quartet-grid.js";
 export {default as athletesBinsColors} from "./athletes-bins-colors.js";
 export {default as athletesBirthdays} from "./athletes-birthdays.js";
 export {default as athletesHeightWeight} from "./athletes-height-weight.js";


### PR DESCRIPTION
Alternative to #985.

I snuck the _axes_ state into the existing _context_ argument rather than adding yet another positional argument to _mark_.render. This allows the mark to access the _axis_.ticks option (whose default value is populated automatically by Plot). I could probably sneak this state somewhere else if you prefer, say in _dimensions_?

I chose to make this a decoration mark (with no data), but in theory we could make this a mark with automatic data based on the tick values, which would allow variable color, stroke-width, and everything else… which could be cool.

Also, maybe we could find a way to remove the grid functionality from the current axis, and instead have the existing _scale_.**grid** option translate into an implicit Plot.gridX or Plot.gridY mark being added?