### PR TITLE
faster maps

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -28,7 +28,10 @@ export function valueObject(channels, scales) {
   return Object.fromEntries(
     Object.entries(channels).map(([name, {scale: scaleName, value}]) => {
       const scale = scales[scaleName];
-      return [name, scale === undefined ? value : map(value, scale)];
+      return [
+        name,
+        scale === undefined ? value : map(value, scale, ["x", "y", "r"].includes(scaleName) ? Float64Array : undefined)
+      ];
     })
   );
 }

--- a/src/options.js
+++ b/src/options.js
@@ -88,13 +88,19 @@ export function arrayify(data, type) {
 // An optimization of type.from(values, f): if the given values are already an
 // instanceof the desired array type, the faster values.map method is used.
 export function map(values, f, type = Array) {
-  return values instanceof type ? values.map(f) : type.from(values, f);
+  if (values instanceof type) return values.map(f);
+  const V = new type(values.length);
+  for (let i = 0; i < values.length; ++i) V[i] = f(values[i], i);
+  return V;
 }
 
 // An optimization of type.from(values): if the given values are already an
 // instanceof the desired array type, the faster values.slice method is used.
 export function slice(values, type = Array) {
-  return values instanceof type ? values.slice() : type.from(values);
+  if (values instanceof type) return values.slice();
+  const V = new type(values.length);
+  for (let i = 0; i < values.length; ++i) V[i] = values[i];
+  return V;
 }
 
 export function isTypedArray(values) {


### PR DESCRIPTION
it's faster to allocate a typed array with a known size than through Array.from — when dealing with millions of points, this can boost the performance quite a bit.

(results of a pairing session with @yurivish)

saving as draft for now (we'll want to make the test on the scale type less ad-hoc, probably?)