### PR TITLE
fixes for duane/ts-options

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -1,16 +1,14 @@
-type ObjectDatum = Record<string, unknown>;
-export type Datum = ObjectDatum | Value;
-export type DatumKeys<T> = T extends ObjectDatum ? keyof T : never;
-
 /**
  * The marks's data contains the data for the mark; typically an array
  * of objects or values, but can also be defined as an iterable compatible
  * with Array.from.
  */
 export type Data<T extends Datum> = ArrayLike<T> | Iterable<T>;
+export type Datum = unknown;
 
 /**
  * An array or typed array constructor, or any class that implements Array.from
+ * We only do internal typechecks for Float32Array | Float64Array
  */
 export type ArrayType = ArrayConstructor | Float32ArrayConstructor | Float64ArrayConstructor;
 


### PR DESCRIPTION
@duaneatat Some changes to your PR so that it validates, but when I add these files into #1005, everything breaks.

The reason, I suspect, is that some value accessors are legitimately _not_ DatumKeys, even if the datum is a {key:value} object. For example, in `Plot.dotX([{value: 10}], {fill: "red", x: "value"})` the fill accessor is legal.
