### PR TITLE
d.ts as JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 dist/
+types/
 node_modules/
 test/output/*-changed.svg
 test/output/*-changed.html

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test:typecheck": "tsc --noEmit",
     "readme:check": "tsx scripts/jsdoc-to-readme.ts --check",
     "readme:update": "tsx scripts/jsdoc-to-readme.ts",
-    "prepublishOnly": "rm -rf dist && rollup -c && tsc",
+    "typesJson": "tsc && tsx scripts/types-to-json.ts",
+    "prepublishOnly": "rm -rf dist && rollup -c && yarn typesJson",
     "postpublish": "git push && git push --tags",
     "dev": "vite"
   },

--- a/scripts/types-to-json.ts
+++ b/scripts/types-to-json.ts
@@ -1,0 +1,22 @@
+import {mkdirSync, readFileSync, rmSync, writeFileSync} from "fs";
+import glob from "glob";
+
+const TYPES_DIRECTORY = "types";
+
+function vfsPath(p: string) {
+  return `/plot${p.slice(TYPES_DIRECTORY.length)}`;
+}
+
+const paths = glob.sync(`${TYPES_DIRECTORY}/**/*.d.ts`);
+
+if (paths.length === 0) throw Error("No d.ts files found, make sure to run tsc first.");
+
+// An object of d.ts paths to file contents.
+const contentsByPath = Object.fromEntries(paths.map((p) => [vfsPath(p), readFileSync(p, {encoding: "utf-8"})]));
+
+// Remove all of the d.ts files until we're ready to publish them.
+rmSync(`./${TYPES_DIRECTORY}`, {recursive: true});
+mkdirSync(`./${TYPES_DIRECTORY}`);
+
+// Write the types.json file.
+writeFileSync(`./${TYPES_DIRECTORY}/types.json`, JSON.stringify(contentsByPath));

--- a/src/format.ts
+++ b/src/format.ts
@@ -8,11 +8,11 @@ const numberFormat = memoize1<Intl.NumberFormat>(
 );
 const monthFormat = memoize1<Intl.DateTimeFormat>(
   (locale: string | string[] | undefined, month: "numeric" | "2-digit" | "long" | "short" | "narrow" | undefined) =>
-    new Intl.DateTimeFormat(locale, {timeZone: "UTC", month})
+    new Intl.DateTimeFormat(locale, {timeZone: "UTC", ...(month && {month})})
 );
 const weekdayFormat = memoize1<Intl.DateTimeFormat>(
   (locale: string | string[] | undefined, weekday: "long" | "short" | "narrow" | undefined) =>
-    new Intl.DateTimeFormat(locale, {timeZone: "UTC", weekday})
+    new Intl.DateTimeFormat(locale, {timeZone: "UTC", ...(weekday && {weekday})})
 );
 
 export function formatNumber(locale = "en-US"): (value: any) => string | undefined {

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -163,6 +163,8 @@ export class BarY extends AbstractBar {
  *
  * If the **y** channel is not specified, the bar will span the full vertical
  * extent of the plot (or facet).
+ *
+ * @param options {{y: any, x2: any}}
  */
 export function barX(data, options = {y: indexOf, x2: identity}) {
   return new BarX(data, maybeStackX(maybeIntervalX(maybeIdentityX(options))));

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -163,8 +163,6 @@ export class BarY extends AbstractBar {
  *
  * If the **y** channel is not specified, the bar will span the full vertical
  * extent of the plot (or facet).
- *
- * @param options {{y: any, x2: any}}
  */
 export function barX(data, options = {y: indexOf, x2: identity}) {
   return new BarX(data, maybeStackX(maybeIntervalX(maybeIdentityX(options))));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "stripInternal": true,
     "outDir": "dist",
     "allowJs": true,
+    "declaration": true,
+    "declarationDir": "types",
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "paths": {


### PR DESCRIPTION
This adds a script that will generate a single `types/types.json` file which is easier to consume in a TypeScript VFS that is bundled by webpack than regular d.ts files. Once we've finished migrating to TypeScript, we can also publish the d.ts files (as well as point to them in the package.json).

Will hold off on merging this until #1016 is reviewed/merged.