### PR TITLE
Basic JSDoc types - Plot.plot and all Marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1245,8 +1245,6 @@ The given *options* are passed through to these underlying marks, with the excep
 
 #### Plot.boxX(*data*, *options*)
 
-
-
 ```js
 Plot.boxX(simpsons.map(d => d.imdb_rating))
 ```
@@ -2981,8 +2979,6 @@ passed two node arguments, the child and the parent.
 <!-- jsdoc tree -->
 
 #### Plot.tree(*data*, *options*)
-
-
 
 A convenience compound mark for rendering a tree diagram, including a
 [link](#link) to

--- a/README.md
+++ b/README.md
@@ -2348,7 +2348,6 @@ Plot.rect(athletes, Plot.bin({fillOpacity: "count"}, {x: "weight", y: "height"})
 Bins on *x* and *y*. Also groups on the first channel of *z*, *fill*, or
 *stroke*, if any.
 
-
 <!-- jsdoc binX -->
 
 #### Plot.binX(*outputs*, *options*)
@@ -2359,7 +2358,6 @@ Plot.rectY(athletes, Plot.binX({y: "count"}, {x: "weight"}))
 
 Bins on *x*. Also groups on *y* and the first channel of *z*, *fill*, or
 *stroke*, if any.
-
 
 <!-- jsdoc binY -->
 
@@ -2458,7 +2456,6 @@ Plot.group({fill: "count"}, {x: "island", y: "species"})
 Groups on *x*, *y*, and the first channel of *z*, *fill*, or *stroke*, if
 any.
 
-
 <!-- jsdoc groupX -->
 
 #### Plot.groupX(*outputs*, *options*)
@@ -2469,7 +2466,6 @@ Plot.groupX({y: "sum"}, {x: "species", y: "body_mass_g"})
 
 Groups on *x* and the first channel of *z*, *fill*, or *stroke*, if any.
 
-
 <!-- jsdoc groupY -->
 
 #### Plot.groupY(*outputs*, *options*)
@@ -2479,7 +2475,6 @@ Plot.groupY({x: "sum"}, {y: "species", x: "body_mass_g"})
 ```
 
 Groups on *y* and the first channel of *z*, *fill*, or *stroke*, if any.
-
 
 <!-- jsdoc groupZ -->
 
@@ -2492,7 +2487,6 @@ Plot.groupZ({x: "proportion"}, {fill: "species"})
 Groups on the first channel of *z*, *fill*, or *stroke*, if any. If none of
 *z*, *fill*, or *stroke* are channels, then all data (within each facet) is
 placed into a single group.
-
 
 <!-- jsdocEnd -->
 
@@ -2571,7 +2565,6 @@ each channel declared in the specified *outputs* object, applies the
 corresponding map method. Each channel in *outputs* must have a corresponding
 input channel in *options*.
 
-
 <!-- jsdoc mapX -->
 
 #### Plot.mapX(*map*, *options*)
@@ -2583,7 +2576,6 @@ Plot.mapX("cumsum", {x: d3.randomNormal()})
 Equivalent to Plot.map({x: *map*, x1: *map*, x2: *map*}, *options*), but
 ignores any of **x**, **x1**, and **x2** not present in *options*.
 
-
 <!-- jsdoc mapY -->
 
 #### Plot.mapY(*map*, *options*)
@@ -2594,7 +2586,6 @@ Plot.mapY("cumsum", {y: d3.randomNormal()})
 
 Equivalent to Plot.map({y: *map*, y1: *map*, y2: *map*}, *options*), but
 ignores any of **y**, **y1**, and **y2** not present in *options*.
-
 
 <!-- jsdoc normalize -->
 
@@ -2805,7 +2796,6 @@ resulting in a count of the data points. The stack options (*offset*,
 *order*, and *reverse*) may be specified as part of the *options* object, if
 the only argument, or as a separate *stack* options argument.
 
-
 <!-- jsdoc stackY1 -->
 
 #### Plot.stackY1(*stack*, *options*)
@@ -2818,7 +2808,6 @@ Equivalent to
 [Plot.stackY](#plotstackystack-options),
 except that the **y1** channel is returned as the **y** channel. This can be
 used, for example, to draw a line at the bottom of each stacked area.
-
 
 <!-- jsdoc stackY2 ->
 
@@ -2833,7 +2822,6 @@ Equivalent to
 except that the **y2** channel is returned as the **y** channel. This can be
 used, for example, to draw a line at the top of each stacked area.
 
-
 <!-- jsdoc stackX -->
 
 #### Plot.stackX(*stack*, *options*)
@@ -2844,7 +2832,6 @@ Plot.stackX({y: "year", x: "revenue", z: "format", fill: "group"})
 
 See Plot.stackY, but with *x* as the input value channel, *y* as the stack
 index, *x1*, *x2* and *x* as the output channels.
-
 
 <!-- jsdoc stackX1 -->
 
@@ -2859,7 +2846,6 @@ Equivalent to
 except that the **x1** channel is returned as the **x** channel. This can be
 used, for example, to draw a line at the left edge of each stacked area.
 
-
 <!-- jsdoc stackX2 -->
 
 #### Plot.stackX2(*stack*, *options*)
@@ -2872,7 +2858,6 @@ Equivalent to
 [Plot.stackX](#plotstackxstack-options),
 except that the **x2** channel is returned as the **x** channel. This can be
 used, for example, to draw a line at the right edge of each stacked area.
-
 
 <!-- jsdocEnd -->
 
@@ -3144,7 +3129,6 @@ Given marks arranged along the *x* axis, the dodgeY transform piles them
 vertically by defining a *y* position channel that avoids overlapping. The
 *x* position channel is unchanged.
 
-
 <!-- jsdoc dodgeX -->
 
 #### Plot.dodgeX(*dodgeOptions*, *options*)
@@ -3156,7 +3140,6 @@ Plot.dodgeX({y: "value"})
 Equivalent to Plot.dodgeY, but piling horizontally, creating a new *x*
 position channel that avoids overlapping. The *y* position channel is
 unchanged.
-
 
 <!-- jsdocEnd -->
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,6 @@ const color = plot.scale("color"); // retrieve the color scale object
 console.log(color.range); // inspect the color scale’s range, ["red", "blue"]
 ```
 
-
 <!-- jsdoc scale -->
 
 #### Plot.scale(*options*)
@@ -3036,7 +3035,6 @@ The following options are supported:
 Any additional *options* are passed through to the constituent link, dot, and
 text marks and their corresponding treeLink or treeNode transform.
 
-
 <!-- jsdoc cluster -->
 
 #### Plot.cluster(*data*, *options*)
@@ -3045,7 +3043,6 @@ Like
 [Plot.tree](#plottreedata-options),
 except sets the **treeLayout** option to D3’s cluster (dendrogram) algorithm,
 which aligns leaf nodes.
-
 
 <!-- jsdocEnd -->
 

--- a/README.md
+++ b/README.md
@@ -979,7 +979,6 @@ Returns an array of marks that implements the *mark*.plot function. See the
 implementation](https://github.com/observablehq/plot/blob/main/src/marks/box.js)
 for an example.
 
-
 <!-- jsdocEnd -->
 
 ### Area
@@ -1027,7 +1026,6 @@ share *x* values, while
 is used in the vertical orientation where the baseline and topline share *y*
 values.
 
-
 <!-- jsdoc areaX -->
 
 #### Plot.areaX(*data*, *options*)
@@ -1062,7 +1060,6 @@ The **interval** option is recommended to “regularize” sampled data; for
 example, if your data represents timestamped temperature measurements and you
 expect one sample per day, use d3.utcDay as the interval.
 
-
 <!-- jsdoc areaY -->
 
 #### Plot.areaY(*data*, *options*)
@@ -1096,7 +1093,6 @@ Plot.areaY(observations, {x: "date", y: "temperature", interval: d3.utcDay)
 The **interval** option is recommended to “regularize” sampled data; for
 example, if your data represents timestamped temperature measurements and you
 expect one sample per day, use d3.utcDay as the interval.
-
 
 <!-- jsdocEnd -->
 
@@ -1135,7 +1131,6 @@ Plot.arrow(inequality, {x1: "POP_1980", y1: "R90_10_1980", x2: "POP_2015", y2: "
 ```
 
 Returns a new arrow with the given *data* and *options*.
-
 
 <!-- jsdocEnd -->
 
@@ -1185,7 +1180,6 @@ following optional channels are supported:
 If the **y** channel is not specified, the bar will span the full vertical
 extent of the plot (or facet).
 
-
 <!-- jsdoc barY -->
 
 #### Plot.barY(*data*, *options*)
@@ -1225,7 +1219,6 @@ following optional channels are supported:
 If the **x** channel is not specified, the bar will span the full horizontal
 extent of the plot (or facet).
 
-
 <!-- jsdocEnd -->
 
 ### Box
@@ -1264,7 +1257,6 @@ defaults to the identity function, as when *data* is an array of numbers. If
 the **y** option is not specified, it defaults to null; if the **y** option
 is specified, it should represent an ordinal (discrete) value.
 
-
 <!-- jsdoc boxY -->
 
 #### Plot.boxY(*data*, *options*)
@@ -1277,7 +1269,6 @@ Returns a vertical boxplot mark. If the **y** option is not specified, it
 defaults to the identity function, as when *data* is an array of numbers. If
 the **x** option is not specified, it defaults to null; if the **x** option
 is specified, it should represent an ordinal (discrete) value.
-
 
 <!-- jsdocEnd -->
 
@@ -1309,7 +1300,6 @@ nor **y** options are specified, *data* is assumed to be an array of pairs
 [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
 *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
-
 <!-- jsdoc cellX -->
 
 #### Plot.cellX(*data*, *options*)
@@ -1325,7 +1315,6 @@ except that if the **x** option is not specified, it defaults to [0, 1, 2,
 channel, the fill defaults to the identity function and assumes that *data* =
 [*x₀*, *x₁*, *x₂*, …].
 
-
 <!-- jsdoc cellY -->
 
 #### Plot.cellY(*data*, *options*)
@@ -1340,7 +1329,6 @@ except that if the **y** option is not specified, it defaults to [0, 1, 2,
 …], and if the **fill** option is not specified and **stroke** is not a
 channel, the fill defaults to the identity function and assumes that *data* =
 [*y₀*, *y₁*, *y₂*, …].
-
 
 <!-- jsdocEnd -->
 
@@ -1364,7 +1352,6 @@ channel value from one of its two endpoints arbitrarily.
 If a **z** channel is specified, the input points are grouped by *z*, and
 separate Delaunay triangulations are constructed for each group.
 
-
 <!-- jsdoc delaunayMesh -->
 
 #### Plot.delaunayMesh(*data*, *options*)
@@ -1378,7 +1365,6 @@ points arbitrarily.
 
 If a **z** channel is specified, the input points are grouped by *z*, and
 separate Delaunay triangulations are constructed for each group.
-
 
 <!-- jsdoc hull -->
 
@@ -1395,7 +1381,6 @@ separate convex hulls are constructed for each group. If the **z** channel is
 not specified, it defaults to either the **fill** channel, if any, or the
 **stroke** channel, if any.
 
-
 <!-- jsdoc voronoi -->
 
 #### Plot.voronoi(*data*, *options*)
@@ -1405,7 +1390,6 @@ by the **x** and **y** channels.
 
 If a **z** channel is specified, the input points are grouped by *z*, and
 separate Voronoi tesselations are constructed for each group.
-
 
 <!-- jsdoc voronoiMesh -->
 
@@ -1420,7 +1404,6 @@ value from one of its constituent points arbitrarily.
 
 If a **z** channel is specified, the input points are grouped by *z*, and
 separate Voronoi tesselations are constructed for each group.
-
 
 <!-- jsdocEnd -->
 
@@ -1452,7 +1435,6 @@ grouped by series, and separate sets of contours are generated for each
 series. If the **stroke** or **fill** is specified as *density*, a color
 channel is constructed with values representing the density threshold value
 of each contour.
-
 
 <!-- jsdocEnd -->
 
@@ -1500,7 +1482,6 @@ nor **y** nor **frameAnchor** options are specified, *data* is assumed to be
 an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
 **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
-
 <!-- jsdoc dotX -->
 
 #### Plot.dotX(*data*, *options*)
@@ -1518,7 +1499,6 @@ If an **interval** is specified, such as d3.utcDay, **y** is transformed to
 (*interval*.floor(*y*) + *interval*.offset(*interval*.floor(*y*))) / 2. If
 the interval is specified as a number *n*, *y* will be the midpoint of two
 consecutive multiples of *n* that bracket *y*.
-
 
 <!-- jsdoc dotY -->
 
@@ -1538,7 +1518,6 @@ If an **interval** is specified, such as d3.utcDay, **x** is transformed to
 the interval is specified as a number *n*, *x* will be the midpoint of two
 consecutive multiples of *n* that bracket *x*.
 
-
 <!-- jsdoc circle -->
 
 #### Plot.circle(*data*, *options*)
@@ -1547,7 +1526,6 @@ Equivalent to
 [Plot.dot](#plotdotdata-options)
 except that the **symbol** option is set to *circle*.
 
-
 <!-- jsdoc hexagon -->
 
 #### Plot.hexagon(*data*, *options*)
@@ -1555,7 +1533,6 @@ except that the **symbol** option is set to *circle*.
 Equivalent to
 [Plot.dot](#plotdotdata-options)
 except that the **symbol** option is set to *hexagon*.
-
 
 <!-- jsdocEnd -->
 
@@ -1613,7 +1590,6 @@ nor **y** nor **frameAnchor** options are specified, *data* is assumed to be
 an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
 **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
-
 <!-- jsdocEnd -->
 
 ### Linear regression
@@ -1643,7 +1619,6 @@ Plot.linearRegressionX(mtcars, {y: "wt", x: "hp"})
 Returns a linear regression mark where *x* is the dependent variable and *y*
 is the independent variable.
 
-
 <!-- jsdoc linearRegressionY -->
 
 #### Plot.linearRegressionY(*data*, *options*)
@@ -1654,7 +1629,6 @@ Plot.linearRegressionY(mtcars, {x: "wt", y: "hp"})
 
 Returns a linear regression mark where *y* is the dependent variable and *x*
 is the independent variable.
-
 
 <!-- jsdocEnd -->
 
@@ -1694,7 +1668,6 @@ nor **y** options are specified, *data* is assumed to be an array of pairs
 [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
 *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
-
 <!-- jsdoc lineX -->
 
 #### Plot.lineX(*data*, *options*)
@@ -1724,7 +1697,6 @@ The **interval** option is recommended to “regularize” sampled data; for
 example, if your data represents timestamped temperature measurements and you
 expect one sample per day, use d3.utcDay as the interval.
 
-
 <!-- jsdoc lineY -->
 
 #### Plot.lineY(*data*, *options*)
@@ -1753,7 +1725,6 @@ Plot.lineY(observations, {x: "date", y: "temperature", interval: d3.utcDay})
 The **interval** option is recommended to “regularize” sampled data; for
 example, if your data represents timestamped temperature measurements and you
 expect one sample per day, use d3.utcDay as the interval.
-
 
 <!-- jsdocEnd -->
 
@@ -1786,7 +1757,6 @@ Plot.link(inequality, {x1: "POP_1980", y1: "R90_10_1980", x2: "POP_2015", y2: "R
 
 Returns a new link with the given *data* and *options*.
 
-
 <!-- jsdocEnd -->
 
 ### Rect
@@ -1818,7 +1788,6 @@ Plot.rect(athletes, Plot.bin({fill: "count"}, {x: "weight", y: "height"}))
 
 Returns a new rect with the given *data* and *options*.
 
-
 <!-- jsdoc rectX -->
 
 #### Plot.rectX(*data*, *options*)
@@ -1836,7 +1805,6 @@ this is the typical configuration for a histogram with rects aligned at *x* =
 0. If the **x** option is not specified, it defaults to the identity
 function.
 
-
 <!-- jsdoc rectY -->
 
 #### Plot.rectY(*data*, *options*)
@@ -1853,7 +1821,6 @@ transform](#plotstackystack-options);
 this is the typical configuration for a histogram with rects aligned at *y* =
 0. If the **y** option is not specified, it defaults to the identity
 function.
-
 
 <!-- jsdocEnd -->
 
@@ -1899,7 +1866,6 @@ derived from **y**: *interval*.floor(*y*) is invoked for each *y* to produce
 If the interval is specified as a number *n*, *y1* and *y2* are taken as the
 two consecutive multiples of *n* that bracket *y*.
 
-
 <!-- jsdoc ruleY -->
 
 #### Plot.ruleY(*data*, *options*)
@@ -1934,7 +1900,6 @@ derived from **x**: *interval*.floor(*x*) is invoked for each *x* to produce
 *x1*, and *interval*.offset(*x1*) is invoked for each *x1* to produce *x2*.
 If the interval is specified as a number *n*, *x1* and *x2* are taken as the
 two consecutive multiples of *n* that bracket *x*.
-
 
 <!-- jsdocEnd -->
 
@@ -1991,7 +1956,6 @@ Returns a new text mark with the given *data* and *options*. If neither the
 to be an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such
 that **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
-
 <!-- jsdoc textX -->
 
 #### Plot.textX(*data*, *options*)
@@ -2006,7 +1970,6 @@ If an **interval** is specified, such as d3.utcDay, **y** is transformed to
 the interval is specified as a number *n*, *y* will be the midpoint of two
 consecutive multiples of *n* that bracket *y*.
 
-
 <!-- jsdoc textY -->
 
 #### Plot.textY(*data*, *options*)
@@ -2020,7 +1983,6 @@ If an **interval** is specified, such as d3.utcDay, **x** is transformed to
 (*interval*.floor(*x*) + *interval*.offset(*interval*.floor(*x*))) / 2. If
 the interval is specified as a number *n*, *x* will be the midpoint of two
 consecutive multiples of *n* that bracket *x*.
-
 
 <!-- jsdocEnd -->
 
@@ -2052,7 +2014,6 @@ The following optional channels are supported:
 If the **y** channel is not specified, the tick will span the full vertical
 extent of the plot (or facet).
 
-
 <!-- jsdoc tickY -->
 
 #### Plot.tickY(*data*, *options*)
@@ -2073,7 +2034,6 @@ The following optional channels are supported:
 
 If the **x** channel is not specified, the tick will span the full vertical
 extent of the plot (or facet).
-
 
 <!-- jsdocEnd -->
 
@@ -2120,7 +2080,6 @@ Returns a new vector with the given *data* and *options*. If neither the
 pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*,
 *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
-
 <!-- jsdoc vectorX -->
 
 #### Plot.vectorX(*data*, *options*)
@@ -2130,7 +2089,6 @@ Equivalent to
 except that if the **x** option is not specified, it defaults to the identity
 function and assumes that *data* = [*x₀*, *x₁*, *x₂*, …].
 
-
 <!-- jsdoc vectorY -->
 
 #### Plot.vectorY(*data*, *options*)
@@ -2139,7 +2097,6 @@ Equivalent to
 [Plot.vector](#plotvectordata-options)
 except that if the **y** option is not specified, it defaults to the identity
 function and assumes that *data* = [*y₀*, *y₁*, *y₂*, …].
-
 
 <!-- jsdocEnd -->
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ const color = plot.scale("color"); // retrieve the color scale object
 console.log(color.range); // inspect the color scale’s range, ["red", "blue"]
 ```
 
+
 <!-- jsdoc scale -->
 
 #### Plot.scale(*options*)
@@ -978,6 +979,7 @@ Returns an array of marks that implements the *mark*.plot function. See the
 implementation](https://github.com/observablehq/plot/blob/main/src/marks/box.js)
 for an example.
 
+
 <!-- jsdocEnd -->
 
 ### Area
@@ -1025,6 +1027,7 @@ share *x* values, while
 is used in the vertical orientation where the baseline and topline share *y*
 values.
 
+
 <!-- jsdoc areaX -->
 
 #### Plot.areaX(*data*, *options*)
@@ -1059,6 +1062,7 @@ The **interval** option is recommended to “regularize” sampled data; for
 example, if your data represents timestamped temperature measurements and you
 expect one sample per day, use d3.utcDay as the interval.
 
+
 <!-- jsdoc areaY -->
 
 #### Plot.areaY(*data*, *options*)
@@ -1092,6 +1096,7 @@ Plot.areaY(observations, {x: "date", y: "temperature", interval: d3.utcDay)
 The **interval** option is recommended to “regularize” sampled data; for
 example, if your data represents timestamped temperature measurements and you
 expect one sample per day, use d3.utcDay as the interval.
+
 
 <!-- jsdocEnd -->
 
@@ -1130,6 +1135,7 @@ Plot.arrow(inequality, {x1: "POP_1980", y1: "R90_10_1980", x2: "POP_2015", y2: "
 ```
 
 Returns a new arrow with the given *data* and *options*.
+
 
 <!-- jsdocEnd -->
 
@@ -1179,6 +1185,7 @@ following optional channels are supported:
 If the **y** channel is not specified, the bar will span the full vertical
 extent of the plot (or facet).
 
+
 <!-- jsdoc barY -->
 
 #### Plot.barY(*data*, *options*)
@@ -1218,6 +1225,7 @@ following optional channels are supported:
 If the **x** channel is not specified, the bar will span the full horizontal
 extent of the plot (or facet).
 
+
 <!-- jsdocEnd -->
 
 ### Box
@@ -1245,6 +1253,8 @@ The given *options* are passed through to these underlying marks, with the excep
 
 #### Plot.boxX(*data*, *options*)
 
+
+
 ```js
 Plot.boxX(simpsons.map(d => d.imdb_rating))
 ```
@@ -1253,6 +1263,7 @@ Returns a horizontal boxplot mark. If the **x** option is not specified, it
 defaults to the identity function, as when *data* is an array of numbers. If
 the **y** option is not specified, it defaults to null; if the **y** option
 is specified, it should represent an ordinal (discrete) value.
+
 
 <!-- jsdoc boxY -->
 
@@ -1266,6 +1277,7 @@ Returns a vertical boxplot mark. If the **y** option is not specified, it
 defaults to the identity function, as when *data* is an array of numbers. If
 the **x** option is not specified, it defaults to null; if the **x** option
 is specified, it should represent an ordinal (discrete) value.
+
 
 <!-- jsdocEnd -->
 
@@ -1297,6 +1309,7 @@ nor **y** options are specified, *data* is assumed to be an array of pairs
 [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
 *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
+
 <!-- jsdoc cellX -->
 
 #### Plot.cellX(*data*, *options*)
@@ -1312,6 +1325,7 @@ except that if the **x** option is not specified, it defaults to [0, 1, 2,
 channel, the fill defaults to the identity function and assumes that *data* =
 [*x₀*, *x₁*, *x₂*, …].
 
+
 <!-- jsdoc cellY -->
 
 #### Plot.cellY(*data*, *options*)
@@ -1326,6 +1340,7 @@ except that if the **y** option is not specified, it defaults to [0, 1, 2,
 …], and if the **fill** option is not specified and **stroke** is not a
 channel, the fill defaults to the identity function and assumes that *data* =
 [*y₀*, *y₁*, *y₂*, …].
+
 
 <!-- jsdocEnd -->
 
@@ -1349,6 +1364,7 @@ channel value from one of its two endpoints arbitrarily.
 If a **z** channel is specified, the input points are grouped by *z*, and
 separate Delaunay triangulations are constructed for each group.
 
+
 <!-- jsdoc delaunayMesh -->
 
 #### Plot.delaunayMesh(*data*, *options*)
@@ -1362,6 +1378,7 @@ points arbitrarily.
 
 If a **z** channel is specified, the input points are grouped by *z*, and
 separate Delaunay triangulations are constructed for each group.
+
 
 <!-- jsdoc hull -->
 
@@ -1378,6 +1395,7 @@ separate convex hulls are constructed for each group. If the **z** channel is
 not specified, it defaults to either the **fill** channel, if any, or the
 **stroke** channel, if any.
 
+
 <!-- jsdoc voronoi -->
 
 #### Plot.voronoi(*data*, *options*)
@@ -1387,6 +1405,7 @@ by the **x** and **y** channels.
 
 If a **z** channel is specified, the input points are grouped by *z*, and
 separate Voronoi tesselations are constructed for each group.
+
 
 <!-- jsdoc voronoiMesh -->
 
@@ -1401,6 +1420,7 @@ value from one of its constituent points arbitrarily.
 
 If a **z** channel is specified, the input points are grouped by *z*, and
 separate Voronoi tesselations are constructed for each group.
+
 
 <!-- jsdocEnd -->
 
@@ -1432,6 +1452,7 @@ grouped by series, and separate sets of contours are generated for each
 series. If the **stroke** or **fill** is specified as *density*, a color
 channel is constructed with values representing the density threshold value
 of each contour.
+
 
 <!-- jsdocEnd -->
 
@@ -1479,6 +1500,7 @@ nor **y** nor **frameAnchor** options are specified, *data* is assumed to be
 an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
 **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
+
 <!-- jsdoc dotX -->
 
 #### Plot.dotX(*data*, *options*)
@@ -1496,6 +1518,7 @@ If an **interval** is specified, such as d3.utcDay, **y** is transformed to
 (*interval*.floor(*y*) + *interval*.offset(*interval*.floor(*y*))) / 2. If
 the interval is specified as a number *n*, *y* will be the midpoint of two
 consecutive multiples of *n* that bracket *y*.
+
 
 <!-- jsdoc dotY -->
 
@@ -1515,6 +1538,7 @@ If an **interval** is specified, such as d3.utcDay, **x** is transformed to
 the interval is specified as a number *n*, *x* will be the midpoint of two
 consecutive multiples of *n* that bracket *x*.
 
+
 <!-- jsdoc circle -->
 
 #### Plot.circle(*data*, *options*)
@@ -1523,6 +1547,7 @@ Equivalent to
 [Plot.dot](#plotdotdata-options)
 except that the **symbol** option is set to *circle*.
 
+
 <!-- jsdoc hexagon -->
 
 #### Plot.hexagon(*data*, *options*)
@@ -1530,6 +1555,7 @@ except that the **symbol** option is set to *circle*.
 Equivalent to
 [Plot.dot](#plotdotdata-options)
 except that the **symbol** option is set to *hexagon*.
+
 
 <!-- jsdocEnd -->
 
@@ -1587,6 +1613,7 @@ nor **y** nor **frameAnchor** options are specified, *data* is assumed to be
 an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
 **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
+
 <!-- jsdocEnd -->
 
 ### Linear regression
@@ -1616,6 +1643,7 @@ Plot.linearRegressionX(mtcars, {y: "wt", x: "hp"})
 Returns a linear regression mark where *x* is the dependent variable and *y*
 is the independent variable.
 
+
 <!-- jsdoc linearRegressionY -->
 
 #### Plot.linearRegressionY(*data*, *options*)
@@ -1626,6 +1654,7 @@ Plot.linearRegressionY(mtcars, {x: "wt", y: "hp"})
 
 Returns a linear regression mark where *y* is the dependent variable and *x*
 is the independent variable.
+
 
 <!-- jsdocEnd -->
 
@@ -1665,6 +1694,7 @@ nor **y** options are specified, *data* is assumed to be an array of pairs
 [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
 *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
+
 <!-- jsdoc lineX -->
 
 #### Plot.lineX(*data*, *options*)
@@ -1694,6 +1724,7 @@ The **interval** option is recommended to “regularize” sampled data; for
 example, if your data represents timestamped temperature measurements and you
 expect one sample per day, use d3.utcDay as the interval.
 
+
 <!-- jsdoc lineY -->
 
 #### Plot.lineY(*data*, *options*)
@@ -1722,6 +1753,7 @@ Plot.lineY(observations, {x: "date", y: "temperature", interval: d3.utcDay})
 The **interval** option is recommended to “regularize” sampled data; for
 example, if your data represents timestamped temperature measurements and you
 expect one sample per day, use d3.utcDay as the interval.
+
 
 <!-- jsdocEnd -->
 
@@ -1754,6 +1786,7 @@ Plot.link(inequality, {x1: "POP_1980", y1: "R90_10_1980", x2: "POP_2015", y2: "R
 
 Returns a new link with the given *data* and *options*.
 
+
 <!-- jsdocEnd -->
 
 ### Rect
@@ -1785,6 +1818,7 @@ Plot.rect(athletes, Plot.bin({fill: "count"}, {x: "weight", y: "height"}))
 
 Returns a new rect with the given *data* and *options*.
 
+
 <!-- jsdoc rectX -->
 
 #### Plot.rectX(*data*, *options*)
@@ -1802,6 +1836,7 @@ this is the typical configuration for a histogram with rects aligned at *x* =
 0. If the **x** option is not specified, it defaults to the identity
 function.
 
+
 <!-- jsdoc rectY -->
 
 #### Plot.rectY(*data*, *options*)
@@ -1818,6 +1853,7 @@ transform](#plotstackystack-options);
 this is the typical configuration for a histogram with rects aligned at *y* =
 0. If the **y** option is not specified, it defaults to the identity
 function.
+
 
 <!-- jsdocEnd -->
 
@@ -1863,6 +1899,7 @@ derived from **y**: *interval*.floor(*y*) is invoked for each *y* to produce
 If the interval is specified as a number *n*, *y1* and *y2* are taken as the
 two consecutive multiples of *n* that bracket *y*.
 
+
 <!-- jsdoc ruleY -->
 
 #### Plot.ruleY(*data*, *options*)
@@ -1897,6 +1934,7 @@ derived from **x**: *interval*.floor(*x*) is invoked for each *x* to produce
 *x1*, and *interval*.offset(*x1*) is invoked for each *x1* to produce *x2*.
 If the interval is specified as a number *n*, *x1* and *x2* are taken as the
 two consecutive multiples of *n* that bracket *x*.
+
 
 <!-- jsdocEnd -->
 
@@ -1953,6 +1991,7 @@ Returns a new text mark with the given *data* and *options*. If neither the
 to be an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such
 that **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
+
 <!-- jsdoc textX -->
 
 #### Plot.textX(*data*, *options*)
@@ -1967,6 +2006,7 @@ If an **interval** is specified, such as d3.utcDay, **y** is transformed to
 the interval is specified as a number *n*, *y* will be the midpoint of two
 consecutive multiples of *n* that bracket *y*.
 
+
 <!-- jsdoc textY -->
 
 #### Plot.textY(*data*, *options*)
@@ -1980,6 +2020,7 @@ If an **interval** is specified, such as d3.utcDay, **x** is transformed to
 (*interval*.floor(*x*) + *interval*.offset(*interval*.floor(*x*))) / 2. If
 the interval is specified as a number *n*, *x* will be the midpoint of two
 consecutive multiples of *n* that bracket *x*.
+
 
 <!-- jsdocEnd -->
 
@@ -2011,6 +2052,7 @@ The following optional channels are supported:
 If the **y** channel is not specified, the tick will span the full vertical
 extent of the plot (or facet).
 
+
 <!-- jsdoc tickY -->
 
 #### Plot.tickY(*data*, *options*)
@@ -2031,6 +2073,7 @@ The following optional channels are supported:
 
 If the **x** channel is not specified, the tick will span the full vertical
 extent of the plot (or facet).
+
 
 <!-- jsdocEnd -->
 
@@ -2077,6 +2120,7 @@ Returns a new vector with the given *data* and *options*. If neither the
 pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*,
 *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
 
+
 <!-- jsdoc vectorX -->
 
 #### Plot.vectorX(*data*, *options*)
@@ -2086,6 +2130,7 @@ Equivalent to
 except that if the **x** option is not specified, it defaults to the identity
 function and assumes that *data* = [*x₀*, *x₁*, *x₂*, …].
 
+
 <!-- jsdoc vectorY -->
 
 #### Plot.vectorY(*data*, *options*)
@@ -2094,6 +2139,7 @@ Equivalent to
 [Plot.vector](#plotvectordata-options)
 except that if the **y** option is not specified, it defaults to the identity
 function and assumes that *data* = [*y₀*, *y₁*, *y₂*, …].
+
 
 <!-- jsdocEnd -->
 
@@ -2995,6 +3041,8 @@ passed two node arguments, the child and the parent.
 
 #### Plot.tree(*data*, *options*)
 
+
+
 A convenience compound mark for rendering a tree diagram, including a
 [link](#link) to
 render links from parent to child, an optional
@@ -3031,6 +3079,7 @@ The following options are supported:
 Any additional *options* are passed through to the constituent link, dot, and
 text marks and their corresponding treeLink or treeNode transform.
 
+
 <!-- jsdoc cluster -->
 
 #### Plot.cluster(*data*, *options*)
@@ -3039,6 +3088,7 @@ Like
 [Plot.tree](#plottreedata-options),
 except sets the **treeLayout** option to D3’s cluster (dendrogram) algorithm,
 which aligns leaf nodes.
+
 
 <!-- jsdocEnd -->
 

--- a/scripts/jsdoc-to-readme.ts
+++ b/scripts/jsdoc-to-readme.ts
@@ -53,8 +53,7 @@ function injectJsDoc(readme: string) {
       if (!declaration) throw new Error(`${name} is not exported by src/index`);
       parts.push(getJsDocs(name, declaration, prefix));
       parts.push("");
-      // Standardize on one leading and trailing new line for each replacement.
-      replacement = `\n${parts.join("\n").trim()}\n`;
+      replacement = pad(parts.join("\n"));
     }
     if (!insideReplacement || isReplacementDelimiter) output.push(line);
     if (replacement) output.push(replacement);
@@ -80,6 +79,7 @@ function makeRelativeUrls(description: string) {
   return description.replace(new RegExp("https://github.com/observablehq/plot/blob/main/README.md#", "g"), "#");
 }
 
+// Standardize on one leading and trailing new line for each replacement.
 function pad(s: string) {
   return `\n${s.trim()}\n`;
 }

--- a/scripts/jsdoc-to-readme.ts
+++ b/scripts/jsdoc-to-readme.ts
@@ -53,7 +53,8 @@ function injectJsDoc(readme: string) {
       if (!declaration) throw new Error(`${name} is not exported by src/index`);
       parts.push(getJsDocs(name, declaration, prefix));
       parts.push("");
-      replacement = parts.join("\n");
+      // Standardize on one leading and trailing new line for each replacement.
+      replacement = `\n${parts.join("\n").trim()}\n`;
     }
     if (!insideReplacement || isReplacementDelimiter) output.push(line);
     if (replacement) output.push(replacement);

--- a/src/marks/area.js
+++ b/src/marks/area.js
@@ -2,6 +2,7 @@
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").StackOptions} StackOptions
+ * @typedef {MarkOptions & StackOptions | undefined} Options
  */
 
 import {area as shapeArea} from "d3";
@@ -92,9 +93,9 @@ export class Area extends Mark {
  * is used in the vertical orientation where the baseline and topline share *y*
  * values.
  * @param {Data} data
- * @param {MarkOptions & StackOptions} options
+ * @param {Options} options
  */
-export function area(data, options) {
+export function area(data, options = undefined) {
   if (options === undefined) return areaY(data, {x: first, y: second});
   return new Area(data, options);
 }
@@ -130,9 +131,9 @@ export function area(data, options) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {MarkOptions & StackOptions} options
+ * @param {Options} options
  */
-export function areaX(data, options) {
+export function areaX(data, options = undefined) {
   const {y = indexOf, ...rest} = maybeDenseIntervalY(options);
   return new Area(data, maybeStackX(maybeIdentityX({...rest, y1: y, y2: undefined})));
 }
@@ -168,9 +169,9 @@ export function areaX(data, options) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {MarkOptions & StackOptions} options
+ * @param {Options} options
  */
-export function areaY(data, options) {
+export function areaY(data, options = undefined) {
   const {x = indexOf, ...rest} = maybeDenseIntervalX(options);
   return new Area(data, maybeStackY(maybeIdentityY({...rest, x1: x, x2: undefined})));
 }

--- a/src/marks/area.js
+++ b/src/marks/area.js
@@ -90,7 +90,6 @@ export class Area extends Mark {
  * [Plot.areaX](https://github.com/observablehq/plot/blob/main/README.md#plotareaxdata-options)
  * is used in the vertical orientation where the baseline and topline share *y*
  * values.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -129,7 +128,6 @@ export function area(data, options) {
  * The **interval** option is recommended to “regularize” sampled data; for
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -168,7 +166,6 @@ export function areaX(data, options) {
  * The **interval** option is recommended to “regularize” sampled data; for
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/area.js
+++ b/src/marks/area.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {area as shapeArea} from "d3";
 import {create} from "../context.js";
 import {Curve} from "../curve.js";
@@ -13,11 +18,6 @@ import {
 import {maybeDenseIntervalX, maybeDenseIntervalY} from "../transforms/bin.js";
 import {maybeIdentityX, maybeIdentityY} from "../transforms/identity.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const defaults = {
   ariaLabel: "area",

--- a/src/marks/area.js
+++ b/src/marks/area.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").StackOptions} StackOptions
  */
 
 import {area as shapeArea} from "d3";
@@ -91,7 +92,7 @@ export class Area extends Mark {
  * is used in the vertical orientation where the baseline and topline share *y*
  * values.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & StackOptions} options
  */
 export function area(data, options) {
   if (options === undefined) return areaY(data, {x: first, y: second});
@@ -129,7 +130,7 @@ export function area(data, options) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & StackOptions} options
  */
 export function areaX(data, options) {
   const {y = indexOf, ...rest} = maybeDenseIntervalY(options);
@@ -167,7 +168,7 @@ export function areaX(data, options) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & StackOptions} options
  */
 export function areaY(data, options) {
   const {x = indexOf, ...rest} = maybeDenseIntervalX(options);

--- a/src/marks/area.js
+++ b/src/marks/area.js
@@ -93,9 +93,9 @@ export class Area extends Mark {
  * is used in the vertical orientation where the baseline and topline share *y*
  * values.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  */
-export function area(data, options = undefined) {
+export function area(data, options) {
   if (options === undefined) return areaY(data, {x: first, y: second});
   return new Area(data, options);
 }
@@ -131,9 +131,9 @@ export function area(data, options = undefined) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  */
-export function areaX(data, options = undefined) {
+export function areaX(data, options) {
   const {y = indexOf, ...rest} = maybeDenseIntervalY(options);
   return new Area(data, maybeStackX(maybeIdentityX({...rest, y1: y, y2: undefined})));
 }
@@ -169,9 +169,9 @@ export function areaX(data, options = undefined) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  */
-export function areaY(data, options = undefined) {
+export function areaY(data, options) {
   const {x = indexOf, ...rest} = maybeDenseIntervalX(options);
   return new Area(data, maybeStackY(maybeIdentityY({...rest, x1: x, x2: undefined})));
 }

--- a/src/marks/area.js
+++ b/src/marks/area.js
@@ -14,6 +14,11 @@ import {maybeDenseIntervalX, maybeDenseIntervalY} from "../transforms/bin.js";
 import {maybeIdentityX, maybeIdentityY} from "../transforms/identity.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "area",
   strokeWidth: 1,
@@ -85,6 +90,9 @@ export class Area extends Mark {
  * [Plot.areaX](https://github.com/observablehq/plot/blob/main/README.md#plotareaxdata-options)
  * is used in the vertical orientation where the baseline and topline share *y*
  * values.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function area(data, options) {
   if (options === undefined) return areaY(data, {x: first, y: second});
@@ -121,6 +129,9 @@ export function area(data, options) {
  * The **interval** option is recommended to “regularize” sampled data; for
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function areaX(data, options) {
   const {y = indexOf, ...rest} = maybeDenseIntervalY(options);
@@ -157,6 +168,9 @@ export function areaX(data, options) {
  * The **interval** option is recommended to “regularize” sampled data; for
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function areaY(data, options) {
   const {x = indexOf, ...rest} = maybeDenseIntervalX(options);

--- a/src/marks/arrow.js
+++ b/src/marks/arrow.js
@@ -182,6 +182,9 @@ function circleCircleIntersect([ax, ay, ar], [bx, by, br], sign) {
  * ```
  *
  * Returns a new arrow with the given *data* and *options*.
+ *
+ * @param {import("../types.js").Data} data
+ * @param {import("../types.js").MarkOptions} options
  */
 export function arrow(data, options = {}) {
   let {x, x1, x2, y, y1, y2, ...remainingOptions} = options;

--- a/src/marks/arrow.js
+++ b/src/marks/arrow.js
@@ -182,7 +182,6 @@ function circleCircleIntersect([ax, ay, ar], [bx, by, br], sign) {
  * ```
  *
  * Returns a new arrow with the given *data* and *options*.
- *
  * @param {import("../types.js").Data} data
  * @param {import("../types.js").MarkOptions} options
  */

--- a/src/marks/arrow.js
+++ b/src/marks/arrow.js
@@ -1,3 +1,9 @@
+/**
+ * @typedef {import("../types.js").ArrowOptions} ArrowOptions
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {create} from "../context.js";
 import {radians} from "../math.js";
 import {constant} from "../options.js";
@@ -182,8 +188,8 @@ function circleCircleIntersect([ax, ay, ar], [bx, by, br], sign) {
  * ```
  *
  * Returns a new arrow with the given *data* and *options*.
- * @param {import("../types.js").Data} data
- * @param {import("../types.js").MarkOptions} options
+ * @param {Data} data
+ * @param {ArrowOptions & MarkOptions} options
  */
 export function arrow(data, options = {}) {
   let {x, x1, x2, y, y1, y2, ...remainingOptions} = options;

--- a/src/marks/arrow.js
+++ b/src/marks/arrow.js
@@ -2,6 +2,7 @@
  * @typedef {import("../types.js").ArrowOptions} ArrowOptions
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {ArrowOptions & MarkOptions | undefined} Options
  */
 
 import {create} from "../context.js";
@@ -189,7 +190,7 @@ function circleCircleIntersect([ax, ay, ar], [bx, by, br], sign) {
  *
  * Returns a new arrow with the given *data* and *options*.
  * @param {Data} data
- * @param {ArrowOptions & MarkOptions} options
+ * @param {Options} options
  */
 export function arrow(data, options = {}) {
   let {x, x1, x2, y, y1, y2, ...remainingOptions} = options;

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -168,7 +168,6 @@ export class BarY extends AbstractBar {
  *
  * If the **y** channel is not specified, the bar will span the full vertical
  * extent of the plot (or facet).
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -211,7 +210,6 @@ export function barX(data, options = {y: indexOf, x2: identity}) {
  *
  * If the **x** channel is not specified, the bar will span the full horizontal
  * extent of the plot (or facet).
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -3,6 +3,7 @@
  * @typedef {import("../types.js").RectOptions} RectOptions
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").StackOptions} StackOptions
+ * @typedef {MarkOptions & StackOptions & RectOptions | undefined} Options
  */
 
 import {create} from "../context.js";
@@ -171,7 +172,7 @@ export class BarY extends AbstractBar {
  * If the **y** channel is not specified, the bar will span the full vertical
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions & StackOptions & RectOptions} options
+ * @param {Options} options
  */
 export function barX(data, options = {y: indexOf, x2: identity}) {
   return new BarX(data, maybeStackX(maybeIntervalX(maybeIdentityX(options))));
@@ -213,7 +214,7 @@ export function barX(data, options = {y: indexOf, x2: identity}) {
  * If the **x** channel is not specified, the bar will span the full horizontal
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions & StackOptions & RectOptions} options
+ * @param {Options} options
  */
 export function barY(data, options = {x: indexOf, y2: identity}) {
   return new BarY(data, maybeStackY(maybeIntervalY(maybeIdentityY(options))));

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {create} from "../context.js";
 import {identity, indexOf, number} from "../options.js";
 import {Mark} from "../plot.js";
@@ -13,11 +18,6 @@ import {
 import {maybeIdentityX, maybeIdentityY} from "../transforms/identity.js";
 import {maybeIntervalX, maybeIntervalY} from "../transforms/interval.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 export class AbstractBar extends Mark {
   constructor(data, channels, options = {}, defaults) {

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,6 +1,8 @@
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").StackOptions} StackOptions
+ * @typedef {MarkOptions & StackOptions} BarOptions
  */
 
 import {create} from "../context.js";
@@ -169,7 +171,7 @@ export class BarY extends AbstractBar {
  * If the **y** channel is not specified, the bar will span the full vertical
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {BarOptions} options
  */
 export function barX(data, options = {y: indexOf, x2: identity}) {
   return new BarX(data, maybeStackX(maybeIntervalX(maybeIdentityX(options))));
@@ -211,8 +213,10 @@ export function barX(data, options = {y: indexOf, x2: identity}) {
  * If the **x** channel is not specified, the bar will span the full horizontal
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {BarOptions} options
  */
 export function barY(data, options = {x: indexOf, y2: identity}) {
   return new BarY(data, maybeStackY(maybeIntervalY(maybeIdentityY(options))));
 }
+
+barY;

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -14,6 +14,11 @@ import {maybeIdentityX, maybeIdentityY} from "../transforms/identity.js";
 import {maybeIntervalX, maybeIntervalY} from "../transforms/interval.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 export class AbstractBar extends Mark {
   constructor(data, channels, options = {}, defaults) {
     super(data, channels, options, defaults);
@@ -163,6 +168,9 @@ export class BarY extends AbstractBar {
  *
  * If the **y** channel is not specified, the bar will span the full vertical
  * extent of the plot (or facet).
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function barX(data, options = {y: indexOf, x2: identity}) {
   return new BarX(data, maybeStackX(maybeIntervalX(maybeIdentityX(options))));
@@ -203,6 +211,9 @@ export function barX(data, options = {y: indexOf, x2: identity}) {
  *
  * If the **x** channel is not specified, the bar will span the full horizontal
  * extent of the plot (or facet).
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function barY(data, options = {x: indexOf, y2: identity}) {
   return new BarY(data, maybeStackY(maybeIntervalY(maybeIdentityY(options))));

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,8 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
- * @typedef {import("../types.js").StackOptions} StackOptions
- * @typedef {MarkOptions & StackOptions} BarOptions
  */
 
 import {create} from "../context.js";
@@ -171,7 +169,7 @@ export class BarY extends AbstractBar {
  * If the **y** channel is not specified, the bar will span the full vertical
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {BarOptions} options
+ * @param {MarkOptions} options
  */
 export function barX(data, options = {y: indexOf, x2: identity}) {
   return new BarX(data, maybeStackX(maybeIntervalX(maybeIdentityX(options))));
@@ -213,10 +211,8 @@ export function barX(data, options = {y: indexOf, x2: identity}) {
  * If the **x** channel is not specified, the bar will span the full horizontal
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {BarOptions} options
+ * @param {MarkOptions} options
  */
 export function barY(data, options = {x: indexOf, y2: identity}) {
   return new BarY(data, maybeStackY(maybeIntervalY(maybeIdentityY(options))));
 }
-
-barY;

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,5 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").RectOptions} RectOptions
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").StackOptions} StackOptions
  */
@@ -170,7 +171,7 @@ export class BarY extends AbstractBar {
  * If the **y** channel is not specified, the bar will span the full vertical
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions & StackOptions} options
+ * @param {MarkOptions & StackOptions & RectOptions} options
  */
 export function barX(data, options = {y: indexOf, x2: identity}) {
   return new BarX(data, maybeStackX(maybeIntervalX(maybeIdentityX(options))));
@@ -212,7 +213,7 @@ export function barX(data, options = {y: indexOf, x2: identity}) {
  * If the **x** channel is not specified, the bar will span the full horizontal
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions & StackOptions} options
+ * @param {MarkOptions & StackOptions & RectOptions} options
  */
 export function barY(data, options = {x: indexOf, y2: identity}) {
   return new BarY(data, maybeStackY(maybeIntervalY(maybeIdentityY(options))));

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").StackOptions} StackOptions
  */
 
 import {create} from "../context.js";
@@ -169,7 +170,7 @@ export class BarY extends AbstractBar {
  * If the **y** channel is not specified, the bar will span the full vertical
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & StackOptions} options
  */
 export function barX(data, options = {y: indexOf, x2: identity}) {
   return new BarX(data, maybeStackX(maybeIntervalX(maybeIdentityX(options))));
@@ -211,7 +212,7 @@ export function barX(data, options = {y: indexOf, x2: identity}) {
  * If the **x** channel is not specified, the bar will span the full horizontal
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & StackOptions} options
  */
 export function barY(data, options = {x: indexOf, y2: identity}) {
   return new BarY(data, maybeStackY(maybeIntervalY(maybeIdentityY(options))));

--- a/src/marks/box.js
+++ b/src/marks/box.js
@@ -21,7 +21,6 @@ import {tickX, tickY} from "./tick.js";
  * defaults to the identity function, as when *data* is an array of numbers. If
  * the **y** option is not specified, it defaults to null; if the **y** option
  * is specified, it should represent an ordinal (discrete) value.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -57,7 +56,6 @@ export function boxX(data, options = {}) {
  * defaults to the identity function, as when *data* is an array of numbers. If
  * the **x** option is not specified, it defaults to null; if the **x** option
  * is specified, it should represent an ordinal (discrete) value.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/box.js
+++ b/src/marks/box.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkOptions | undefined} Options
  */
 
 import {min, max, quantile} from "d3";
@@ -22,7 +22,7 @@ import {tickX, tickY} from "./tick.js";
  * the **y** option is not specified, it defaults to null; if the **y** option
  * is specified, it should represent an ordinal (discrete) value.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function boxX(data, options = {}) {
   // Returns a composite mark for producing a horizontal box plot, applying the
@@ -57,7 +57,7 @@ export function boxX(data, options = {}) {
  * the **x** option is not specified, it defaults to null; if the **x** option
  * is specified, it should represent an ordinal (discrete) value.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function boxY(data, options = {}) {
   // Returns a composite mark for producing a vertical box plot, applying the

--- a/src/marks/box.js
+++ b/src/marks/box.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {min, max, quantile} from "d3";
 import {marks} from "../plot.js";
 import {groupX, groupY, groupZ} from "../transforms/group.js";
@@ -6,11 +11,6 @@ import {barX, barY} from "./bar.js";
 import {dot} from "./dot.js";
 import {ruleX, ruleY} from "./rule.js";
 import {tickX, tickY} from "./tick.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 /**
  * ```js

--- a/src/marks/box.js
+++ b/src/marks/box.js
@@ -8,6 +8,11 @@ import {ruleX, ruleY} from "./rule.js";
 import {tickX, tickY} from "./tick.js";
 
 /**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
+/**
  * ```js
  * Plot.boxX(simpsons.map(d => d.imdb_rating))
  * ```
@@ -16,6 +21,9 @@ import {tickX, tickY} from "./tick.js";
  * defaults to the identity function, as when *data* is an array of numbers. If
  * the **y** option is not specified, it defaults to null; if the **y** option
  * is specified, it should represent an ordinal (discrete) value.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function boxX(data, options = {}) {
   // Returns a composite mark for producing a horizontal box plot, applying the
@@ -49,6 +57,9 @@ export function boxX(data, options = {}) {
  * defaults to the identity function, as when *data* is an array of numbers. If
  * the **x** option is not specified, it defaults to null; if the **x** option
  * is specified, it should represent an ordinal (discrete) value.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function boxY(data, options = {}) {
   // Returns a composite mark for producing a vertical box plot, applying the

--- a/src/marks/cell.js
+++ b/src/marks/cell.js
@@ -38,7 +38,6 @@ export class Cell extends AbstractBar {
  * nor **y** options are specified, *data* is assumed to be an array of pairs
  * [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
  * *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -59,7 +58,6 @@ export function cell(data, options = {}) {
  * …], and if the **fill** option is not specified and **stroke** is not a
  * channel, the fill defaults to the identity function and assumes that *data* =
  * [*x₀*, *x₁*, *x₂*, …].
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -80,7 +78,6 @@ export function cellX(data, options = {}) {
  * …], and if the **fill** option is not specified and **stroke** is not a
  * channel, the fill defaults to the identity function and assumes that *data* =
  * [*y₀*, *y₁*, *y₂*, …].
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/cell.js
+++ b/src/marks/cell.js
@@ -2,6 +2,7 @@
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").RectOptions} RectOptions
+ * @typedef {RectOptions & MarkOptions | undefined} Options
  */
 
 import {identity, indexOf, maybeColorChannel, maybeTuple} from "../options.js";
@@ -40,7 +41,7 @@ export class Cell extends AbstractBar {
  * [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
  * *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {RectOptions & MarkOptions} options
+ * @param {Options} options
  */
 export function cell(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -60,7 +61,7 @@ export function cell(data, options = {}) {
  * channel, the fill defaults to the identity function and assumes that *data* =
  * [*x₀*, *x₁*, *x₂*, …].
  * @param {Data} data
- * @param {RectOptions & MarkOptions} options
+ * @param {Options} options
  */
 export function cellX(data, options = {}) {
   let {x = indexOf, fill, stroke, ...remainingOptions} = options;
@@ -80,7 +81,7 @@ export function cellX(data, options = {}) {
  * channel, the fill defaults to the identity function and assumes that *data* =
  * [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {RectOptions & MarkOptions} options
+ * @param {Options} options
  */
 export function cellY(data, options = {}) {
   let {y = indexOf, fill, stroke, ...remainingOptions} = options;

--- a/src/marks/cell.js
+++ b/src/marks/cell.js
@@ -2,6 +2,11 @@ import {identity, indexOf, maybeColorChannel, maybeTuple} from "../options.js";
 import {applyTransform} from "../style.js";
 import {AbstractBar} from "./bar.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "cell"
 };
@@ -33,6 +38,9 @@ export class Cell extends AbstractBar {
  * nor **y** options are specified, *data* is assumed to be an array of pairs
  * [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
  * *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function cell(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -51,6 +59,9 @@ export function cell(data, options = {}) {
  * …], and if the **fill** option is not specified and **stroke** is not a
  * channel, the fill defaults to the identity function and assumes that *data* =
  * [*x₀*, *x₁*, *x₂*, …].
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function cellX(data, options = {}) {
   let {x = indexOf, fill, stroke, ...remainingOptions} = options;
@@ -69,6 +80,9 @@ export function cellX(data, options = {}) {
  * …], and if the **fill** option is not specified and **stroke** is not a
  * channel, the fill defaults to the identity function and assumes that *data* =
  * [*y₀*, *y₁*, *y₂*, …].
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function cellY(data, options = {}) {
   let {y = indexOf, fill, stroke, ...remainingOptions} = options;

--- a/src/marks/cell.js
+++ b/src/marks/cell.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").RectOptions} RectOptions
  */
 
 import {identity, indexOf, maybeColorChannel, maybeTuple} from "../options.js";
@@ -39,7 +40,7 @@ export class Cell extends AbstractBar {
  * [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
  * *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {RectOptions & MarkOptions} options
  */
 export function cell(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -59,7 +60,7 @@ export function cell(data, options = {}) {
  * channel, the fill defaults to the identity function and assumes that *data* =
  * [*x₀*, *x₁*, *x₂*, …].
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {RectOptions & MarkOptions} options
  */
 export function cellX(data, options = {}) {
   let {x = indexOf, fill, stroke, ...remainingOptions} = options;
@@ -79,7 +80,7 @@ export function cellX(data, options = {}) {
  * channel, the fill defaults to the identity function and assumes that *data* =
  * [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {RectOptions & MarkOptions} options
  */
 export function cellY(data, options = {}) {
   let {y = indexOf, fill, stroke, ...remainingOptions} = options;

--- a/src/marks/cell.js
+++ b/src/marks/cell.js
@@ -1,11 +1,11 @@
-import {identity, indexOf, maybeColorChannel, maybeTuple} from "../options.js";
-import {applyTransform} from "../style.js";
-import {AbstractBar} from "./bar.js";
-
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  */
+
+import {identity, indexOf, maybeColorChannel, maybeTuple} from "../options.js";
+import {applyTransform} from "../style.js";
+import {AbstractBar} from "./bar.js";
 
 const defaults = {
   ariaLabel: "cell"

--- a/src/marks/delaunay.js
+++ b/src/marks/delaunay.js
@@ -297,10 +297,10 @@ function delaunayMark(DelaunayMark, data, {x, y, ...options} = {}) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  * @returns {DelaunayLink}
  */
-export function delaunayLink(data, options = undefined) {
+export function delaunayLink(data, options) {
   return delaunayMark(DelaunayLink, data, options);
 }
 
@@ -315,10 +315,10 @@ export function delaunayLink(data, options = undefined) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  * @returns {DelaunayMesh}
  */
-export function delaunayMesh(data, options = undefined) {
+export function delaunayMesh(data, options) {
   return delaunayMark(DelaunayMesh, data, options);
 }
 
@@ -334,10 +334,10 @@ export function delaunayMesh(data, options = undefined) {
  * not specified, it defaults to either the **fill** channel, if any, or the
  * **stroke** channel, if any.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  * @returns {Hull}
  */
-export function hull(data, options = undefined) {
+export function hull(data, options) {
   return delaunayMark(Hull, data, options);
 }
 
@@ -348,10 +348,10 @@ export function hull(data, options = undefined) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  * @returns {Voronoi}
  */
-export function voronoi(data, options = undefined) {
+export function voronoi(data, options) {
   return delaunayMark(Voronoi, data, options);
 }
 
@@ -366,9 +366,9 @@ export function voronoi(data, options = undefined) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  * @returns {VoronoiMesh}
  */
-export function voronoiMesh(data, options = undefined) {
+export function voronoiMesh(data, options) {
   return delaunayMark(VoronoiMesh, data, options);
 }

--- a/src/marks/delaunay.js
+++ b/src/marks/delaunay.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {group, path, select, Delaunay} from "d3";
 import {create} from "../context.js";
 import {Curve} from "../curve.js";
@@ -11,11 +16,6 @@ import {
   applyTransform
 } from "../style.js";
 import {markers, applyMarkers} from "./marker.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const delaunayLinkDefaults = {
   ariaLabel: "delaunay link",

--- a/src/marks/delaunay.js
+++ b/src/marks/delaunay.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkerOptions} MarkerOptions
  */
 
 import {group, path, select, Delaunay} from "d3";
@@ -295,7 +296,7 @@ function delaunayMark(DelaunayMark, data, {x, y, ...options} = {}) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & MarkerOptions} options
  * @returns {DelaunayLink}
  */
 export function delaunayLink(data, options) {
@@ -313,7 +314,7 @@ export function delaunayLink(data, options) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & MarkerOptions} options
  * @returns {DelaunayMesh}
  */
 export function delaunayMesh(data, options) {
@@ -332,7 +333,7 @@ export function delaunayMesh(data, options) {
  * not specified, it defaults to either the **fill** channel, if any, or the
  * **stroke** channel, if any.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & MarkerOptions} options
  * @returns {Hull}
  */
 export function hull(data, options) {
@@ -346,7 +347,7 @@ export function hull(data, options) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & MarkerOptions} options
  * @returns {Voronoi}
  */
 export function voronoi(data, options) {
@@ -364,7 +365,7 @@ export function voronoi(data, options) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & MarkerOptions} options
  * @returns {VoronoiMesh}
  */
 export function voronoiMesh(data, options) {

--- a/src/marks/delaunay.js
+++ b/src/marks/delaunay.js
@@ -294,7 +294,6 @@ function delaunayMark(DelaunayMark, data, {x, y, ...options} = {}) {
  *
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  * @returns {DelaunayLink}
@@ -313,7 +312,6 @@ export function delaunayLink(data, options) {
  *
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  * @returns {DelaunayMesh}
@@ -333,7 +331,6 @@ export function delaunayMesh(data, options) {
  * separate convex hulls are constructed for each group. If the **z** channel is
  * not specified, it defaults to either the **fill** channel, if any, or the
  * **stroke** channel, if any.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  * @returns {Hull}
@@ -348,7 +345,6 @@ export function hull(data, options) {
  *
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  * @returns {Voronoi}
@@ -367,7 +363,6 @@ export function voronoi(data, options) {
  *
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  * @returns {VoronoiMesh}

--- a/src/marks/delaunay.js
+++ b/src/marks/delaunay.js
@@ -12,6 +12,11 @@ import {
 } from "../style.js";
 import {markers, applyMarkers} from "./marker.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const delaunayLinkDefaults = {
   ariaLabel: "delaunay link",
   fill: "none",
@@ -289,6 +294,10 @@ function delaunayMark(DelaunayMark, data, {x, y, ...options} = {}) {
  *
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
+ * @returns {DelaunayLink}
  */
 export function delaunayLink(data, options) {
   return delaunayMark(DelaunayLink, data, options);
@@ -304,6 +313,10 @@ export function delaunayLink(data, options) {
  *
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
+ * @returns {DelaunayMesh}
  */
 export function delaunayMesh(data, options) {
   return delaunayMark(DelaunayMesh, data, options);
@@ -320,6 +333,10 @@ export function delaunayMesh(data, options) {
  * separate convex hulls are constructed for each group. If the **z** channel is
  * not specified, it defaults to either the **fill** channel, if any, or the
  * **stroke** channel, if any.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
+ * @returns {Hull}
  */
 export function hull(data, options) {
   return delaunayMark(Hull, data, options);
@@ -331,6 +348,10 @@ export function hull(data, options) {
  *
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
+ * @returns {Voronoi}
  */
 export function voronoi(data, options) {
   return delaunayMark(Voronoi, data, options);
@@ -346,6 +367,10 @@ export function voronoi(data, options) {
  *
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
+ * @returns {VoronoiMesh}
  */
 export function voronoiMesh(data, options) {
   return delaunayMark(VoronoiMesh, data, options);

--- a/src/marks/delaunay.js
+++ b/src/marks/delaunay.js
@@ -2,6 +2,7 @@
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").MarkerOptions} MarkerOptions
+ * @typedef {MarkOptions & MarkerOptions | undefined} Options
  */
 
 import {group, path, select, Delaunay} from "d3";
@@ -296,10 +297,10 @@ function delaunayMark(DelaunayMark, data, {x, y, ...options} = {}) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
  * @param {Data} data
- * @param {MarkOptions & MarkerOptions} options
+ * @param {Options} options
  * @returns {DelaunayLink}
  */
-export function delaunayLink(data, options) {
+export function delaunayLink(data, options = undefined) {
   return delaunayMark(DelaunayLink, data, options);
 }
 
@@ -314,10 +315,10 @@ export function delaunayLink(data, options) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Delaunay triangulations are constructed for each group.
  * @param {Data} data
- * @param {MarkOptions & MarkerOptions} options
+ * @param {Options} options
  * @returns {DelaunayMesh}
  */
-export function delaunayMesh(data, options) {
+export function delaunayMesh(data, options = undefined) {
   return delaunayMark(DelaunayMesh, data, options);
 }
 
@@ -333,10 +334,10 @@ export function delaunayMesh(data, options) {
  * not specified, it defaults to either the **fill** channel, if any, or the
  * **stroke** channel, if any.
  * @param {Data} data
- * @param {MarkOptions & MarkerOptions} options
+ * @param {Options} options
  * @returns {Hull}
  */
-export function hull(data, options) {
+export function hull(data, options = undefined) {
   return delaunayMark(Hull, data, options);
 }
 
@@ -347,10 +348,10 @@ export function hull(data, options) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
  * @param {Data} data
- * @param {MarkOptions & MarkerOptions} options
+ * @param {Options} options
  * @returns {Voronoi}
  */
-export function voronoi(data, options) {
+export function voronoi(data, options = undefined) {
   return delaunayMark(Voronoi, data, options);
 }
 
@@ -365,9 +366,9 @@ export function voronoi(data, options) {
  * If a **z** channel is specified, the input points are grouped by *z*, and
  * separate Voronoi tesselations are constructed for each group.
  * @param {Data} data
- * @param {MarkOptions & MarkerOptions} options
+ * @param {Options} options
  * @returns {VoronoiMesh}
  */
-export function voronoiMesh(data, options) {
+export function voronoiMesh(data, options = undefined) {
   return delaunayMark(VoronoiMesh, data, options);
 }

--- a/src/marks/density.js
+++ b/src/marks/density.js
@@ -89,7 +89,6 @@ export class Density extends Mark {
  * series. If the **stroke** or **fill** is specified as *density*, a color
  * channel is constructed with values representing the density threshold value
  * of each contour.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/density.js
+++ b/src/marks/density.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {contourDensity, create, geoPath} from "d3";
 import {identity, isTypedArray, maybeTuple, maybeZ, valueof} from "../options.js";
 import {Mark} from "../plot.js";
@@ -11,11 +16,6 @@ import {
   groupZ
 } from "../style.js";
 import {initializer} from "../transforms/basic.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const defaults = {
   ariaLabel: "density",

--- a/src/marks/density.js
+++ b/src/marks/density.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkOptions | undefined} Options
  */
 
 import {contourDensity, create, geoPath} from "d3";
@@ -90,7 +90,7 @@ export class Density extends Mark {
  * channel is constructed with values representing the density threshold value
  * of each contour.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function density(data, options = {}) {
   let {x, y, ...remainingOptions} = options;

--- a/src/marks/density.js
+++ b/src/marks/density.js
@@ -12,6 +12,11 @@ import {
 } from "../style.js";
 import {initializer} from "../transforms/basic.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "density",
   fill: "none",
@@ -84,6 +89,9 @@ export class Density extends Mark {
  * series. If the **stroke** or **fill** is specified as *density*, a color
  * channel is constructed with values representing the density threshold value
  * of each contour.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function density(data, options = {}) {
   let {x, y, ...remainingOptions} = options;

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -187,9 +187,9 @@ export function dotY(data, options = {}) {
  * [Plot.dot](https://github.com/observablehq/plot/blob/main/README.md#plotdotdata-options)
  * except that the **symbol** option is set to *circle*.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  */
-export function circle(data, options = undefined) {
+export function circle(data, options) {
   return dot(data, {...options, symbol: "circle"});
 }
 
@@ -198,8 +198,8 @@ export function circle(data, options = undefined) {
  * [Plot.dot](https://github.com/observablehq/plot/blob/main/README.md#plotdotdata-options)
  * except that the **symbol** option is set to *hexagon*.
  * @param {Data} data
- * @param {MarkOptions & DotOptions} options
+ * @param {Options=} options
  */
-export function hexagon(data, options = undefined) {
+export function hexagon(data, options) {
   return dot(data, {...options, symbol: "hexagon"});
 }

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").DotOptions} DotOptions
  */
 
 import {path, symbolCircle} from "d3";
@@ -128,7 +129,7 @@ export class Dot extends Mark {
  * an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
  * **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & DotOptions} options
  */
 export function dot(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -151,7 +152,7 @@ export function dot(data, options = {}) {
  * the interval is specified as a number *n*, *y* will be the midpoint of two
  * consecutive multiples of *n* that bracket *y*.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & DotOptions} options
  */
 export function dotX(data, options = {}) {
   const {x = identity, ...remainingOptions} = options;
@@ -173,7 +174,7 @@ export function dotX(data, options = {}) {
  * the interval is specified as a number *n*, *x* will be the midpoint of two
  * consecutive multiples of *n* that bracket *x*.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & DotOptions} options
  */
 export function dotY(data, options = {}) {
   const {y = identity, ...remainingOptions} = options;
@@ -185,7 +186,7 @@ export function dotY(data, options = {}) {
  * [Plot.dot](https://github.com/observablehq/plot/blob/main/README.md#plotdotdata-options)
  * except that the **symbol** option is set to *circle*.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & DotOptions} options
  */
 export function circle(data, options) {
   return dot(data, {...options, symbol: "circle"});
@@ -196,7 +197,7 @@ export function circle(data, options) {
  * [Plot.dot](https://github.com/observablehq/plot/blob/main/README.md#plotdotdata-options)
  * except that the **symbol** option is set to *hexagon*.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & DotOptions} options
  */
 export function hexagon(data, options) {
   return dot(data, {...options, symbol: "hexagon"});

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -14,6 +14,11 @@ import {maybeSymbolChannel} from "../symbols.js";
 import {sort} from "../transforms/basic.js";
 import {maybeIntervalMidX, maybeIntervalMidY} from "../transforms/interval.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "dot",
   fill: "none",
@@ -122,6 +127,9 @@ export class Dot extends Mark {
  * nor **y** nor **frameAnchor** options are specified, *data* is assumed to be
  * an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
  * **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function dot(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -143,6 +151,9 @@ export function dot(data, options = {}) {
  * (*interval*.floor(*y*) + *interval*.offset(*interval*.floor(*y*))) / 2. If
  * the interval is specified as a number *n*, *y* will be the midpoint of two
  * consecutive multiples of *n* that bracket *y*.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function dotX(data, options = {}) {
   const {x = identity, ...remainingOptions} = options;
@@ -163,6 +174,9 @@ export function dotX(data, options = {}) {
  * (*interval*.floor(*x*) + *interval*.offset(*interval*.floor(*x*))) / 2. If
  * the interval is specified as a number *n*, *x* will be the midpoint of two
  * consecutive multiples of *n* that bracket *x*.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function dotY(data, options = {}) {
   const {y = identity, ...remainingOptions} = options;
@@ -173,6 +187,9 @@ export function dotY(data, options = {}) {
  * Equivalent to
  * [Plot.dot](https://github.com/observablehq/plot/blob/main/README.md#plotdotdata-options)
  * except that the **symbol** option is set to *circle*.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function circle(data, options) {
   return dot(data, {...options, symbol: "circle"});
@@ -182,6 +199,9 @@ export function circle(data, options) {
  * Equivalent to
  * [Plot.dot](https://github.com/observablehq/plot/blob/main/README.md#plotdotdata-options)
  * except that the **symbol** option is set to *hexagon*.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function hexagon(data, options) {
   return dot(data, {...options, symbol: "hexagon"});

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {path, symbolCircle} from "d3";
 import {create} from "../context.js";
 import {positive} from "../defined.js";
@@ -13,11 +18,6 @@ import {
 import {maybeSymbolChannel} from "../symbols.js";
 import {sort} from "../transforms/basic.js";
 import {maybeIntervalMidX, maybeIntervalMidY} from "../transforms/interval.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const defaults = {
   ariaLabel: "dot",

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -2,6 +2,7 @@
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").DotOptions} DotOptions
+ * @typedef {MarkOptions & DotOptions | undefined} Options
  */
 
 import {path, symbolCircle} from "d3";
@@ -129,7 +130,7 @@ export class Dot extends Mark {
  * an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
  * **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {MarkOptions & DotOptions} options
+ * @param {Options} options
  */
 export function dot(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -152,7 +153,7 @@ export function dot(data, options = {}) {
  * the interval is specified as a number *n*, *y* will be the midpoint of two
  * consecutive multiples of *n* that bracket *y*.
  * @param {Data} data
- * @param {MarkOptions & DotOptions} options
+ * @param {Options} options
  */
 export function dotX(data, options = {}) {
   const {x = identity, ...remainingOptions} = options;
@@ -174,7 +175,7 @@ export function dotX(data, options = {}) {
  * the interval is specified as a number *n*, *x* will be the midpoint of two
  * consecutive multiples of *n* that bracket *x*.
  * @param {Data} data
- * @param {MarkOptions & DotOptions} options
+ * @param {Options} options
  */
 export function dotY(data, options = {}) {
   const {y = identity, ...remainingOptions} = options;
@@ -186,9 +187,9 @@ export function dotY(data, options = {}) {
  * [Plot.dot](https://github.com/observablehq/plot/blob/main/README.md#plotdotdata-options)
  * except that the **symbol** option is set to *circle*.
  * @param {Data} data
- * @param {MarkOptions & DotOptions} options
+ * @param {Options} options
  */
-export function circle(data, options) {
+export function circle(data, options = undefined) {
   return dot(data, {...options, symbol: "circle"});
 }
 
@@ -199,6 +200,6 @@ export function circle(data, options) {
  * @param {Data} data
  * @param {MarkOptions & DotOptions} options
  */
-export function hexagon(data, options) {
+export function hexagon(data, options = undefined) {
   return dot(data, {...options, symbol: "hexagon"});
 }

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -127,7 +127,6 @@ export class Dot extends Mark {
  * nor **y** nor **frameAnchor** options are specified, *data* is assumed to be
  * an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
  * **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -151,7 +150,6 @@ export function dot(data, options = {}) {
  * (*interval*.floor(*y*) + *interval*.offset(*interval*.floor(*y*))) / 2. If
  * the interval is specified as a number *n*, *y* will be the midpoint of two
  * consecutive multiples of *n* that bracket *y*.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -174,7 +172,6 @@ export function dotX(data, options = {}) {
  * (*interval*.floor(*x*) + *interval*.offset(*interval*.floor(*x*))) / 2. If
  * the interval is specified as a number *n*, *x* will be the midpoint of two
  * consecutive multiples of *n* that bracket *x*.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -187,7 +184,6 @@ export function dotY(data, options = {}) {
  * Equivalent to
  * [Plot.dot](https://github.com/observablehq/plot/blob/main/README.md#plotdotdata-options)
  * except that the **symbol** option is set to *circle*.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -199,7 +195,6 @@ export function circle(data, options) {
  * Equivalent to
  * [Plot.dot](https://github.com/observablehq/plot/blob/main/README.md#plotdotdata-options)
  * except that the **symbol** option is set to *hexagon*.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/frame.js
+++ b/src/marks/frame.js
@@ -50,8 +50,8 @@ export class Frame extends Mark {
  *
  * Returns a new frame with the specified *options*.
  *
- * @param {Options} options
+ * @param {Options=} options
  */
-export function frame(options = undefined) {
+export function frame(options) {
   return new Frame(options);
 }

--- a/src/marks/frame.js
+++ b/src/marks/frame.js
@@ -1,6 +1,7 @@
 /**
- * @typedef {import("../types.js").StyleOptions} ConstantStyleOptions
+ * @typedef {import("../types.js").StyleOptions} StyleOptions
  * @typedef {import("../types.js").RectOptions} RectOptions
+ * @typedef {StyleOptions & RectOptions | undefined} Options
  */
 
 import {create} from "../context.js";
@@ -49,8 +50,8 @@ export class Frame extends Mark {
  *
  * Returns a new frame with the specified *options*.
  *
- * @param {ConstantStyleOptions & RectOptions}
+ * @param {Options} options
  */
-export function frame(options) {
+export function frame(options = undefined) {
   return new Frame(options);
 }

--- a/src/marks/frame.js
+++ b/src/marks/frame.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").ConstantStyleOptions} ConstantStyleOptions
+ * @typedef {import("../types.js").RectOptions} RectOptions
+ */
+
 import {create} from "../context.js";
 import {number} from "../options.js";
 import {Mark} from "../plot.js";
@@ -43,6 +48,8 @@ export class Frame extends Mark {
  * ```
  *
  * Returns a new frame with the specified *options*.
+ *
+ * @param {ConstantStyleOptions & RectOptions}
  */
 export function frame(options) {
   return new Frame(options);

--- a/src/marks/frame.js
+++ b/src/marks/frame.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("../types.js").ConstantStyleOptions} ConstantStyleOptions
+ * @typedef {import("../types.js").StyleOptions} ConstantStyleOptions
  * @typedef {import("../types.js").RectOptions} RectOptions
  */
 

--- a/src/marks/hexgrid.js
+++ b/src/marks/hexgrid.js
@@ -22,9 +22,9 @@ const defaults = {
  * The **binWidth** option specifies the distance between the centers of
  * neighboring hexagons, in pixels (defaults to 20). The **clip** option
  * defaults to true, clipping the mark to the frame’s dimensions.
- * @param {Options} options
+ * @param {Options=} options
  */
-export function hexgrid(options = undefined) {
+export function hexgrid(options) {
   return new Hexgrid(options);
 }
 

--- a/src/marks/hexgrid.js
+++ b/src/marks/hexgrid.js
@@ -1,3 +1,9 @@
+/**
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {{binWidth?: number}} HexOptions
+ * @typedef {MarkOptions & HexOptions | undefined} Options
+ */
+
 import {create} from "../context.js";
 import {number} from "../options.js";
 import {Mark} from "../plot.js";
@@ -16,8 +22,9 @@ const defaults = {
  * The **binWidth** option specifies the distance between the centers of
  * neighboring hexagons, in pixels (defaults to 20). The **clip** option
  * defaults to true, clipping the mark to the frame’s dimensions.
+ * @param {Options} options
  */
-export function hexgrid(options) {
+export function hexgrid(options = undefined) {
   return new Hexgrid(options);
 }
 

--- a/src/marks/image.js
+++ b/src/marks/image.js
@@ -118,6 +118,9 @@ export class Image extends Mark {
  * nor **y** nor **frameAnchor** options are specified, *data* is assumed to be
  * an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
  * **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
+ *
+ * @param {import("../types.js").Data} data
+ * @param {import("../types.js").MarkOptions} options
  */
 export function image(data, options = {}) {
   let {x, y, ...remainingOptions} = options;

--- a/src/marks/image.js
+++ b/src/marks/image.js
@@ -118,7 +118,6 @@ export class Image extends Mark {
  * nor **y** nor **frameAnchor** options are specified, *data* is assumed to be
  * an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
  * **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
- *
  * @param {import("../types.js").Data} data
  * @param {import("../types.js").MarkOptions} options
  */

--- a/src/marks/image.js
+++ b/src/marks/image.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions | undefined} Options
+ */
 import {create} from "../context.js";
 import {positive} from "../defined.js";
 import {maybeFrameAnchor, maybeNumberChannel, maybeTuple, string} from "../options.js";
@@ -118,8 +122,8 @@ export class Image extends Mark {
  * nor **y** nor **frameAnchor** options are specified, *data* is assumed to be
  * an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that
  * **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
- * @param {import("../types.js").Data} data
- * @param {import("../types.js").MarkOptions} options
+ * @param {Data} data
+ * @param {Options} options
  */
 export function image(data, options = {}) {
   let {x, y, ...remainingOptions} = options;

--- a/src/marks/line.js
+++ b/src/marks/line.js
@@ -84,7 +84,6 @@ export class Line extends Mark {
  * nor **y** options are specified, *data* is assumed to be an array of pairs
  * [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
  * *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -119,7 +118,6 @@ export function line(data, options = {}) {
  * The **interval** option is recommended to “regularize” sampled data; for
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -153,7 +151,6 @@ export function lineX(data, options = {}) {
  * The **interval** option is recommended to “regularize” sampled data; for
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/line.js
+++ b/src/marks/line.js
@@ -2,6 +2,7 @@
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").MarkerOptions} MarkerOptions
+ * @typedef {MarkOptions & MarkerOptions | undefined} Options
  */
 
 import {line as shapeLine} from "d3";
@@ -86,7 +87,7 @@ export class Line extends Mark {
  * [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
  * *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {MarkOptions & MarkerOptions} options
+ * @param {Options} options
  */
 export function line(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -120,7 +121,7 @@ export function line(data, options = {}) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {MarkOptions & MarkerOptions} options
+ * @param {Options} options
  */
 export function lineX(data, options = {}) {
   const {x = identity, y = indexOf, ...remainingOptions} = options;
@@ -153,7 +154,7 @@ export function lineX(data, options = {}) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {MarkOptions & MarkerOptions} options
+ * @param {Options} options
  */
 export function lineY(data, options = {}) {
   const {x = indexOf, y = identity, ...remainingOptions} = options;

--- a/src/marks/line.js
+++ b/src/marks/line.js
@@ -13,6 +13,11 @@ import {
 import {maybeDenseIntervalX, maybeDenseIntervalY} from "../transforms/bin.js";
 import {applyGroupedMarkers, markers} from "./marker.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "line",
   fill: "none",
@@ -79,6 +84,9 @@ export class Line extends Mark {
  * nor **y** options are specified, *data* is assumed to be an array of pairs
  * [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
  * *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function line(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -111,6 +119,9 @@ export function line(data, options = {}) {
  * The **interval** option is recommended to “regularize” sampled data; for
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function lineX(data, options = {}) {
   const {x = identity, y = indexOf, ...remainingOptions} = options;
@@ -142,6 +153,9 @@ export function lineX(data, options = {}) {
  * The **interval** option is recommended to “regularize” sampled data; for
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function lineY(data, options = {}) {
   const {x = indexOf, y = identity, ...remainingOptions} = options;

--- a/src/marks/line.js
+++ b/src/marks/line.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkerOptions} MarkerOptions
  */
 
 import {line as shapeLine} from "d3";
@@ -85,7 +86,7 @@ export class Line extends Mark {
  * [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*, *x₁*,
  * *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & MarkerOptions} options
  */
 export function line(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -119,7 +120,7 @@ export function line(data, options = {}) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & MarkerOptions} options
  */
 export function lineX(data, options = {}) {
   const {x = identity, y = indexOf, ...remainingOptions} = options;
@@ -152,7 +153,7 @@ export function lineX(data, options = {}) {
  * example, if your data represents timestamped temperature measurements and you
  * expect one sample per day, use d3.utcDay as the interval.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {MarkOptions & MarkerOptions} options
  */
 export function lineY(data, options = {}) {
   const {x = indexOf, y = identity, ...remainingOptions} = options;

--- a/src/marks/line.js
+++ b/src/marks/line.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {line as shapeLine} from "d3";
 import {create} from "../context.js";
 import {Curve} from "../curve.js";
@@ -12,11 +17,6 @@ import {
 } from "../style.js";
 import {maybeDenseIntervalX, maybeDenseIntervalY} from "../transforms/bin.js";
 import {applyGroupedMarkers, markers} from "./marker.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const defaults = {
   ariaLabel: "line",

--- a/src/marks/linearRegression.js
+++ b/src/marks/linearRegression.js
@@ -6,6 +6,11 @@ import {qt} from "../stats.js";
 import {applyDirectStyles, applyGroupedChannelStyles, applyIndirectStyles, applyTransform, groupZ} from "../style.js";
 import {maybeDenseIntervalX, maybeDenseIntervalY} from "../transforms/bin.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "linear-regression",
   fill: "currentColor",
@@ -129,6 +134,9 @@ class LinearRegressionY extends LinearRegression {
  *
  * Returns a linear regression mark where *x* is the dependent variable and *y*
  * is the independent variable.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function linearRegressionX(data, options = {}) {
   const {
@@ -148,6 +156,9 @@ export function linearRegressionX(data, options = {}) {
  *
  * Returns a linear regression mark where *y* is the dependent variable and *x*
  * is the independent variable.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function linearRegressionY(data, options = {}) {
   const {

--- a/src/marks/linearRegression.js
+++ b/src/marks/linearRegression.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkOptions | undefined} Options
  */
 
 import {extent, range, sum, area as shapeArea, namespaces} from "d3";
@@ -135,7 +135,7 @@ class LinearRegressionY extends LinearRegression {
  * Returns a linear regression mark where *x* is the dependent variable and *y*
  * is the independent variable.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function linearRegressionX(data, options = {}) {
   const {
@@ -156,7 +156,7 @@ export function linearRegressionX(data, options = {}) {
  * Returns a linear regression mark where *y* is the dependent variable and *x*
  * is the independent variable.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function linearRegressionY(data, options = {}) {
   const {

--- a/src/marks/linearRegression.js
+++ b/src/marks/linearRegression.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {extent, range, sum, area as shapeArea, namespaces} from "d3";
 import {create} from "../context.js";
 import {identity, indexOf, isNone, isNoneish, maybeZ} from "../options.js";
@@ -5,11 +10,6 @@ import {Mark} from "../plot.js";
 import {qt} from "../stats.js";
 import {applyDirectStyles, applyGroupedChannelStyles, applyIndirectStyles, applyTransform, groupZ} from "../style.js";
 import {maybeDenseIntervalX, maybeDenseIntervalY} from "../transforms/bin.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const defaults = {
   ariaLabel: "linear-regression",

--- a/src/marks/linearRegression.js
+++ b/src/marks/linearRegression.js
@@ -134,7 +134,6 @@ class LinearRegressionY extends LinearRegression {
  *
  * Returns a linear regression mark where *x* is the dependent variable and *y*
  * is the independent variable.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -156,7 +155,6 @@ export function linearRegressionX(data, options = {}) {
  *
  * Returns a linear regression mark where *y* is the dependent variable and *x*
  * is the independent variable.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/link.js
+++ b/src/marks/link.js
@@ -2,6 +2,7 @@
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").MarkerOptions} MarkerOptions
+ * @typedef {MarkOptions & MarkerOptions | undefined} Options
  */
 
 import {path} from "d3";
@@ -71,7 +72,7 @@ export class Link extends Mark {
  *
  * Returns a new link with the given *data* and *options*.
  * @param {Data} data
- * @param {MarkOptions & MarkerOptions} options
+ * @param {Options} options
  */
 export function link(data, options = {}) {
   let {x, x1, x2, y, y1, y2, ...remainingOptions} = options;

--- a/src/marks/link.js
+++ b/src/marks/link.js
@@ -1,3 +1,9 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkerOptions} MarkerOptions
+ */
+
 import {path} from "d3";
 import {create} from "../context.js";
 import {Curve} from "../curve.js";
@@ -64,8 +70,8 @@ export class Link extends Mark {
  * ```
  *
  * Returns a new link with the given *data* and *options*.
- * @param {import("../types.js").Data} data
- * @param {import("../types.js").MarkOptions} options
+ * @param {Data} data
+ * @param {MarkOptions & MarkerOptions} options
  */
 export function link(data, options = {}) {
   let {x, x1, x2, y, y1, y2, ...remainingOptions} = options;

--- a/src/marks/link.js
+++ b/src/marks/link.js
@@ -64,6 +64,9 @@ export class Link extends Mark {
  * ```
  *
  * Returns a new link with the given *data* and *options*.
+ *
+ * @param {import("../types.js").Data} data
+ * @param {import("../types.js").MarkOptions} options
  */
 export function link(data, options = {}) {
   let {x, x1, x2, y, y1, y2, ...remainingOptions} = options;

--- a/src/marks/link.js
+++ b/src/marks/link.js
@@ -64,7 +64,6 @@ export class Link extends Mark {
  * ```
  *
  * Returns a new link with the given *data* and *options*.
- *
  * @param {import("../types.js").Data} data
  * @param {import("../types.js").MarkOptions} options
  */

--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").RectOptions} RectOptions
  */
 
 import {create} from "../context.js";
@@ -140,7 +141,7 @@ export function rectX(data, options = {y: indexOf, interval: 1, x2: identity}) {
  * 0. If the **y** option is not specified, it defaults to the identity
  * function.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {RectOptions & MarkOptions} options
  */
 export function rectY(data, options = {x: indexOf, interval: 1, y2: identity}) {
   return new Rect(data, maybeStackY(maybeTrivialIntervalX(maybeIdentityY(options))));

--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -99,7 +99,6 @@ export class Rect extends Mark {
  * ```
  *
  * Returns a new rect with the given *data* and *options*.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -120,7 +119,6 @@ export function rect(data, options) {
  * this is the typical configuration for a histogram with rects aligned at *x* =
  * 0. If the **x** option is not specified, it defaults to the identity
  * function.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -141,7 +139,6 @@ export function rectX(data, options = {y: indexOf, interval: 1, x2: identity}) {
  * this is the typical configuration for a histogram with rects aligned at *y* =
  * 0. If the **y** option is not specified, it defaults to the identity
  * function.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -102,9 +102,9 @@ export class Rect extends Mark {
  *
  * Returns a new rect with the given *data* and *options*.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  */
-export function rect(data, options = undefined) {
+export function rect(data, options) {
   return new Rect(data, maybeTrivialIntervalX(maybeTrivialIntervalY(options)));
 }
 

--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -2,6 +2,7 @@
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").RectOptions} RectOptions
+ * @typedef {MarkOptions & RectOptions | undefined} Options
  */
 
 import {create} from "../context.js";
@@ -101,9 +102,9 @@ export class Rect extends Mark {
  *
  * Returns a new rect with the given *data* and *options*.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
-export function rect(data, options) {
+export function rect(data, options = undefined) {
   return new Rect(data, maybeTrivialIntervalX(maybeTrivialIntervalY(options)));
 }
 
@@ -121,7 +122,7 @@ export function rect(data, options) {
  * 0. If the **x** option is not specified, it defaults to the identity
  * function.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function rectX(data, options = {y: indexOf, interval: 1, x2: identity}) {
   return new Rect(data, maybeStackX(maybeTrivialIntervalY(maybeIdentityX(options))));
@@ -141,7 +142,7 @@ export function rectX(data, options = {y: indexOf, interval: 1, x2: identity}) {
  * 0. If the **y** option is not specified, it defaults to the identity
  * function.
  * @param {Data} data
- * @param {RectOptions & MarkOptions} options
+ * @param {Options} options
  */
 export function rectY(data, options = {x: indexOf, interval: 1, y2: identity}) {
   return new Rect(data, maybeStackY(maybeTrivialIntervalX(maybeIdentityY(options))));

--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {create} from "../context.js";
 import {identity, indexOf, number} from "../options.js";
 import {Mark} from "../plot.js";
@@ -13,11 +18,6 @@ import {
 import {maybeIdentityX, maybeIdentityY} from "../transforms/identity.js";
 import {maybeTrivialIntervalX, maybeTrivialIntervalY} from "../transforms/interval.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const defaults = {
   ariaLabel: "rect"

--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -14,6 +14,11 @@ import {maybeIdentityX, maybeIdentityY} from "../transforms/identity.js";
 import {maybeTrivialIntervalX, maybeTrivialIntervalY} from "../transforms/interval.js";
 import {maybeStackX, maybeStackY} from "../transforms/stack.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "rect"
 };
@@ -94,6 +99,9 @@ export class Rect extends Mark {
  * ```
  *
  * Returns a new rect with the given *data* and *options*.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function rect(data, options) {
   return new Rect(data, maybeTrivialIntervalX(maybeTrivialIntervalY(options)));
@@ -112,6 +120,9 @@ export function rect(data, options) {
  * this is the typical configuration for a histogram with rects aligned at *x* =
  * 0. If the **x** option is not specified, it defaults to the identity
  * function.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function rectX(data, options = {y: indexOf, interval: 1, x2: identity}) {
   return new Rect(data, maybeStackX(maybeTrivialIntervalY(maybeIdentityX(options))));
@@ -130,6 +141,9 @@ export function rectX(data, options = {y: indexOf, interval: 1, x2: identity}) {
  * this is the typical configuration for a histogram with rects aligned at *y* =
  * 0. If the **y** option is not specified, it defaults to the identity
  * function.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function rectY(data, options = {x: indexOf, interval: 1, y2: identity}) {
   return new Rect(data, maybeStackY(maybeTrivialIntervalX(maybeIdentityY(options))));

--- a/src/marks/rule.js
+++ b/src/marks/rule.js
@@ -1,14 +1,14 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {create} from "../context.js";
 import {identity, number} from "../options.js";
 import {Mark} from "../plot.js";
 import {isCollapsed} from "../scales.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyChannelStyles, offset} from "../style.js";
 import {maybeIntervalX, maybeIntervalY} from "../transforms/interval.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const defaults = {
   ariaLabel: "rule",

--- a/src/marks/rule.js
+++ b/src/marks/rule.js
@@ -143,9 +143,9 @@ export class RuleY extends Mark {
  * If the interval is specified as a number *n*, *y1* and *y2* are taken as the
  * two consecutive multiples of *n* that bracket *y*.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  */
-export function ruleX(data, options = undefined) {
+export function ruleX(data, options) {
   let {x = identity, y, y1, y2, ...rest} = maybeIntervalY(options);
   [y1, y2] = maybeOptionalZero(y, y1, y2);
   return new RuleX(data, {...rest, x, y1, y2});
@@ -183,9 +183,9 @@ export function ruleX(data, options = undefined) {
  * If the interval is specified as a number *n*, *x1* and *x2* are taken as the
  * two consecutive multiples of *n* that bracket *x*.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  */
-export function ruleY(data, options = undefined) {
+export function ruleY(data, options) {
   let {y = identity, x, x1, x2, ...rest} = maybeIntervalX(options);
   [x1, x2] = maybeOptionalZero(x, x1, x2);
   return new RuleY(data, {...rest, y, x1, x2});

--- a/src/marks/rule.js
+++ b/src/marks/rule.js
@@ -142,7 +142,6 @@ export class RuleY extends Mark {
  * *y1*, and *interval*.offset(*y1*) is invoked for each *y1* to produce *y2*.
  * If the interval is specified as a number *n*, *y1* and *y2* are taken as the
  * two consecutive multiples of *n* that bracket *y*.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -183,7 +182,6 @@ export function ruleX(data, options) {
  * *x1*, and *interval*.offset(*x1*) is invoked for each *x1* to produce *x2*.
  * If the interval is specified as a number *n*, *x1* and *x2* are taken as the
  * two consecutive multiples of *n* that bracket *x*.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/rule.js
+++ b/src/marks/rule.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkOptions | undefined} Options
  */
 
 import {create} from "../context.js";
@@ -143,9 +143,9 @@ export class RuleY extends Mark {
  * If the interval is specified as a number *n*, *y1* and *y2* are taken as the
  * two consecutive multiples of *n* that bracket *y*.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
-export function ruleX(data, options) {
+export function ruleX(data, options = undefined) {
   let {x = identity, y, y1, y2, ...rest} = maybeIntervalY(options);
   [y1, y2] = maybeOptionalZero(y, y1, y2);
   return new RuleX(data, {...rest, x, y1, y2});
@@ -183,9 +183,9 @@ export function ruleX(data, options) {
  * If the interval is specified as a number *n*, *x1* and *x2* are taken as the
  * two consecutive multiples of *n* that bracket *x*.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
-export function ruleY(data, options) {
+export function ruleY(data, options = undefined) {
   let {y = identity, x, x1, x2, ...rest} = maybeIntervalX(options);
   [x1, x2] = maybeOptionalZero(x, x1, x2);
   return new RuleY(data, {...rest, y, x1, x2});

--- a/src/marks/rule.js
+++ b/src/marks/rule.js
@@ -5,6 +5,11 @@ import {isCollapsed} from "../scales.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyChannelStyles, offset} from "../style.js";
 import {maybeIntervalX, maybeIntervalY} from "../transforms/interval.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "rule",
   fill: null,
@@ -137,6 +142,9 @@ export class RuleY extends Mark {
  * *y1*, and *interval*.offset(*y1*) is invoked for each *y1* to produce *y2*.
  * If the interval is specified as a number *n*, *y1* and *y2* are taken as the
  * two consecutive multiples of *n* that bracket *y*.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function ruleX(data, options) {
   let {x = identity, y, y1, y2, ...rest} = maybeIntervalY(options);
@@ -175,6 +183,9 @@ export function ruleX(data, options) {
  * *x1*, and *interval*.offset(*x1*) is invoked for each *x1* to produce *x2*.
  * If the interval is specified as a number *n*, *x1* and *x2* are taken as the
  * two consecutive multiples of *n* that bracket *x*.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function ruleY(data, options) {
   let {y = identity, x, x1, x2, ...rest} = maybeIntervalX(options);

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -167,7 +167,6 @@ function applyMultilineText(selection, {monospace, lineAnchor, lineHeight, lineW
  * **x** nor **y** nor **frameAnchor** options are specified, *data* is assumed
  * to be an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such
  * that **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -187,7 +186,6 @@ export function text(data, options = {}) {
  * (*interval*.floor(*y*) + *interval*.offset(*interval*.floor(*y*))) / 2. If
  * the interval is specified as a number *n*, *y* will be the midpoint of two
  * consecutive multiples of *n* that bracket *y*.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -206,7 +204,6 @@ export function textX(data, options = {}) {
  * (*interval*.floor(*x*) + *interval*.offset(*interval*.floor(*x*))) / 2. If
  * the interval is specified as a number *n*, *x* will be the midpoint of two
  * consecutive multiples of *n* that bracket *x*.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkOptions | undefined} Options
  */
 
 import {namespaces} from "d3";
@@ -168,7 +168,7 @@ function applyMultilineText(selection, {monospace, lineAnchor, lineHeight, lineW
  * to be an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such
  * that **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function text(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -187,7 +187,7 @@ export function text(data, options = {}) {
  * the interval is specified as a number *n*, *y* will be the midpoint of two
  * consecutive multiples of *n* that bracket *y*.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function textX(data, options = {}) {
   const {x = identity, ...remainingOptions} = options;
@@ -205,7 +205,7 @@ export function textX(data, options = {}) {
  * the interval is specified as a number *n*, *x* will be the midpoint of two
  * consecutive multiples of *n* that bracket *x*.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function textY(data, options = {}) {
   const {y = identity, ...remainingOptions} = options;

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {namespaces} from "d3";
 import {create} from "../context.js";
 import {nonempty} from "../defined.js";
@@ -27,11 +32,6 @@ import {
   applyFrameAnchor
 } from "../style.js";
 import {maybeIntervalMidX, maybeIntervalMidY} from "../transforms/interval.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const defaults = {
   ariaLabel: "text",

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -28,6 +28,11 @@ import {
 } from "../style.js";
 import {maybeIntervalMidX, maybeIntervalMidY} from "../transforms/interval.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "text",
   strokeLinejoin: "round",
@@ -162,6 +167,9 @@ function applyMultilineText(selection, {monospace, lineAnchor, lineHeight, lineW
  * **x** nor **y** nor **frameAnchor** options are specified, *data* is assumed
  * to be an array of pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such
  * that **x** = [*x₀*, *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function text(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -179,6 +187,9 @@ export function text(data, options = {}) {
  * (*interval*.floor(*y*) + *interval*.offset(*interval*.floor(*y*))) / 2. If
  * the interval is specified as a number *n*, *y* will be the midpoint of two
  * consecutive multiples of *n* that bracket *y*.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function textX(data, options = {}) {
   const {x = identity, ...remainingOptions} = options;
@@ -195,6 +206,9 @@ export function textX(data, options = {}) {
  * (*interval*.floor(*x*) + *interval*.offset(*interval*.floor(*x*))) / 2. If
  * the interval is specified as a number *n*, *x* will be the midpoint of two
  * consecutive multiples of *n* that bracket *x*.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function textY(data, options = {}) {
   const {y = identity, ...remainingOptions} = options;

--- a/src/marks/tick.js
+++ b/src/marks/tick.js
@@ -3,6 +3,11 @@ import {identity, number} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyChannelStyles, offset} from "../style.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "tick",
   fill: null,
@@ -116,6 +121,9 @@ export class TickY extends AbstractTick {
  *
  * If the **y** channel is not specified, the tick will span the full vertical
  * extent of the plot (or facet).
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function tickX(data, options = {}) {
   const {x = identity, ...remainingOptions} = options;
@@ -139,6 +147,9 @@ export function tickX(data, options = {}) {
  *
  * If the **x** channel is not specified, the tick will span the full vertical
  * extent of the plot (or facet).
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function tickY(data, options = {}) {
   const {y = identity, ...remainingOptions} = options;

--- a/src/marks/tick.js
+++ b/src/marks/tick.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkOptions | undefined} Options
  */
 
 import {create} from "../context.js";
@@ -122,7 +122,7 @@ export class TickY extends AbstractTick {
  * If the **y** channel is not specified, the tick will span the full vertical
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function tickX(data, options = {}) {
   const {x = identity, ...remainingOptions} = options;
@@ -147,7 +147,7 @@ export function tickX(data, options = {}) {
  * If the **x** channel is not specified, the tick will span the full vertical
  * extent of the plot (or facet).
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function tickY(data, options = {}) {
   const {y = identity, ...remainingOptions} = options;

--- a/src/marks/tick.js
+++ b/src/marks/tick.js
@@ -121,7 +121,6 @@ export class TickY extends AbstractTick {
  *
  * If the **y** channel is not specified, the tick will span the full vertical
  * extent of the plot (or facet).
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -147,7 +146,6 @@ export function tickX(data, options = {}) {
  *
  * If the **x** channel is not specified, the tick will span the full vertical
  * extent of the plot (or facet).
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/tick.js
+++ b/src/marks/tick.js
@@ -1,12 +1,12 @@
-import {create} from "../context.js";
-import {identity, number} from "../options.js";
-import {Mark} from "../plot.js";
-import {applyDirectStyles, applyIndirectStyles, applyTransform, applyChannelStyles, offset} from "../style.js";
-
 /**
  * @typedef {import("../types.js").Data} Data
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  */
+
+import {create} from "../context.js";
+import {identity, number} from "../options.js";
+import {Mark} from "../plot.js";
+import {applyDirectStyles, applyIndirectStyles, applyTransform, applyChannelStyles, offset} from "../style.js";
 
 const defaults = {
   ariaLabel: "tick",

--- a/src/marks/tree.js
+++ b/src/marks/tree.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkOptions | undefined} Options
  */
 
 import {cluster as Cluster} from "d3";
@@ -48,7 +48,7 @@ import {text} from "./text.js";
  * Any additional *options* are passed through to the constituent link, dot, and
  * text marks and their corresponding treeLink or treeNode transform.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function tree(data, options = {}) {
   let {
@@ -116,8 +116,8 @@ export function tree(data, options = {}) {
  * except sets the **treeLayout** option to D3’s cluster (dendrogram) algorithm,
  * which aligns leaf nodes.
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
-export function cluster(data, options) {
+export function cluster(data, options = undefined) {
   return tree(data, {...options, treeLayout: Cluster});
 }

--- a/src/marks/tree.js
+++ b/src/marks/tree.js
@@ -47,7 +47,6 @@ import {text} from "./text.js";
  *
  * Any additional *options* are passed through to the constituent link, dot, and
  * text marks and their corresponding treeLink or treeNode transform.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -116,7 +115,6 @@ export function tree(data, options = {}) {
  * [Plot.tree](https://github.com/observablehq/plot/blob/main/README.md#plottreedata-options),
  * except sets the **treeLayout** option to D3’s cluster (dendrogram) algorithm,
  * which aligns leaf nodes.
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/tree.js
+++ b/src/marks/tree.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {cluster as Cluster} from "d3";
 import {isNoneish} from "../options.js";
 import {marks} from "../plot.js";
@@ -5,11 +10,6 @@ import {maybeTreeAnchor, treeLink, treeNode} from "../transforms/tree.js";
 import {dot} from "./dot.js";
 import {link} from "./link.js";
 import {text} from "./text.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 /**
  * A convenience compound mark for rendering a tree diagram, including a

--- a/src/marks/tree.js
+++ b/src/marks/tree.js
@@ -116,8 +116,8 @@ export function tree(data, options = {}) {
  * except sets the **treeLayout** option to D3’s cluster (dendrogram) algorithm,
  * which aligns leaf nodes.
  * @param {Data} data
- * @param {Options} options
+ * @param {Options=} options
  */
-export function cluster(data, options = undefined) {
+export function cluster(data, options) {
   return tree(data, {...options, treeLayout: Cluster});
 }

--- a/src/marks/tree.js
+++ b/src/marks/tree.js
@@ -7,6 +7,11 @@ import {link} from "./link.js";
 import {text} from "./text.js";
 
 /**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
+/**
  * A convenience compound mark for rendering a tree diagram, including a
  * [link](https://github.com/observablehq/plot/blob/main/README.md#link) to
  * render links from parent to child, an optional
@@ -42,6 +47,9 @@ import {text} from "./text.js";
  *
  * Any additional *options* are passed through to the constituent link, dot, and
  * text marks and their corresponding treeLink or treeNode transform.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function tree(data, options = {}) {
   let {
@@ -108,6 +116,9 @@ export function tree(data, options = {}) {
  * [Plot.tree](https://github.com/observablehq/plot/blob/main/README.md#plottreedata-options),
  * except sets the **treeLayout** option to D3’s cluster (dendrogram) algorithm,
  * which aligns leaf nodes.
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function cluster(data, options) {
   return tree(data, {...options, treeLayout: Cluster});

--- a/src/marks/vector.js
+++ b/src/marks/vector.js
@@ -88,7 +88,6 @@ export class Vector extends Mark {
  * **x** nor **y** options are specified, *data* is assumed to be an array of
  * pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*,
  * *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -103,7 +102,6 @@ export function vector(data, options = {}) {
  * [Plot.vector](https://github.com/observablehq/plot/blob/main/README.md#plotvectordata-options)
  * except that if the **x** option is not specified, it defaults to the identity
  * function and assumes that *data* = [*x₀*, *x₁*, *x₂*, …].
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */
@@ -117,7 +115,6 @@ export function vectorX(data, options = {}) {
  * [Plot.vector](https://github.com/observablehq/plot/blob/main/README.md#plotvectordata-options)
  * except that if the **y** option is not specified, it defaults to the identity
  * function and assumes that *data* = [*y₀*, *y₁*, *y₂*, …].
- *
  * @param {Data} data
  * @param {MarkOptions} options
  */

--- a/src/marks/vector.js
+++ b/src/marks/vector.js
@@ -10,6 +10,11 @@ import {
   applyTransform
 } from "../style.js";
 
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 const defaults = {
   ariaLabel: "vector",
   fill: null,
@@ -83,6 +88,9 @@ export class Vector extends Mark {
  * **x** nor **y** options are specified, *data* is assumed to be an array of
  * pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*,
  * *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function vector(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -95,6 +103,9 @@ export function vector(data, options = {}) {
  * [Plot.vector](https://github.com/observablehq/plot/blob/main/README.md#plotvectordata-options)
  * except that if the **x** option is not specified, it defaults to the identity
  * function and assumes that *data* = [*x₀*, *x₁*, *x₂*, …].
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function vectorX(data, options = {}) {
   const {x = identity, ...remainingOptions} = options;
@@ -106,6 +117,9 @@ export function vectorX(data, options = {}) {
  * [Plot.vector](https://github.com/observablehq/plot/blob/main/README.md#plotvectordata-options)
  * except that if the **y** option is not specified, it defaults to the identity
  * function and assumes that *data* = [*y₀*, *y₁*, *y₂*, …].
+ *
+ * @param {Data} data
+ * @param {MarkOptions} options
  */
 export function vectorY(data, options = {}) {
   const {y = identity, ...remainingOptions} = options;

--- a/src/marks/vector.js
+++ b/src/marks/vector.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").MarkOptions | undefined} Options
  */
 
 import {create} from "../context.js";
@@ -89,7 +89,7 @@ export class Vector extends Mark {
  * pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*,
  * *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function vector(data, options = {}) {
   let {x, y, ...remainingOptions} = options;
@@ -103,7 +103,7 @@ export function vector(data, options = {}) {
  * except that if the **x** option is not specified, it defaults to the identity
  * function and assumes that *data* = [*x₀*, *x₁*, *x₂*, …].
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function vectorX(data, options = {}) {
   const {x = identity, ...remainingOptions} = options;
@@ -116,7 +116,7 @@ export function vectorX(data, options = {}) {
  * except that if the **y** option is not specified, it defaults to the identity
  * function and assumes that *data* = [*y₀*, *y₁*, *y₂*, …].
  * @param {Data} data
- * @param {MarkOptions} options
+ * @param {Options} options
  */
 export function vectorY(data, options = {}) {
   const {y = identity, ...remainingOptions} = options;

--- a/src/marks/vector.js
+++ b/src/marks/vector.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").Data} Data
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ */
+
 import {create} from "../context.js";
 import {radians} from "../math.js";
 import {maybeFrameAnchor, maybeNumberChannel, maybeTuple, keyword, identity} from "../options.js";
@@ -9,11 +14,6 @@ import {
   applyIndirectStyles,
   applyTransform
 } from "../style.js";
-
-/**
- * @typedef {import("../types.js").Data} Data
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- */
 
 const defaults = {
   ariaLabel: "vector",

--- a/src/plot.js
+++ b/src/plot.js
@@ -368,6 +368,9 @@ import {consumeWarnings, warn} from "./warnings.js";
  * const color = plot.scale("color"); // retrieve the color scale object
  * console.log(color.range); // inspect the color scale’s range, ["red", "blue"]
  * ```
+ *
+ * @param {import("../types.js").PlotOptions} options
+ * @returns {Element}
  */
 export function plot(options = {}) {
   const {facet, style, caption, ariaLabel, ariaDescription} = options;
@@ -713,6 +716,9 @@ export class Mark {
  * [box mark
  * implementation](https://github.com/observablehq/plot/blob/main/src/marks/box.js)
  * for an example.
+ *
+ * @param {Mark[]} marks
+ * @returns {Mark}
  */
 export function marks(...marks) {
   marks.plot = Mark.prototype.plot;

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import("./types.js").PlotOptions | undefined} Options
+ * @typedef {import("./types.js").Chart | undefined} Chart
+ */
 import {cross, difference, groups, InternMap, select} from "d3";
 import {Axes, autoAxisTicks, autoScaleLabels} from "./axes.js";
 import {Channel, Channels, channelDomain, valueObject} from "./channel.js";
@@ -368,8 +372,8 @@ import {consumeWarnings, warn} from "./warnings.js";
  * const color = plot.scale("color"); // retrieve the color scale object
  * console.log(color.range); // inspect the color scale’s range, ["red", "blue"]
  * ```
- * @param {import("./types.js").PlotOptions} options
- * @returns {Element}
+ * @param {Options} options
+ * @returns {Chart}
  */
 export function plot(options = {}) {
   const {facet, style, caption, ariaLabel, ariaDescription} = options;

--- a/src/plot.js
+++ b/src/plot.js
@@ -716,7 +716,6 @@ export class Mark {
  * [box mark
  * implementation](https://github.com/observablehq/plot/blob/main/src/marks/box.js)
  * for an example.
- *
  * @param {Mark[]} marks
  * @returns {Mark}
  */

--- a/src/plot.js
+++ b/src/plot.js
@@ -368,7 +368,7 @@ import {consumeWarnings, warn} from "./warnings.js";
  * const color = plot.scale("color"); // retrieve the color scale object
  * console.log(color.range); // inspect the color scale’s range, ["red", "blue"]
  * ```
- * @param {import("../types.js").PlotOptions} options
+ * @param {import("./types.js").PlotOptions} options
  * @returns {Element}
  */
 export function plot(options = {}) {

--- a/src/plot.js
+++ b/src/plot.js
@@ -368,7 +368,6 @@ import {consumeWarnings, warn} from "./warnings.js";
  * const color = plot.scale("color"); // retrieve the color scale object
  * console.log(color.range); // inspect the color scale’s range, ["red", "blue"]
  * ```
- *
  * @param {import("../types.js").PlotOptions} options
  * @returns {Element}
  */

--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").StackOptions} StackOptions
+ */
+
 import {InternMap, cumsum, group, groupSort, greatest, max, min, rollup, sum} from "d3";
 import {ascendingDefined} from "../defined.js";
 import {field, column, maybeColumn, maybeZ, mid, range, valueof, maybeZero, one} from "../options.js";
@@ -12,6 +17,8 @@ import {basic} from "./basic.js";
  * index, *x1*, *x2* and *x* as the output channels.
  *
  * @link https://github.com/observablehq/plot/blob/main/README.md#stack
+ * @param {StackOptions & MarkOptions} stack
+ * @param {MarkOptions} options
  */
 export function stackX(stack = {}, options = {}) {
   if (arguments.length === 1) [stack, options] = mergeOptions(stack);
@@ -31,6 +38,8 @@ export function stackX(stack = {}, options = {}) {
  * used, for example, to draw a line at the left edge of each stacked area.
  *
  * @link https://github.com/observablehq/plot/blob/main/README.md#stack
+ * @param {StackOptions & MarkOptions} stack
+ * @param {MarkOptions} options
  */
 export function stackX1(stack = {}, options = {}) {
   if (arguments.length === 1) [stack, options] = mergeOptions(stack);
@@ -50,6 +59,8 @@ export function stackX1(stack = {}, options = {}) {
  * used, for example, to draw a line at the right edge of each stacked area.
  *
  * @link https://github.com/observablehq/plot/blob/main/README.md#stack
+ * @param {StackOptions & MarkOptions} stack
+ * @param {MarkOptions} options
  */
 export function stackX2(stack = {}, options = {}) {
   if (arguments.length === 1) [stack, options] = mergeOptions(stack);
@@ -72,6 +83,8 @@ export function stackX2(stack = {}, options = {}) {
  * the only argument, or as a separate *stack* options argument.
  *
  * @link https://github.com/observablehq/plot/blob/main/README.md#stack
+ * @param {StackOptions & MarkOptions} stack
+ * @param {MarkOptions} options
  */
 export function stackY(stack = {}, options = {}) {
   if (arguments.length === 1) [stack, options] = mergeOptions(stack);
@@ -91,6 +104,8 @@ export function stackY(stack = {}, options = {}) {
  * used, for example, to draw a line at the bottom of each stacked area.
  *
  * @link https://github.com/observablehq/plot/blob/main/README.md#stack
+ * @param {StackOptions & MarkOptions} stack
+ * @param {MarkOptions} options
  */
 export function stackY1(stack = {}, options = {}) {
   if (arguments.length === 1) [stack, options] = mergeOptions(stack);
@@ -110,6 +125,8 @@ export function stackY1(stack = {}, options = {}) {
  * used, for example, to draw a line at the top of each stacked area.
  *
  * @link https://github.com/observablehq/plot/blob/main/README.md#stack
+ * @param {StackOptions & MarkOptions} stack
+ * @param {MarkOptions} options
  */
 export function stackY2(stack = {}, options = {}) {
   if (arguments.length === 1) [stack, options] = mergeOptions(stack);

--- a/src/transforms/window.js
+++ b/src/transforms/window.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../types.js").MarkOptions} MarkOptions
  * @typedef {import("../types.js").WindowOptions} WindowOptions
+ * @typedef {WindowOptions & MarkOptions | undefined} Options
  */
 
 import {deviation, max, min, median, mode, variance} from "d3";
@@ -10,7 +11,7 @@ import {warn} from "../warnings.js";
 import {mapX, mapY} from "./map.js";
 
 /**
- * @param {WindowOptions & MarkOptions} windowOptions
+ * @param {Options} windowOptions
  * @param {MarkOptions} options
  */
 export function windowX(windowOptions = {}, options) {

--- a/src/transforms/window.js
+++ b/src/transforms/window.js
@@ -1,9 +1,18 @@
+/**
+ * @typedef {import("../types.js").MarkOptions} MarkOptions
+ * @typedef {import("../types.js").WindowOptions} WindowOptions
+ */
+
 import {deviation, max, min, median, mode, variance} from "d3";
 import {defined} from "../defined.js";
 import {percentile, take} from "../options.js";
 import {warn} from "../warnings.js";
 import {mapX, mapY} from "./map.js";
 
+/**
+ * @param {WindowOptions & MarkOptions} windowOptions
+ * @param {MarkOptions} options
+ */
 export function windowX(windowOptions = {}, options) {
   if (arguments.length === 1) options = windowOptions;
   return mapX(window(windowOptions), options);

--- a/src/transforms/window.js
+++ b/src/transforms/window.js
@@ -1,19 +1,9 @@
-/**
- * @typedef {import("../types.js").MarkOptions} MarkOptions
- * @typedef {import("../types.js").WindowOptions} WindowOptions
- * @typedef {WindowOptions & MarkOptions | undefined} Options
- */
-
 import {deviation, max, min, median, mode, variance} from "d3";
 import {defined} from "../defined.js";
 import {percentile, take} from "../options.js";
 import {warn} from "../warnings.js";
 import {mapX, mapY} from "./map.js";
 
-/**
- * @param {Options} windowOptions
- * @param {MarkOptions} options
- */
 export function windowX(windowOptions = {}, options) {
   if (arguments.length === 1) options = windowOptions;
   return mapX(window(windowOptions), options);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,178 +1,1018 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export type Row = Record<string, any>;
+/**
+ * Options
+ */
 
-export type Data = Row[];
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type ColorAccessor<T extends Datum, U extends Value = Value> = Accessor<T, U> | (string & {});
 
-export type Accessor = (d: any) => any;
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type pXX = `p${Digit}${Digit}` & {};
+type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
 
-export type Channel = string | Accessor;
+export type GetColumn = {transform: () => ValueArray; label?: string};
 
-export interface MarkOptions {
-  x?: Channel;
-  y?: Channel;
-  fill?: Channel;
-  fillOpacity?: Channel;
-  stroke?: Channel;
-  strokeOpacity?: Channel;
-  strokeWidth?: Channel;
-  opacity?: Channel;
-  title?: Channel;
-  href?: Channel;
-  ariaLabel?: Channel;
-}
+export type Accessor<T extends Datum, U extends Value = Value> =
+  | FieldNames<T>
+  | AccessorFunction<T, U>
+  | ValueArray
+  | TransformMethod;
 
-export interface ScaleOptions {
-  domain?: any[];
-  range?: any[];
-  type?:
-    | "time"
-    | "utc"
-    | "diverging"
-    | "diverging-sqrt"
-    | "diverging-pow"
-    | "diverging-log"
-    | "diverging-symlog"
-    | "categorical"
-    | "ordinal"
-    | "cyclical"
-    | "sequential"
-    | "linear"
-    | "sqrt"
-    | "threshold"
-    | "quantile"
-    | "quantize"
-    | "pow"
-    | "log"
-    | "symlog"
-    | "utc"
-    | "time"
-    | "point"
-    | "band"
-    | "identity";
-  unknown?: any;
-  reverse?: boolean;
-  interval?: any;
-  tickFormat?: string | ((d: any) => any);
-  base?: number;
-  exponent?: number;
-  clamp?: boolean;
-  nice?: boolean;
-  zero?: boolean;
-  percent?: boolean;
-  transform?: (t: any) => any;
-  inset?: number;
-  round?: boolean;
-  insetLeft?: number;
-  insetRight?: number;
-  insetTop?: number;
-  insetBottom?: number;
-  padding?: number;
-  align?: number;
-  paddingInner?: number;
-  paddingOuter?: number;
-  axis?: "top" | "bottom" | "left" | "right" | null;
-  ticks?: number;
-  tickSize?: number;
-  tickPadding?: number;
-  tickRotate?: number;
-  line?: boolean;
+export type AccessorValue<T extends Datum, U extends Value, V extends Accessor<T, U>> = V extends keyof T
+  ? T[V]
+  : V extends AccessorFunction<T, infer Val>
+  ? Val
+  : never;
+type AccessorFunction<T, U extends Value = Value> = (d: T, i: number) => U;
+
+export type TransformMethod<T extends Datum = Datum> = {
+  transform: (data: Data<T> | null | undefined) => ValueArray | Iterable<Value> | null | undefined;
   label?: string;
-  labelAnchor?: "top" | "right" | "bottom" | "left" | "center";
-  labelOffset?: number;
-  legend?: boolean;
-  fontVariant?: string;
-  ariaLabel?: string;
-  ariaDescription?: string;
-}
+};
 
-export interface ColorScaleOptions {
-  scheme?:
-    | "accent"
-    | "category10"
-    | "dark2"
-    | "paired"
-    | "pastel1"
-    | "pastel2"
-    | "set1"
-    | "set2"
-    | "set3"
-    | "tableau10"
-    | "brbg"
-    | "prgn"
-    | "piyg"
-    | "puor"
-    | "rdbu"
-    | "rdgy"
-    | "rdylbu"
-    | "rdylgn"
-    | "spectral"
-    | "burd"
-    | "buylrd"
-    | "blues"
-    | "greens"
-    | "greys"
-    | "oranges"
-    | "purples"
-    | "reds"
-    | "turbo"
-    | "viridis"
-    | "magma"
-    | "inferno"
-    | "plasma"
-    | "cividis"
-    | "cubehelix"
-    | "warm"
-    | "cool"
-    | "bugn"
-    | "bupu"
-    | "gnbu"
-    | "orrd"
-    | "pubu"
-    | "pubugn"
-    | "purd"
-    | "rdpu"
-    | "ylgn"
-    | "ylgnbu"
-    | "ylorbr"
-    | "ylorrd"
-    | "rainbow"
-    | "sinebow";
-  interpolate?: "number" | "rgb" | "hsl" | "hcl" | "lab" | ((t: number) => string);
-  pivot?: number;
-}
+/**
+ * Data
+ */
 
-export interface PlotOptions {
-  marginTop?: number;
-  marginRight?: number;
-  marginBottom?: number;
-  marginLeft?: number;
-  margin?: number;
-  width?: number;
-  height?: number;
-  marks?: any[];
-  style?: Record<string, string>;
-  caption?: string | Element;
+/**
+ * Values are associated to screen encodings (positions, colors…) via scales.
+ */
+export type Value = number | string | Date | boolean | null | undefined;
+
+/**
+ * A Row represents a data point with values attached to field names; typically,
+ * a row from a tabular dataset.
+ */
+export type Row = Record<string, Value>;
+
+/**
+ * A single Datum is often a Value, a Row, or an array of values; if a Row, possible field names
+ * can be inferred from its keys to define accessors; if an array, typical accessors are indices,
+ * and length, expressed as strings
+ */
+export type Datum = Row | Value | Value[];
+export type FieldNames<T> = T extends Row
+  ? keyof T
+  : T extends Value[]
+  ? // eslint-disable-next-line @typescript-eslint/ban-types
+    "length" | "0" | "1" | "2" | (string & {})
+  : never;
+
+/**
+ * The marks data; typically an array of Datum, but can also
+ * be defined as an iterable compatible with Array.from.
+ */
+export type Data<T extends Datum> = ArrayLike<T> | Iterable<T> | TypedArray;
+
+/**
+ * An array or typed array constructor, or any class that implements Array.from
+ */
+export type ArrayType = ArrayConstructor | TypedArrayConstructor;
+
+/**
+ * The data is then arrayified, and a range of indices is computed, serving as pointers
+ * into the columnar representation of each channel
+ */
+export type DataArray<T extends Datum> = T[] | TypedArray;
+
+/**
+ * A series is an array of indices, used to group data into classes (e.g., groups and facets)
+ */
+export type index = number; // integer
+export type Series = index[] | Uint32Array;
+export type Facets = Series[];
+
+export type NumericArray = number[] | TypedArray;
+export type ValueArray = NumericArray | Value[];
+
+/**
+ * Typed arrays are preserved through arrayify
+ */
+export type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Uint8ClampedArray
+  | Float32Array
+  | Float64Array;
+
+export type TypedArrayConstructor =
+  | Int8ArrayConstructor
+  | Uint8ArrayConstructor
+  | Int16ArrayConstructor
+  | Uint16ArrayConstructor
+  | Int32ArrayConstructor
+  | Uint32ArrayConstructor
+  | Uint8ClampedArrayConstructor
+  | Float32ArrayConstructor
+  | Float64ArrayConstructor;
+
+export type Constructor<T extends TypedArray> = T extends Int8Array
+  ? Int8ArrayConstructor
+  : T extends Uint8Array
+  ? Uint8ArrayConstructor
+  : T extends Int16Array
+  ? Int16ArrayConstructor
+  : T extends Int32Array
+  ? Int32ArrayConstructor
+  : T extends Uint32Array
+  ? Uint32ArrayConstructor
+  : T extends Uint8ClampedArray
+  ? Uint8ClampedArrayConstructor
+  : T extends Float32Array
+  ? Float32ArrayConstructor
+  : T extends Float64Array
+  ? Float64ArrayConstructor
+  : never;
+
+/**
+ * Plot API
+ * @link https://github.com/observablehq/plot/blob/main/README.md
+ */
+
+/**
+ * API Types
+ */
+type pixels = number;
+
+/**
+ * The data is then arrayified, and a range of indices is computed, serving as pointers
+ * into a the column representation of Plot.valueof
+ */
+
+/**
+ * Layout options (in pixels)
+ */
+type LayoutOptions = {
+  marginTop?: pixels; // the top margin
+  marginRight?: pixels; // the right margin
+  marginBottom?: pixels; // the bottom margin
+  marginLeft?: pixels; // the left margin
+  margin?: pixels; // shorthand for the four margins
+  width?: pixels; // the outer width of the plot (including margins)
+  height?: pixels; // the outer height of the plot (including margins)
+};
+
+/**
+ * Facet options
+ */
+type FacetOptions<T extends Datum> = {
+  facet?: {
+    data: Data<T>;
+    x?: Accessor<T>;
+    y?: Accessor<T>;
+    marginTop?: pixels; // the top margin
+    marginRight?: pixels; // the right margin
+    marginBottom?: pixels; // the bottom margin
+    marginLeft?: pixels; // the left margin
+    margin?: pixels; // shorthand for the four margins
+    grid?: boolean; // if true, draw grid lines for each facet
+    label?: null; // if null, disable default facet axis labels
+  };
+};
+
+/**
+ * Style options
+ */
+type PlotStyleOptions = {
+  style?: string | Partial<CSSStyleDeclaration>;
+};
+
+/**
+ * Scale options
+ */
+type ScaleOptions = any; // TODO
+type ScalesOptions = {
   x?: ScaleOptions;
   y?: ScaleOptions;
   r?: ScaleOptions;
-  color?: ScaleOptions & ColorScaleOptions;
+  color?: ScaleOptions;
   opacity?: ScaleOptions;
   length?: ScaleOptions;
   symbol?: ScaleOptions;
-  grid?: boolean;
-  facet?: FacetOptions;
+  fx?: ScaleOptions;
+  fy?: ScaleOptions;
+  inset?: pixels;
+  grid?: boolean; // shorthand for x.grid and y.grid
+};
+
+/**
+ * An instantiated mark
+ */
+export type InstantiatedMark<T extends Datum> = {
+  initialize: (data: Data<T>) => void;
+  z?: Accessor<T>; // copy the user option for error messages
+  clip?: "frame";
+  dx: number;
+  dy: number;
+  marker?: MaybeMarkerFunction;
+  markerStart?: MaybeMarkerFunction;
+  markerMid?: MaybeMarkerFunction;
+  markerEnd?: MaybeMarkerFunction;
+
+  // common styles, as constants
+  stroke?: string | null;
+  fill?: string | null;
+  fillOpacity?: number | null;
+  strokeWidth?: number | null;
+  strokeOpacity?: number | null;
+  strokeLinejoin?: string | null;
+  strokeLinecap?: string | null;
+  strokeMiterlimit?: number | null;
+  strokeDasharray?: string | null;
+  strokeDashoffset?: string | null;
+  target?: string | null;
+  ariaLabel?: string | null;
+  ariaDescription?: string | null;
+  ariaHidden?: "true" | "false";
+  opacity?: number | null;
+  mixBlendMode?: string | null;
+  paintOrder?: string | null;
+  pointerEvents?: string | null;
+  shapeRendering?: string | null;
+
+  // other styles, some of which are not supported by all marks
+  frameAnchor?: string;
+
+  // other properties
+  sort?: SortOption | null;
+};
+
+/**
+ * A mark
+ */
+type Mark<T extends Datum> = InstantiatedMark<T> | (() => SVGElement | null | undefined) | Mark<T>[];
+type MarksOptions<T extends Datum> = {marks?: Mark<T>[]};
+
+/**
+ * Other top-level options
+ */
+type TopLevelOptions = {
+  ariaLabel?: string | null;
+  ariaDescription?: string | null;
+  caption?: string | HTMLElement; // a caption
+  className?: string;
+  document?: Document; // the document used to create plot elements
+};
+
+/**
+ * Plot options
+ */
+export type PlotOptions<T extends Datum> = LayoutOptions &
+  FacetOptions<T> &
+  MarksOptions<T> &
+  PlotStyleOptions &
+  ScalesOptions &
+  TopLevelOptions;
+
+/**
+ * Legend options
+ */
+type LegendOptions = any; // TODO
+
+/**
+ * Plot returns a SVG or a FIGURE element, with additional properties
+ */
+export interface Chart extends HTMLElement {
+  scale: (
+    scaleName: "x" | "y" | "r" | "color" | "opacity" | "length" | "symbol" | "fx" | "fy"
+  ) => ScaleOptions | undefined;
+  legend: (scaleName: "color" | "opacity" | "symbol", legendOptions: LegendOptions) => HTMLElement | undefined;
 }
 
-export interface FacetOptions {
-  data: any;
-  x?: any;
-  y?: any;
-  marginTop?: number;
-  marginRight?: number;
-  marginBottom?: number;
-  marginLeft?: number;
-  margin?: number;
-  grid?: boolean;
+export type MaybeSymbol<T extends Datum> = Accessor<T> | SymbolName | SymbolObject | null | undefined;
+
+/**
+ * Mark channel options
+ */
+export type CommonChannelOptions<T extends Datum> = {
+  x?: Accessor<T> | number; // TODO: OptionsX
+  x1?: Accessor<T> | number;
+  x2?: Accessor<T> | number;
+  y?: Accessor<T> | number; // TODO: OptionsY
+  y1?: Accessor<T> | number;
+  y2?: Accessor<T> | number;
+  z?: Accessor<T>;
+  fill?: ColorAccessor<T> | null;
+  fillOpacity?: Accessor<T> | number | null;
+  r?: Accessor<T>; // TODO: OptionsR
+  stroke?: ColorAccessor<T> | null;
+  strokeOpacity?: Accessor<T> | number | null;
+  strokeWidth?: Accessor<T> | number | null;
+  symbol?: MaybeSymbol<T>;
+  opacity?: Accessor<T> | number | null;
+};
+
+/**
+ * Mark constant style options
+ */
+export type ConstantStyleOptions = {
+  ariaDescription?: string;
+  ariaHidden?: boolean;
+  target?: string;
+  strokeLinecap?: string;
+  strokeLinejoin?: string;
+  strokeMiterlimit?: pixels;
+  strokeDasharray?: pixels | string | pixels[];
+  strokeDashoffset?: string;
+  mixBlendMode?: string;
+  paintOrder?: string;
+  pointerEvents?: string;
+  shapeRendering?: string;
+};
+
+/**
+ * Default options for marks, strings or numbers
+ */
+export type DefaultOptions = {
+  ariaLabel?: string;
+  fill?: string;
+  fillOpacity?: number;
+  stroke?: string;
+  strokeOpacity?: number;
+  strokeWidth?: pixels;
+  strokeLinecap?: string;
+  strokeLinejoin?: string;
+  strokeMiterlimit?: pixels;
+  paintOrder?: string;
+};
+
+/**
+ * Channel styles
+ */
+export type ChannelStyles = {
+  ariaLabel?: ValueArray;
+  title?: ValueArray;
+  fill?: ValueArray;
+  fillOpacity?: ValueArray;
+  stroke?: ValueArray;
+  strokeOpacity?: ValueArray;
+  strokeWidth?: ValueArray;
+  opacity?: ValueArray;
+  href: ValueArray;
+  z?: ValueArray;
+};
+
+/**
+ * Inset options for marks
+ */
+type InsetOptions = {
+  inset?: pixels;
+  insetLeft?: pixels;
+  insetRight?: pixels;
+  insetTop?: pixels;
+  insetBottom?: pixels;
+};
+
+/**
+ * Interval options
+ * 
+If the interval option is specified, the binX transform is implicitly applied to the specified options. The reducer of the output y channel may be specified via the reduce option, which defaults to first. To default to zero instead of showing gaps in data, as when the observed value represents a quantity, use the sum reducer.
+
+Plot.lineY(observations, {x: "date", y: "temperature", interval: d3.utcDay})
+The interval option is recommended to “regularize” sampled data; for example, if your data represents timestamped temperature measurements and you expect one sample per day, use d3.utcDay as the interval.
+ * @link TODO: unclear where to link
+ * TODO: accept number or Date (for e.g., d3.utcYear)
+ */
+export type Interval = number | IntervalObject;
+export type IntervalObject = {
+  floor: (v: number) => number;
+  offset: (v: number) => number;
+  range: (lo: number, hi: number) => number[];
+};
+
+/**
+ * The Plot.normalizeX and Plot.normalizeY transforms normalize series values relative to the given basis. For example, if the series values are [y₀, y₁, y₂, …] and the first basis is used, the mapped series values would be [y₀ / y₀, y₁ / y₀, y₂ / y₀, …] as in an index chart. The basis option specifies how to normalize the series values. The following basis methods are supported:
+ *
+ * * first - the first value, as in an index chart; the default
+ * * last - the last value
+ * * min - the minimum value
+ * * max - the maximum value
+ * * mean - the mean value (average)
+ * * median - the median value
+ * * pXX - the percentile value, where XX is a number in [00,99]
+ * * sum - the sum of values
+ * * extent - the minimum is mapped to zero, and the maximum to one
+ * * deviation - each value is transformed by subtracting the mean and then dividing by the standard deviation
+ * * a function to be passed an array of values, returning the desired basis
+ */
+export type Basis =
+  | "first"
+  | "last"
+  | "min"
+  | "max"
+  | "median"
+  | "p50"
+  | "p95"
+  | pXX
+  | "sum"
+  | "extent"
+  | "deviation"
+  | BasisFunction;
+type BasisFunction = (V: ValueArray) => Value;
+
+/**
+ * Other Mark options
+ */
+type OtherMarkOptions<T extends Datum> = {
+  // the following are necessarily channels
+  title?: Accessor<T>;
+  href?: Accessor<T>;
+  ariaLabel?: Accessor<T>;
+  // filter & sort
+  filter?: Accessor<T>;
+  sort?: SortOption | null;
+  reverse?: boolean;
+  // include in facet
+  facet?: "auto" | "include" | "exclude" | boolean | null;
+  // interval
+  interval?: number | Interval;
+  // basis for the normalize transform
+  basis?: Basis;
+  // transform
+  transform?: TransformOption<T>;
+  initializer?: InitializerOption<T>;
+};
+
+/**
+ * Aggregation options for Series transforms (group, bin, sort…):
+ * * a string describing an aggregation (first, min, sum, count…)
+ * * a function - passed the array of values for each series
+ * * an object with a reduce method, an optionally a scope
+ * @link https://github.com/observablehq/plot/blob/main/README.md#group
+ */
+export type AggregationMethod =
+  | ((
+      | "first"
+      | "last"
+      | "count"
+      | "sum"
+      | "proportion"
+      | "proportion-facet"
+      | "min"
+      | "min-index"
+      | "max"
+      | "max-index"
+      | "mean"
+      | "median"
+      | "mode"
+      | "p25"
+      | "p95"
+      | pXX
+      | "deviation"
+      | "variance"
+      | AggregationFunction
+    ) & {reduce?: never}) // duck-typing in maybeReduce
+  | Aggregate;
+
+/**
+ * An object with a reduce method, and optionally a scope, for the group transform or the bin transform
+ *
+ * the reduce method is repeatedly passed three arguments: the index for each bin (an array
+ * of integers), the input channel’s array of values, and the extent of the bin (an object
+ * {x1, x2, y1, y2}); it must then return the corresponding aggregate value for the bin.
+ * If the reducer object’s scope is “data”, then the reduce method is first invoked for the
+ * full data; the return value of the reduce method is then made available as a third argument
+ * (making the extent the fourth argument). Similarly if the scope is “facet”, then the reduce
+ * method is invoked for each facet, and the resulting reduce value is made available while
+ * reducing the facet’s bins. (This optional scope is used by the proportion and proportion-facet
+ * reducers.)
+ * @link https://github.com/observablehq/plot/blob/main/README.md#bin
+ * @link https://github.com/observablehq/plot/blob/main/README.md#group
+ */
+
+export type Aggregate = {
   label?: string;
+  reduce: (
+    I: Series,
+    X: ValueArray,
+    contextOrExtent?: Value | BinExtent | null,
+    extent?: BinExtent
+  ) => Value | null | undefined;
+  scope?: "data" | "facet";
+};
+
+/**
+ * The extent of a bin, for extent-based reducers
+ */
+export type BinExtent = {
+  x1?: number | Date;
+  x2?: number | Date;
+  y1?: number | Date;
+  y2?: number | Date;
+};
+
+type AggregationFunction = (values?: ValueArray, extent?: BinExtent) => Value;
+
+/**
+ * The sort option, inside a mark, might sort the mark's data if specified as a string or a function.
+ * If specified as an object, it will sort the domain of an associated scale
+ * @link https://github.com/observablehq/plot/blob/main/README.md#transforms
+ * @link https://github.com/observablehq/plot/blob/main/README.md#sort-options
+ */
+export type SortOption = (
+  | // Field, accessor or comparator
+  ((string | ((d: Datum) => Datum) | Comparator) & {value?: never; channel?: never}) // duck-typing in isDomainSort
+  | ChannelSortOption
+  | DomainSortOption
+) & {transform?: never}; // duck-typing in isOptions
+
+/**
+ * A comparator function returns a number to sort two values
+ */
+export type Comparator = (a: Datum, b: Datum) => number;
+
+type SortChannel = "x" | "y" | "r" | "data";
+
+type ChannelSortOption = {
+  channel: SortChannel;
+  order?: "descending" | "ascending" | "none"; // TODO
+  value?: never; // duck-typing in isDomainSort
+};
+
+export type DomainSortOption = {
+  x?: SortChannel | SortValue;
+  y?: SortChannel | SortValue;
+  fx?: SortChannel | SortValue;
+  fy?: SortChannel | SortValue;
+  color?: SortChannel | SortValue;
+  reduce?: AggregationMethod;
+  reverse?: boolean;
+  limit?: number | [number, number];
+  channel?: never; // duck-typing in isDomainSort
+  value?: never; // duck-typing in isDomainSort
+};
+type SortValue = {
+  value: SortChannel;
+  reduce?: AggregationMethod;
+  reverse?: boolean;
+  limit?: number | [number, number];
+};
+
+/**
+ * Definition for the transform and initializer functions.
+ */
+export type TransformFunction<T extends Datum> = (
+  this: InstantiatedMark<T>,
+  data: DataArray<T>,
+  facets: Series[]
+) => {data: DataArray<T>; facets: Series[]; channels?: never};
+
+/**
+ * Plot’s transforms provide a convenient mechanism for transforming data as part of a plot specification.
+ * @link https://github.com/observablehq/plot/blob/main/README.md#transforms
+ */
+export type TransformOption<T extends Datum> = TransformFunction<T> | null | undefined;
+
+/**
+ * Initializers can be used to transform and derive new channels prior to rendering. Unlike transforms which
+ * operate in abstract data space, initializers can operate in screen space such as pixel coordinates and colors.
+ * For example, initializers can modify a marks’ positions to avoid occlusion. Initializers are invoked *after*
+ * the initial scales are constructed and can modify the channels or derive new channels; these in turn may (or
+ * may not, as desired) be passed to scales.
+ * @link https://github.com/observablehq/plot/blob/main/README.md#initializers
+ */
+export type InitializerFunction<T extends Datum> = (
+  this: InstantiatedMark<T>,
+  data: DataArray<T>,
+  facets: Series[],
+  channels?: any,
+  scales?: any,
+  dimensions?: Dimensions
+) => {data: DataArray<T>; facets: Series[]; channels?: any};
+export type InitializerOption<T extends Datum> = InitializerFunction<T> | TransformOption<T>; // TODO
+
+/**
+ * The bin transform’s value option
+ *
+ * To control how the quantitative dimensions x and y are divided into bins,
+ * the following options are supported:
+ * * thresholds - the threshold values; see below
+ * * interval - an alternative method of specifying thresholds
+ * * domain - values outside the domain will be omitted
+ * * cumulative - if positive, each bin will contain all lesser bins
+ *
+ * These options may be specified either on the options or outputs object. If the domain option is not specified, it defaults to the minimum and maximum of the corresponding dimension (x or y), possibly niced to match the threshold interval to ensure that the first and last bin have the same width as other bins. If cumulative is negative (-1 by convention), each bin will contain all greater bins rather than all lesser bins, representing the complementary cumulative distribution.
+ *
+ * To pass separate binning options for x and y, the x and y input channels can be specified as an object with the options above and a value option to specify the input channel values.
+ *
+ * The thresholds option may be specified as a named method or a variety of other ways:
+ *
+ * * auto (default) - Scott’s rule, capped at 200
+ * * freedman-diaconis - the Freedman–Diaconis rule
+ * * scott - Scott’s normal reference rule
+ * * sturges - Sturges’ formula
+ * * a count (hint) representing the desired number of bins
+ * * an array of n threshold values for n + 1 bins
+ * * an interval or time interval (for temporal binning; see below)
+ * * a function that returns an array, count, or time interval
+ *
+ * If the thresholds option is specified as a function, it is passed three arguments: the array of input values, the domain minimum, and the domain maximum. If a number, d3.ticks or d3.utcTicks is used to choose suitable nice thresholds. If an interval, it must expose an interval.floor(value), interval.ceil(value), interval.offset(value), and interval.range(start, stop) methods. If the interval is a time interval such as d3.utcDay, or if the thresholds are specified as an array of dates, then the binned values are implicitly coerced to dates. Time intervals are intervals that are also functions that return a Date instance when called with no arguments.
+ *
+ * If the interval option is used instead of thresholds, it may be either an interval, a time interval, or a number. If a number n, threshold values are consecutive multiples of n that span the domain; otherwise, the interval option is equivalent to the thresholds option. When the thresholds are specified as an interval, and the default domain is used, the domain will automatically be extended to start and end to align with the interval.
+ *
+ * @link https://github.com/observablehq/plot/blob/main/README.md#bin
+ */
+export type BinValue<T extends Datum> = {
+  value?: Accessor<T>;
+  thresholds?: any;
+  interval?: number | IntervalObject;
+  domain?: number[] | ((V: ValueArray) => ValueArray);
+  cumulative?: number | boolean;
+  //        order?: "descending" | "ascending" | Comparator;
+  //        reverse?: boolean;
+};
+
+/**
+ * The group transform's output options
+ */
+export type OutputOptions<T extends Datum> = Partial<{[P in keyof CommonChannelOptions<T>]: AggregationMethod}> & {
+  data?: any; // TODO: this option is not tested in any example, and not documented (https://github.com/observablehq/plot/pull/272)
+  title?: AggregationMethod;
+  href?: AggregationMethod;
+  filter?: AggregationMethod | null;
+  sort?: AggregationMethod;
+  reverse?: boolean;
+  interval?: number | Interval;
+} & BinOptions<T>;
+
+export type Reducer<T extends Datum> = {
+  name?: keyof OutputOptions<T>;
+  output: GetColumn;
+  initialize: (data: DataArray<T>) => void;
+  scope: (scope: Aggregate["scope"], I?: Series) => void;
+  reduce: (I: Series, extent?: BinExtent) => ValueArray;
+  label?: string;
+};
+
+/**
+ * The shuffle transform’s seed option
+ * @link https://github.com/observablehq/plot/blob/main/README.md#plotshuffleoptions
+ */
+export type ShuffleOptions = {
+  seed?: null | number;
+};
+
+/**
+ * Map methods for Plot.map, Plot.mapX, Plot.mapY
+ * * cumsum - a cumulative sum
+ * * rank - the rank of each value in the sorted array
+ * * quantile - the rank, normalized between 0 and 1
+ * * a function to be passed an array of values, returning new values
+ * * an object that implements the map method
+ */
+export type MapMethods = "cumsum" | "rank" | "quantile" | ((S: ValueArray) => ValueArray) | MapMethod; // duck-typing in maybeMap
+
+export type MapMethod = {map: (I: Series, S: ValueArray, T: ValueArray) => void};
+
+/**
+ * Selects the points of each series selected by the selector, which can be specified
+ * either as a function which receives as input the index of the series, the shorthand
+ * “first” or “last”, or as a {key: value} object with exactly one key being the name
+ * of a channel and the value being a function which receives as input the index of the
+ * series and the channel values. The value may alternatively be specified as the
+ * shorthand “min” and “max” which respectively select the minimum and maximum points
+ * for the specified channel.
+ * @link https://github.com/observablehq/plot/blob/main/README.md#plotselectselector-options
+ */
+export type Selector = ((I: Series) => Series) | "first" | "last" | Record<string, SelectorFunction>;
+export type SelectorFunction = "min" | "max" | ((I: Series, X: ValueArray) => Series);
+
+/**
+ * Stack options
+ * @link https://github.com/observablehq/plot/blob/main/README.md#stack
+ */
+type StackOptions = {offset?: Offset; order?: StackOrder; reverse?: boolean};
+
+/**
+ * Stack order options:
+ * The following order methods are supported:
+ *
+ * * null - input order (default)
+ * * value - ascending value order (or descending with reverse)
+ * * sum - order series by their total value
+ * * appearance - order series by the position of their maximum value
+ * * inside-out - order the earliest-appearing series on the inside
+ * * a named field or function of data - order data by priority
+ * * an array of z values
+ * @link https://github.com/observablehq/plot/blob/main/README.md#stack
+ */
+export type StackOrder =
+  | null
+  | "value"
+  | "sum"
+  | "appearance"
+  | "inside-out"
+  | string
+  | ((d: Datum) => Value)
+  | ValueArray;
+
+/**
+ * Stack offset options
+ *
+ * After all values have been stacked from zero, an optional offset can be applied to translate or scale the stacks. The following offset methods are supported:
+ *
+ * * null - a zero baseline (default)
+ * * expand (or normalize) - rescale each stack to fill [0, 1]
+ * * center (or silhouette) - align the centers of all stacks
+ * * wiggle - translate stacks to minimize apparent movement
+ * * a function to be passed a nested index, and start, end, and z values
+ *
+ * If a given stack has zero total value, the expand offset will not adjust the stack’s position. Both the center and wiggle offsets ensure that the lowest element across stacks starts at zero for better default axes. The wiggle offset is recommended for streamgraphs, and if used, changes the default order to inside-out; see Byron & Wattenberg.
+ *
+ * If the offset is specified as a function, it will receive four arguments: an index of stacks nested by facet and then stack, an array of start values, an array of end values, and an array of z values. For stackX, the start and end values correspond to x1 and x2, while for stackY, the start and end values correspond to y1 and y2. The offset function is then responsible for mutating the arrays of start and end values, such as by subtracting a common offset for each of the indices that pertain to the same stack.
+ */
+type Offset = null | "expand" | "center" | "wiggle" | OffsetFunction;
+export type OffsetFunction = (stacks: Series[][], Y1: Float64Array, Y2: Float64Array, Z?: ValueArray | null) => void;
+
+/**
+ * Window options
+ *
+ * The Plot.windowX and Plot.windowY transforms compute a moving window around each data point and then derive a summary statistic from values in the current window, say to compute rolling averages, rolling minimums, or rolling maximums. These transforms also take additional options:
+ *
+ * * k - the window size (the number of elements in the window)
+ * * anchor - how to align the window: start, middle, or end
+ * * reduce - the aggregation method (window reducer)
+ * * strict - if true, output undefined if any window value is undefined; defaults to false
+ *
+ * If the strict option is true, the output start values or end values or both (depending on the anchor) of each series may be undefined since there are not enough elements to create a window of size k; output values may also be undefined if some of the input values in the corresponding window are undefined. If the strict option is false (the default), the window will be automatically truncated as needed, and undefined input values are ignored. For example, if k is 24 and anchor is middle, then the initial 11 values have effective window sizes of 13, 14, 15, … 23, and likewise the last 12 values have effective window sizes of 23, 22, 21, … 12. Values computed with a truncated window may be noisy; if you would prefer to not show this data, set the strict option to true.
+ *
+ * The following window reducers are supported:
+ *
+ * * min - the minimum
+ * * max - the maximum
+ * * mean - the mean (average)
+ * * median - the median
+ * * mode - the mode (most common occurrence)
+ * * pXX - the percentile value, where XX is a number in [00,99]
+ * * sum - the sum of values
+ * * deviation - the standard deviation
+ * * variance - the variance per Welford’s algorithm
+ * * difference - the difference between the last and first window value
+ * * ratio - the ratio of the last and first window value
+ * * first - the first value
+ * * last - the last value
+ * * a function to be passed an array of k values
+ *
+ * @link https://github.com/observablehq/plot/blob/main/README.md#plotwindowk
+ */
+export type WindowOptions = {
+  k?: number;
+  anchor?: "start" | "middle" | "end";
+  reduce?:
+    | "min"
+    | "max"
+    | "mean"
+    | "median"
+    | "mode"
+    | "p25"
+    | "p95"
+    | pXX
+    | "sum"
+    | "deviation"
+    | "variance"
+    | "difference"
+    | "ratio"
+    | "first"
+    | "last"
+    | ((values: ValueArray) => Value);
+  strict?: boolean;
+  shift?: "deprecated";
+};
+
+/**
+ * The bin options can be specified as part of the inputs or of the outputs
+ */
+export type BinOptions<T extends Datum> = {
+  value?: Accessor<T>;
+  cumulative?: boolean;
+  domain?: number[];
+  thresholds?: number | number[];
+  interval?: number | IntervalObject;
+};
+
+/**
+ * Mark options (as passed by the user or returned by a transform)
+ */
+export type MarkOptions<T extends Datum> = CommonChannelOptions<T> &
+  ConstantStyleOptions &
+  InsetOptions &
+  BinOptions<T> &
+  StackOptions &
+  WindowOptions &
+  OtherMarkOptions<T>;
+export type LineOptions<T extends Datum> = MarkOptions<T> & MarkerOptions;
+// export type RectOptions = MarkOptions & InsetOptions; // TODO: only add inset options where they are meaningful (bars, rects, etc)
+
+/**
+ * The scales passed to a mark's render function
+ */
+export type Scales = {
+  x?: Scale;
+  y?: Scale;
+  r?: Scale;
+  length?: Scale;
+  opacity?: Scale;
+};
+
+type Scale = any; // TODO
+
+/**
+ * The dimensions passed to a mark's render function
+ */
+export type Dimensions = {
+  width: pixels;
+  height: pixels;
+  marginLeft: pixels;
+  marginRight: pixels;
+  marginTop: pixels;
+  marginBottom: pixels;
+};
+
+/**
+ * A marker defines a graphic drawn on vertices of a delaunay, line or a link mark
+ * @link https://github.com/observablehq/plot/blob/main/README.md#markers
+ */
+export type MarkerOption =
+  | "none"
+  | "arrow"
+  | "dot"
+  | "circle"
+  | "circle-stroke"
+  | MarkerFunction
+  | boolean
+  | null
+  | undefined;
+export type MarkerOptions = {
+  marker?: MarkerOption;
+  markerStart?: MarkerOption;
+  markerMid?: MarkerOption;
+  markerEnd?: MarkerOption;
+};
+export type MarkerFunction = (color: string, document: Context["document"]) => SVGElement;
+type MaybeMarkerFunction = MarkerFunction | null;
+
+/**
+ * Ordinal color schemes
+ */
+export type OrdinalSchemes =
+  | "accent"
+  | "category10"
+  | "dark2"
+  | "paired"
+  | "pastel1"
+  | "pastel2"
+  | "set1"
+  | "set2"
+  | "set3"
+  | "tableau10"
+  | "brbg"
+  | "prgn"
+  | "piyg"
+  | "puor"
+  | "rdbu"
+  | "rdgy"
+  | "rdylbu"
+  | "rdylgn"
+  | "spectral"
+  | "burd"
+  | "buylrd"
+  | "blues"
+  | "greens"
+  | "greys"
+  | "oranges"
+  | "purples"
+  | "reds"
+  | "turbo"
+  | "viridis"
+  | "magma"
+  | "inferno"
+  | "plasma"
+  | "cividis"
+  | "cubehelix"
+  | "warm"
+  | "cool"
+  | "bugn"
+  | "bupu"
+  | "gnbu"
+  | "orrd"
+  | "pubu"
+  | "pubugn"
+  | "purd"
+  | "rdpu"
+  | "ylgn"
+  | "ylgnbu"
+  | "ylorbr"
+  | "ylorrd"
+  | "rainbow"
+  | "sinebow";
+
+/**
+ * Quantitative color schemes
+ */
+export type QuantitativeSchemes = DivergingSchemes | SequentialSchemes | CyclicalSchemes;
+
+/**
+ * Diverging color schemes
+ */
+type DivergingSchemes =
+  | "brbg"
+  | "prgn"
+  | "piyg"
+  | "puor"
+  | "rdbu"
+  | "rdgy"
+  | "rdylbu"
+  | "rdylgn"
+  | "spectral"
+  | "burd"
+  | "buylrd";
+
+/**
+ * Sequential color schemes
+ */
+type SequentialSchemes =
+  | "blues"
+  | "greens"
+  | "greys"
+  | "purples"
+  | "reds"
+  | "oranges"
+  | "turbo"
+  | "viridis"
+  | "magma"
+  | "inferno"
+  | "plasma"
+  | "cividis"
+  | "cubehelix"
+  | "warm"
+  | "cool"
+  | "bugn"
+  | "bupu"
+  | "gnbu"
+  | "orrd"
+  | "pubugn"
+  | "pubu"
+  | "purd"
+  | "rdpu"
+  | "ylgnbu"
+  | "ylgn"
+  | "ylorbr"
+  | "ylorrd";
+
+/**
+ * Cyclical color schemes
+ */
+type CyclicalSchemes = "rainbow" | "sinebow";
+
+/**
+ * The context in which Plot operates
+ */
+export interface Context {
+  document: Document;
 }
+
+/**
+ * Know symbols for dots
+ * @link https://github.com/observablehq/plot/blob/main/README.md#dot
+ */
+export type SymbolName =
+  | "asterisk"
+  | "circle"
+  | "cross"
+  | "diamond"
+  | "diamond2"
+  | "hexagon"
+  | "plus"
+  | "square"
+  | "square2"
+  | "star"
+  | "times"
+  | "triangle"
+  | "triangle2"
+  | "wye";
+
+/**
+ * A symbol object with a draw function
+ * @link https://github.com/d3/d3-shape/blob/main/README.md#custom-symbol-types
+ */
+export type SymbolObject = {draw: (context: CanvasPath, size: number) => void};
+
+/**
+ * A restrictive definition of D3 selections
+ */
+export type Selection = {
+  append: (name: string) => Selection;
+  attr: (name: string, value: any) => Selection;
+  call: (callback: (selection: Selection, ...args: any[]) => void, ...args: any[]) => Selection;
+  each: (callback: (d: any) => void) => Selection;
+  filter: (filter: (d: any, i: number) => boolean) => Selection;
+  property: (name: string, value: any) => Selection;
+  style: (name: string, value: any) => Selection;
+  text: (value: any) => Selection;
+  [Symbol.iterator]: () => IterableIterator<SVGElement | HTMLElement>;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ type DataArray<T extends Datum = Datum> = T[] | TypedArray;
  */
 type index = number; // integer
 type Series = index[] | Uint32Array;
-type Facets = Series[];
+// type Facets = Series[];
 
 type NumericArray = number[] | TypedArray;
 type ValueArray = NumericArray | Value[];
@@ -832,8 +832,6 @@ type BinOptions = {
  */
 export type MarkOptions = CommonChannelOptions & ConstantStyleOptions & OtherMarkOptions;
 
-type LineOptions = MarkOptions & MarkerOptions;
-
 /**
  * The scales passed to a mark's render function
  */
@@ -864,7 +862,7 @@ type Dimensions = {
  * @link https://github.com/observablehq/plot/blob/main/README.md#markers
  */
 type MarkerOption = "none" | "arrow" | "dot" | "circle" | "circle-stroke" | MarkerFunction | boolean | null | undefined;
-type MarkerOptions = {
+export type MarkerOptions = {
   marker?: MarkerOption;
   markerStart?: MarkerOption;
   markerMid?: MarkerOption;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,178 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type Row = Record<string, any>;
+
+export type Data = Row[];
+
+export type Accessor = (d: any) => any;
+
+export type Channel = string | Accessor;
+
+export interface MarkOptions {
+  x?: Channel;
+  y?: Channel;
+  fill?: Channel;
+  fillOpacity?: Channel;
+  stroke?: Channel;
+  strokeOpacity?: Channel;
+  strokeWidth?: Channel;
+  opacity?: Channel;
+  title?: Channel;
+  href?: Channel;
+  ariaLabel?: Channel;
+}
+
+export interface ScaleOptions {
+  domain?: any[];
+  range?: any[];
+  type?:
+    | "time"
+    | "utc"
+    | "diverging"
+    | "diverging-sqrt"
+    | "diverging-pow"
+    | "diverging-log"
+    | "diverging-symlog"
+    | "categorical"
+    | "ordinal"
+    | "cyclical"
+    | "sequential"
+    | "linear"
+    | "sqrt"
+    | "threshold"
+    | "quantile"
+    | "quantize"
+    | "pow"
+    | "log"
+    | "symlog"
+    | "utc"
+    | "time"
+    | "point"
+    | "band"
+    | "identity";
+  unknown?: any;
+  reverse?: boolean;
+  interval?: any;
+  tickFormat?: string | ((d: any) => any);
+  base?: number;
+  exponent?: number;
+  clamp?: boolean;
+  nice?: boolean;
+  zero?: boolean;
+  percent?: boolean;
+  transform?: (t: any) => any;
+  inset?: number;
+  round?: boolean;
+  insetLeft?: number;
+  insetRight?: number;
+  insetTop?: number;
+  insetBottom?: number;
+  padding?: number;
+  align?: number;
+  paddingInner?: number;
+  paddingOuter?: number;
+  axis?: "top" | "bottom" | "left" | "right" | null;
+  ticks?: number;
+  tickSize?: number;
+  tickPadding?: number;
+  tickRotate?: number;
+  line?: boolean;
+  label?: string;
+  labelAnchor?: "top" | "right" | "bottom" | "left" | "center";
+  labelOffset?: number;
+  legend?: boolean;
+  fontVariant?: string;
+  ariaLabel?: string;
+  ariaDescription?: string;
+}
+
+export interface ColorScaleOptions {
+  scheme?:
+    | "accent"
+    | "category10"
+    | "dark2"
+    | "paired"
+    | "pastel1"
+    | "pastel2"
+    | "set1"
+    | "set2"
+    | "set3"
+    | "tableau10"
+    | "brbg"
+    | "prgn"
+    | "piyg"
+    | "puor"
+    | "rdbu"
+    | "rdgy"
+    | "rdylbu"
+    | "rdylgn"
+    | "spectral"
+    | "burd"
+    | "buylrd"
+    | "blues"
+    | "greens"
+    | "greys"
+    | "oranges"
+    | "purples"
+    | "reds"
+    | "turbo"
+    | "viridis"
+    | "magma"
+    | "inferno"
+    | "plasma"
+    | "cividis"
+    | "cubehelix"
+    | "warm"
+    | "cool"
+    | "bugn"
+    | "bupu"
+    | "gnbu"
+    | "orrd"
+    | "pubu"
+    | "pubugn"
+    | "purd"
+    | "rdpu"
+    | "ylgn"
+    | "ylgnbu"
+    | "ylorbr"
+    | "ylorrd"
+    | "rainbow"
+    | "sinebow";
+  interpolate?: "number" | "rgb" | "hsl" | "hcl" | "lab" | ((t: number) => string);
+  pivot?: number;
+}
+
+export interface PlotOptions {
+  marginTop?: number;
+  marginRight?: number;
+  marginBottom?: number;
+  marginLeft?: number;
+  margin?: number;
+  width?: number;
+  height?: number;
+  marks?: any[];
+  style?: Record<string, string>;
+  caption?: string | Element;
+  x?: ScaleOptions;
+  y?: ScaleOptions;
+  r?: ScaleOptions;
+  color?: ScaleOptions & ColorScaleOptions;
+  opacity?: ScaleOptions;
+  length?: ScaleOptions;
+  symbol?: ScaleOptions;
+  grid?: boolean;
+  facet?: FacetOptions;
+}
+
+export interface FacetOptions {
+  data: any;
+  x?: any;
+  y?: any;
+  marginTop?: number;
+  marginRight?: number;
+  marginBottom?: number;
+  marginLeft?: number;
+  margin?: number;
+  grid?: boolean;
+  label?: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,12 +319,15 @@ type CommonChannelOptions = {
   z?: Accessor;
   fill?: ColorAccessor | null;
   fillOpacity?: Accessor | number | null;
-  r?: Accessor; // TODO: OptionsR
   stroke?: ColorAccessor | null;
   strokeOpacity?: Accessor | number | null;
   strokeWidth?: Accessor | number | null;
-  symbol?: MaybeSymbol;
   opacity?: Accessor | number | null;
+};
+
+export type DotOptions = {
+  r?: Accessor | number;
+  symbol?: MaybeSymbol;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,9 +5,6 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-type ColorAccessor = Channel | (string & {});
-
-// eslint-disable-next-line @typescript-eslint/ban-types
 type pXX = string & {}; // p00 to p99
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -306,9 +303,9 @@ type ChannelOptions = {
   y1?: Channel;
   y2?: Channel;
   z?: Channel;
-  fill?: ColorAccessor;
+  fill?: Channel;
   fillOpacity?: Channel;
-  stroke?: ColorAccessor;
+  stroke?: Channel;
   strokeOpacity?: Channel;
   strokeWidth?: Channel;
   title?: Channel;
@@ -389,19 +386,7 @@ type IntervalObject = {
  * * deviation - each value is transformed by subtracting the mean and then dividing by the standard deviation
  * * a function to be passed an array of values, returning the desired basis
  */
-type Basis =
-  | "first"
-  | "last"
-  | "min"
-  | "max"
-  | "median"
-  | "p50"
-  | "p95"
-  | pXX
-  | "sum"
-  | "extent"
-  | "deviation"
-  | BasisFunction;
+type Basis = "first" | "last" | "min" | "max" | "median" | "p95" | pXX | "sum" | "extent" | "deviation" | BasisFunction;
 type BasisFunction = (V: ValueArray) => Value;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,12 +8,12 @@
 type ColorAccessor = Accessor | (string & {});
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-type pXX = `p${Digit}${Digit}` & {};
-type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+type pXX = string & {}; // p00 to p99
 
 type GetColumn = {transform: () => ValueArray; label?: string};
 
-type Accessor = string | AccessorFunction | ValueArray | TransformMethod;
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Accessor = AccessorFunction | ValueArray | TransformMethod | (string & {});
 
 type AccessorFunction = (d: any, i: number) => any;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -330,7 +330,7 @@ type CommonChannelOptions = {
 /**
  * Mark constant style options
  */
-type ConstantStyleOptions = {
+export type ConstantStyleOptions = {
   ariaDescription?: string;
   ariaHidden?: boolean;
   target?: string;
@@ -378,14 +378,22 @@ type ChannelStyles = {
 };
 
 /**
- * Inset options for marks
+ * Rect options for marks
  */
-type InsetOptions = {
+export type RectOptions = RadiusOptions & InsetOptionsX & InsetOptionsY;
+
+export type RadiusOptions = {rx?: number; ry?: number};
+
+export type InsetOptionsX = {
+  inset?: pixels;
+  insetTop?: pixels;
+  insetBottom?: pixels;
+};
+
+export type InsetOptionsY = {
   inset?: pixels;
   insetLeft?: pixels;
   insetRight?: pixels;
-  insetTop?: pixels;
-  insetBottom?: pixels;
 };
 
 /**
@@ -709,6 +717,18 @@ type SelectorFunction = "min" | "max" | ((I: Series, X: ValueArray) => Series);
 export type StackOptions = {offset?: Offset; order?: StackOrder; reverse?: boolean};
 
 /**
+ * Arrow options
+ */
+export type ArrowOptions = {
+  bend?: number | boolean;
+  headAngle?: number;
+  inset?: number;
+  insetStart?: number;
+  insetEnd?: number;
+  length?: number;
+};
+
+/**
  * Stack order options:
  * The following order methods are supported:
  *
@@ -810,9 +830,9 @@ type BinOptions = {
 /**
  * Mark options (as passed by the user or returned by a transform)
  */
-export type MarkOptions = CommonChannelOptions & ConstantStyleOptions & InsetOptions & OtherMarkOptions;
+export type MarkOptions = CommonChannelOptions & ConstantStyleOptions & OtherMarkOptions;
+
 type LineOptions = MarkOptions & MarkerOptions;
-// type RectOptions = MarkOptions & InsetOptions; // TODO: only add inset options where they are meaningful (bars, rects, etc)
 
 /**
  * The scales passed to a mark's render function

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,28 +5,19 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type ColorAccessor<T extends Datum, U extends Value = Value> = Accessor<T, U> | (string & {});
+type ColorAccessor = Accessor | (string & {});
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type pXX = `p${Digit}${Digit}` & {};
+type pXX = `p${Digit}${Digit}` & {};
 type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
 
-export type GetColumn = {transform: () => ValueArray; label?: string};
+type GetColumn = {transform: () => ValueArray; label?: string};
 
-export type Accessor<T extends Datum, U extends Value = Value> =
-  | FieldNames<T>
-  | AccessorFunction<T, U>
-  | ValueArray
-  | TransformMethod;
+type Accessor = string | AccessorFunction | ValueArray | TransformMethod;
 
-export type AccessorValue<T extends Datum, U extends Value, V extends Accessor<T, U>> = V extends keyof T
-  ? T[V]
-  : V extends AccessorFunction<T, infer Val>
-  ? Val
-  : never;
-type AccessorFunction<T, U extends Value = Value> = (d: T, i: number) => U;
+type AccessorFunction = (d: any, i: number) => any;
 
-export type TransformMethod<T extends Datum = Datum> = {
+type TransformMethod<T extends Datum = Datum> = {
   transform: (data: Data<T> | null | undefined) => ValueArray | Iterable<Value> | null | undefined;
   label?: string;
 };
@@ -38,58 +29,47 @@ export type TransformMethod<T extends Datum = Datum> = {
 /**
  * Values are associated to screen encodings (positions, colors…) via scales.
  */
-export type Value = number | string | Date | boolean | null | undefined;
+type Value = number | string | Date | boolean | null | undefined;
 
 /**
  * A Row represents a data point with values attached to field names; typically,
  * a row from a tabular dataset.
  */
-export type Row = Record<string, Value>;
+type Row = Record<string, Value>;
 
 /**
  * A single Datum is often a Value, a Row, or an array of values; if a Row, possible field names
  * can be inferred from its keys to define accessors; if an array, typical accessors are indices,
  * and length, expressed as strings
  */
-export type Datum = Row | Value | Value[];
-export type FieldNames<T> = T extends Row
-  ? keyof T
-  : T extends Value[]
-  ? // eslint-disable-next-line @typescript-eslint/ban-types
-    "length" | "0" | "1" | "2" | (string & {})
-  : never;
+type Datum = Row | Value | Value[];
 
 /**
  * The marks data; typically an array of Datum, but can also
  * be defined as an iterable compatible with Array.from.
  */
-export type Data<T extends Datum> = ArrayLike<T> | Iterable<T> | TypedArray;
-
-/**
- * An array or typed array constructor, or any class that implements Array.from
- */
-export type ArrayType = ArrayConstructor | TypedArrayConstructor;
+type Data<T extends Datum> = ArrayLike<T> | Iterable<T> | TypedArray;
 
 /**
  * The data is then arrayified, and a range of indices is computed, serving as pointers
  * into the columnar representation of each channel
  */
-export type DataArray<T extends Datum> = T[] | TypedArray;
+type DataArray<T extends Datum = Datum> = T[] | TypedArray;
 
 /**
  * A series is an array of indices, used to group data into classes (e.g., groups and facets)
  */
-export type index = number; // integer
-export type Series = index[] | Uint32Array;
-export type Facets = Series[];
+type index = number; // integer
+type Series = index[] | Uint32Array;
+type Facets = Series[];
 
-export type NumericArray = number[] | TypedArray;
-export type ValueArray = NumericArray | Value[];
+type NumericArray = number[] | TypedArray;
+type ValueArray = NumericArray | Value[];
 
 /**
  * Typed arrays are preserved through arrayify
  */
-export type TypedArray =
+type TypedArray =
   | Int8Array
   | Uint8Array
   | Int16Array
@@ -99,35 +79,6 @@ export type TypedArray =
   | Uint8ClampedArray
   | Float32Array
   | Float64Array;
-
-export type TypedArrayConstructor =
-  | Int8ArrayConstructor
-  | Uint8ArrayConstructor
-  | Int16ArrayConstructor
-  | Uint16ArrayConstructor
-  | Int32ArrayConstructor
-  | Uint32ArrayConstructor
-  | Uint8ClampedArrayConstructor
-  | Float32ArrayConstructor
-  | Float64ArrayConstructor;
-
-export type Constructor<T extends TypedArray> = T extends Int8Array
-  ? Int8ArrayConstructor
-  : T extends Uint8Array
-  ? Uint8ArrayConstructor
-  : T extends Int16Array
-  ? Int16ArrayConstructor
-  : T extends Int32Array
-  ? Int32ArrayConstructor
-  : T extends Uint32Array
-  ? Uint32ArrayConstructor
-  : T extends Uint8ClampedArray
-  ? Uint8ClampedArrayConstructor
-  : T extends Float32Array
-  ? Float32ArrayConstructor
-  : T extends Float64Array
-  ? Float64ArrayConstructor
-  : never;
 
 /**
  * Plot API
@@ -160,11 +111,11 @@ type LayoutOptions = {
 /**
  * Facet options
  */
-type FacetOptions<T extends Datum> = {
+type FacetOptions = {
   facet?: {
-    data: Data<T>;
-    x?: Accessor<T>;
-    y?: Accessor<T>;
+    data: Data<Datum>;
+    x?: Accessor;
+    y?: Accessor;
     marginTop?: pixels; // the top margin
     marginRight?: pixels; // the right margin
     marginBottom?: pixels; // the bottom margin
@@ -185,12 +136,11 @@ type PlotStyleOptions = {
 /**
  * Scale options
  */
-type ScaleOptions = any; // TODO
 type ScalesOptions = {
   x?: ScaleOptions;
   y?: ScaleOptions;
   r?: ScaleOptions;
-  color?: ScaleOptions;
+  color?: ScaleOptions & ColorScaleOptions;
   opacity?: ScaleOptions;
   length?: ScaleOptions;
   symbol?: ScaleOptions;
@@ -200,12 +150,82 @@ type ScalesOptions = {
   grid?: boolean; // shorthand for x.grid and y.grid
 };
 
+export interface ScaleOptions {
+  domain?: any[];
+  range?: any[];
+  type?:
+    | "time"
+    | "utc"
+    | "diverging"
+    | "diverging-sqrt"
+    | "diverging-pow"
+    | "diverging-log"
+    | "diverging-symlog"
+    | "categorical"
+    | "ordinal"
+    | "cyclical"
+    | "sequential"
+    | "linear"
+    | "sqrt"
+    | "threshold"
+    | "quantile"
+    | "quantize"
+    | "pow"
+    | "log"
+    | "symlog"
+    | "utc"
+    | "time"
+    | "point"
+    | "band"
+    | "identity";
+  unknown?: any;
+  reverse?: boolean;
+  interval?: any;
+  tickFormat?: string | ((d: any) => any);
+  base?: number;
+  exponent?: number;
+  clamp?: boolean;
+  nice?: boolean;
+  zero?: boolean;
+  percent?: boolean;
+  transform?: (t: any) => any;
+  inset?: number;
+  round?: boolean;
+  insetLeft?: number;
+  insetRight?: number;
+  insetTop?: number;
+  insetBottom?: number;
+  padding?: number;
+  align?: number;
+  paddingInner?: number;
+  paddingOuter?: number;
+  axis?: "top" | "bottom" | "left" | "right" | null;
+  ticks?: number;
+  tickSize?: number;
+  tickPadding?: number;
+  tickRotate?: number;
+  line?: boolean;
+  label?: string;
+  labelAnchor?: "top" | "right" | "bottom" | "left" | "center";
+  labelOffset?: number;
+  legend?: boolean;
+  fontVariant?: string;
+  ariaLabel?: string;
+  ariaDescription?: string;
+}
+
+export interface ColorScaleOptions {
+  scheme?: OrdinalSchemes | QuantitativeSchemes;
+  interpolate?: "number" | "rgb" | "hsl" | "hcl" | "lab" | ((t: number) => string);
+  pivot?: number;
+}
+
 /**
  * An instantiated mark
  */
-export type InstantiatedMark<T extends Datum> = {
-  initialize: (data: Data<T>) => void;
-  z?: Accessor<T>; // copy the user option for error messages
+type InstantiatedMark = {
+  initialize: (data: Data<Datum>) => void;
+  z?: Accessor; // copy the user option for error messages
   clip?: "frame";
   dx: number;
   dy: number;
@@ -245,8 +265,8 @@ export type InstantiatedMark<T extends Datum> = {
 /**
  * A mark
  */
-type Mark<T extends Datum> = InstantiatedMark<T> | (() => SVGElement | null | undefined) | Mark<T>[];
-type MarksOptions<T extends Datum> = {marks?: Mark<T>[]};
+type Mark = InstantiatedMark | (() => SVGElement | null | undefined) | Mark[];
+type MarksOptions = {marks?: Mark[]};
 
 /**
  * Other top-level options
@@ -262,9 +282,9 @@ type TopLevelOptions = {
 /**
  * Plot options
  */
-export type PlotOptions<T extends Datum> = LayoutOptions &
-  FacetOptions<T> &
-  MarksOptions<T> &
+export type PlotOptions = LayoutOptions &
+  FacetOptions &
+  MarksOptions &
   PlotStyleOptions &
   ScalesOptions &
   TopLevelOptions;
@@ -284,33 +304,33 @@ export interface Chart extends HTMLElement {
   legend: (scaleName: "color" | "opacity" | "symbol", legendOptions: LegendOptions) => HTMLElement | undefined;
 }
 
-export type MaybeSymbol<T extends Datum> = Accessor<T> | SymbolName | SymbolObject | null | undefined;
+type MaybeSymbol = Accessor | SymbolName | SymbolObject | null | undefined;
 
 /**
  * Mark channel options
  */
-export type CommonChannelOptions<T extends Datum> = {
-  x?: Accessor<T> | number; // TODO: OptionsX
-  x1?: Accessor<T> | number;
-  x2?: Accessor<T> | number;
-  y?: Accessor<T> | number; // TODO: OptionsY
-  y1?: Accessor<T> | number;
-  y2?: Accessor<T> | number;
-  z?: Accessor<T>;
-  fill?: ColorAccessor<T> | null;
-  fillOpacity?: Accessor<T> | number | null;
-  r?: Accessor<T>; // TODO: OptionsR
-  stroke?: ColorAccessor<T> | null;
-  strokeOpacity?: Accessor<T> | number | null;
-  strokeWidth?: Accessor<T> | number | null;
-  symbol?: MaybeSymbol<T>;
-  opacity?: Accessor<T> | number | null;
+type CommonChannelOptions = {
+  x?: Accessor | number; // TODO: OptionsX
+  x1?: Accessor | number;
+  x2?: Accessor | number;
+  y?: Accessor | number; // TODO: OptionsY
+  y1?: Accessor | number;
+  y2?: Accessor | number;
+  z?: Accessor;
+  fill?: ColorAccessor | null;
+  fillOpacity?: Accessor | number | null;
+  r?: Accessor; // TODO: OptionsR
+  stroke?: ColorAccessor | null;
+  strokeOpacity?: Accessor | number | null;
+  strokeWidth?: Accessor | number | null;
+  symbol?: MaybeSymbol;
+  opacity?: Accessor | number | null;
 };
 
 /**
  * Mark constant style options
  */
-export type ConstantStyleOptions = {
+type ConstantStyleOptions = {
   ariaDescription?: string;
   ariaHidden?: boolean;
   target?: string;
@@ -328,7 +348,7 @@ export type ConstantStyleOptions = {
 /**
  * Default options for marks, strings or numbers
  */
-export type DefaultOptions = {
+type DefaultOptions = {
   ariaLabel?: string;
   fill?: string;
   fillOpacity?: number;
@@ -344,7 +364,7 @@ export type DefaultOptions = {
 /**
  * Channel styles
  */
-export type ChannelStyles = {
+type ChannelStyles = {
   ariaLabel?: ValueArray;
   title?: ValueArray;
   fill?: ValueArray;
@@ -378,8 +398,8 @@ The interval option is recommended to “regularize” sampled data; for example
  * @link TODO: unclear where to link
  * TODO: accept number or Date (for e.g., d3.utcYear)
  */
-export type Interval = number | IntervalObject;
-export type IntervalObject = {
+type Interval = number | IntervalObject;
+type IntervalObject = {
   floor: (v: number) => number;
   offset: (v: number) => number;
   range: (lo: number, hi: number) => number[];
@@ -400,7 +420,7 @@ export type IntervalObject = {
  * * deviation - each value is transformed by subtracting the mean and then dividing by the standard deviation
  * * a function to be passed an array of values, returning the desired basis
  */
-export type Basis =
+type Basis =
   | "first"
   | "last"
   | "min"
@@ -418,13 +438,13 @@ type BasisFunction = (V: ValueArray) => Value;
 /**
  * Other Mark options
  */
-type OtherMarkOptions<T extends Datum> = {
+type OtherMarkOptions = {
   // the following are necessarily channels
-  title?: Accessor<T>;
-  href?: Accessor<T>;
-  ariaLabel?: Accessor<T>;
+  title?: Accessor;
+  href?: Accessor;
+  ariaLabel?: Accessor;
   // filter & sort
-  filter?: Accessor<T>;
+  filter?: Accessor;
   sort?: SortOption | null;
   reverse?: boolean;
   // include in facet
@@ -434,8 +454,8 @@ type OtherMarkOptions<T extends Datum> = {
   // basis for the normalize transform
   basis?: Basis;
   // transform
-  transform?: TransformOption<T>;
-  initializer?: InitializerOption<T>;
+  transform?: TransformOption;
+  initializer?: InitializerOption;
 };
 
 /**
@@ -445,7 +465,7 @@ type OtherMarkOptions<T extends Datum> = {
  * * an object with a reduce method, an optionally a scope
  * @link https://github.com/observablehq/plot/blob/main/README.md#group
  */
-export type AggregationMethod =
+type AggregationMethod =
   | ((
       | "first"
       | "last"
@@ -485,7 +505,7 @@ export type AggregationMethod =
  * @link https://github.com/observablehq/plot/blob/main/README.md#group
  */
 
-export type Aggregate = {
+type Aggregate = {
   label?: string;
   reduce: (
     I: Series,
@@ -499,7 +519,7 @@ export type Aggregate = {
 /**
  * The extent of a bin, for extent-based reducers
  */
-export type BinExtent = {
+type BinExtent = {
   x1?: number | Date;
   x2?: number | Date;
   y1?: number | Date;
@@ -514,7 +534,7 @@ type AggregationFunction = (values?: ValueArray, extent?: BinExtent) => Value;
  * @link https://github.com/observablehq/plot/blob/main/README.md#transforms
  * @link https://github.com/observablehq/plot/blob/main/README.md#sort-options
  */
-export type SortOption = (
+type SortOption = (
   | // Field, accessor or comparator
   ((string | ((d: Datum) => Datum) | Comparator) & {value?: never; channel?: never}) // duck-typing in isDomainSort
   | ChannelSortOption
@@ -524,7 +544,7 @@ export type SortOption = (
 /**
  * A comparator function returns a number to sort two values
  */
-export type Comparator = (a: Datum, b: Datum) => number;
+type Comparator = (a: Datum, b: Datum) => number;
 
 type SortChannel = "x" | "y" | "r" | "data";
 
@@ -534,7 +554,7 @@ type ChannelSortOption = {
   value?: never; // duck-typing in isDomainSort
 };
 
-export type DomainSortOption = {
+type DomainSortOption = {
   x?: SortChannel | SortValue;
   y?: SortChannel | SortValue;
   fx?: SortChannel | SortValue;
@@ -556,17 +576,17 @@ type SortValue = {
 /**
  * Definition for the transform and initializer functions.
  */
-export type TransformFunction<T extends Datum> = (
-  this: InstantiatedMark<T>,
-  data: DataArray<T>,
+type TransformFunction = (
+  this: InstantiatedMark,
+  data: DataArray,
   facets: Series[]
-) => {data: DataArray<T>; facets: Series[]; channels?: never};
+) => {data: DataArray; facets: Series[]; channels?: never};
 
 /**
  * Plot’s transforms provide a convenient mechanism for transforming data as part of a plot specification.
  * @link https://github.com/observablehq/plot/blob/main/README.md#transforms
  */
-export type TransformOption<T extends Datum> = TransformFunction<T> | null | undefined;
+type TransformOption = TransformFunction | null | undefined;
 
 /**
  * Initializers can be used to transform and derive new channels prior to rendering. Unlike transforms which
@@ -576,15 +596,15 @@ export type TransformOption<T extends Datum> = TransformFunction<T> | null | und
  * may not, as desired) be passed to scales.
  * @link https://github.com/observablehq/plot/blob/main/README.md#initializers
  */
-export type InitializerFunction<T extends Datum> = (
-  this: InstantiatedMark<T>,
-  data: DataArray<T>,
+type InitializerFunction = (
+  this: InstantiatedMark,
+  data: DataArray,
   facets: Series[],
   channels?: any,
   scales?: any,
   dimensions?: Dimensions
-) => {data: DataArray<T>; facets: Series[]; channels?: any};
-export type InitializerOption<T extends Datum> = InitializerFunction<T> | TransformOption<T>; // TODO
+) => {data: DataArray; facets: Series[]; channels?: any};
+type InitializerOption = InitializerFunction | TransformOption;
 
 /**
  * The bin transform’s value option
@@ -617,8 +637,8 @@ export type InitializerOption<T extends Datum> = InitializerFunction<T> | Transf
  *
  * @link https://github.com/observablehq/plot/blob/main/README.md#bin
  */
-export type BinValue<T extends Datum> = {
-  value?: Accessor<T>;
+type BinValue = {
+  value?: Accessor;
   thresholds?: any;
   interval?: number | IntervalObject;
   domain?: number[] | ((V: ValueArray) => ValueArray);
@@ -630,7 +650,7 @@ export type BinValue<T extends Datum> = {
 /**
  * The group transform's output options
  */
-export type OutputOptions<T extends Datum> = Partial<{[P in keyof CommonChannelOptions<T>]: AggregationMethod}> & {
+type OutputOptions = Partial<{[P in keyof CommonChannelOptions]: AggregationMethod}> & {
   data?: any; // TODO: this option is not tested in any example, and not documented (https://github.com/observablehq/plot/pull/272)
   title?: AggregationMethod;
   href?: AggregationMethod;
@@ -638,12 +658,12 @@ export type OutputOptions<T extends Datum> = Partial<{[P in keyof CommonChannelO
   sort?: AggregationMethod;
   reverse?: boolean;
   interval?: number | Interval;
-} & BinOptions<T>;
+} & BinOptions;
 
-export type Reducer<T extends Datum> = {
-  name?: keyof OutputOptions<T>;
+type Reducer = {
+  name?: keyof OutputOptions;
   output: GetColumn;
-  initialize: (data: DataArray<T>) => void;
+  initialize: (data: DataArray) => void;
   scope: (scope: Aggregate["scope"], I?: Series) => void;
   reduce: (I: Series, extent?: BinExtent) => ValueArray;
   label?: string;
@@ -653,7 +673,7 @@ export type Reducer<T extends Datum> = {
  * The shuffle transform’s seed option
  * @link https://github.com/observablehq/plot/blob/main/README.md#plotshuffleoptions
  */
-export type ShuffleOptions = {
+type ShuffleOptions = {
   seed?: null | number;
 };
 
@@ -665,9 +685,9 @@ export type ShuffleOptions = {
  * * a function to be passed an array of values, returning new values
  * * an object that implements the map method
  */
-export type MapMethods = "cumsum" | "rank" | "quantile" | ((S: ValueArray) => ValueArray) | MapMethod; // duck-typing in maybeMap
+type MapMethods = "cumsum" | "rank" | "quantile" | ((S: ValueArray) => ValueArray) | MapMethod; // duck-typing in maybeMap
 
-export type MapMethod = {map: (I: Series, S: ValueArray, T: ValueArray) => void};
+type MapMethod = {map: (I: Series, S: ValueArray, T: ValueArray) => void};
 
 /**
  * Selects the points of each series selected by the selector, which can be specified
@@ -679,8 +699,8 @@ export type MapMethod = {map: (I: Series, S: ValueArray, T: ValueArray) => void}
  * for the specified channel.
  * @link https://github.com/observablehq/plot/blob/main/README.md#plotselectselector-options
  */
-export type Selector = ((I: Series) => Series) | "first" | "last" | Record<string, SelectorFunction>;
-export type SelectorFunction = "min" | "max" | ((I: Series, X: ValueArray) => Series);
+type Selector = ((I: Series) => Series) | "first" | "last" | Record<string, SelectorFunction>;
+type SelectorFunction = "min" | "max" | ((I: Series, X: ValueArray) => Series);
 
 /**
  * Stack options
@@ -701,15 +721,7 @@ type StackOptions = {offset?: Offset; order?: StackOrder; reverse?: boolean};
  * * an array of z values
  * @link https://github.com/observablehq/plot/blob/main/README.md#stack
  */
-export type StackOrder =
-  | null
-  | "value"
-  | "sum"
-  | "appearance"
-  | "inside-out"
-  | string
-  | ((d: Datum) => Value)
-  | ValueArray;
+type StackOrder = null | "value" | "sum" | "appearance" | "inside-out" | string | ((d: Datum) => Value) | ValueArray;
 
 /**
  * Stack offset options
@@ -727,7 +739,7 @@ export type StackOrder =
  * If the offset is specified as a function, it will receive four arguments: an index of stacks nested by facet and then stack, an array of start values, an array of end values, and an array of z values. For stackX, the start and end values correspond to x1 and x2, while for stackY, the start and end values correspond to y1 and y2. The offset function is then responsible for mutating the arrays of start and end values, such as by subtracting a common offset for each of the indices that pertain to the same stack.
  */
 type Offset = null | "expand" | "center" | "wiggle" | OffsetFunction;
-export type OffsetFunction = (stacks: Series[][], Y1: Float64Array, Y2: Float64Array, Z?: ValueArray | null) => void;
+type OffsetFunction = (stacks: Series[][], Y1: Float64Array, Y2: Float64Array, Z?: ValueArray | null) => void;
 
 /**
  * Window options
@@ -760,7 +772,7 @@ export type OffsetFunction = (stacks: Series[][], Y1: Float64Array, Y2: Float64A
  *
  * @link https://github.com/observablehq/plot/blob/main/README.md#plotwindowk
  */
-export type WindowOptions = {
+type WindowOptions = {
   k?: number;
   anchor?: "start" | "middle" | "end";
   reduce?:
@@ -787,8 +799,8 @@ export type WindowOptions = {
 /**
  * The bin options can be specified as part of the inputs or of the outputs
  */
-export type BinOptions<T extends Datum> = {
-  value?: Accessor<T>;
+type BinOptions = {
+  value?: Accessor;
   cumulative?: boolean;
   domain?: number[];
   thresholds?: number | number[];
@@ -798,20 +810,14 @@ export type BinOptions<T extends Datum> = {
 /**
  * Mark options (as passed by the user or returned by a transform)
  */
-export type MarkOptions<T extends Datum> = CommonChannelOptions<T> &
-  ConstantStyleOptions &
-  InsetOptions &
-  BinOptions<T> &
-  StackOptions &
-  WindowOptions &
-  OtherMarkOptions<T>;
-export type LineOptions<T extends Datum> = MarkOptions<T> & MarkerOptions;
-// export type RectOptions = MarkOptions & InsetOptions; // TODO: only add inset options where they are meaningful (bars, rects, etc)
+export type MarkOptions = CommonChannelOptions & ConstantStyleOptions & InsetOptions & OtherMarkOptions;
+type LineOptions = MarkOptions & MarkerOptions;
+// type RectOptions = MarkOptions & InsetOptions; // TODO: only add inset options where they are meaningful (bars, rects, etc)
 
 /**
  * The scales passed to a mark's render function
  */
-export type Scales = {
+type Scales = {
   x?: Scale;
   y?: Scale;
   r?: Scale;
@@ -824,7 +830,7 @@ type Scale = any; // TODO
 /**
  * The dimensions passed to a mark's render function
  */
-export type Dimensions = {
+type Dimensions = {
   width: pixels;
   height: pixels;
   marginLeft: pixels;
@@ -837,29 +843,20 @@ export type Dimensions = {
  * A marker defines a graphic drawn on vertices of a delaunay, line or a link mark
  * @link https://github.com/observablehq/plot/blob/main/README.md#markers
  */
-export type MarkerOption =
-  | "none"
-  | "arrow"
-  | "dot"
-  | "circle"
-  | "circle-stroke"
-  | MarkerFunction
-  | boolean
-  | null
-  | undefined;
-export type MarkerOptions = {
+type MarkerOption = "none" | "arrow" | "dot" | "circle" | "circle-stroke" | MarkerFunction | boolean | null | undefined;
+type MarkerOptions = {
   marker?: MarkerOption;
   markerStart?: MarkerOption;
   markerMid?: MarkerOption;
   markerEnd?: MarkerOption;
 };
-export type MarkerFunction = (color: string, document: Context["document"]) => SVGElement;
+type MarkerFunction = (color: string, document: Context["document"]) => SVGElement;
 type MaybeMarkerFunction = MarkerFunction | null;
 
 /**
  * Ordinal color schemes
  */
-export type OrdinalSchemes =
+type OrdinalSchemes =
   | "accent"
   | "category10"
   | "dark2"
@@ -914,7 +911,7 @@ export type OrdinalSchemes =
 /**
  * Quantitative color schemes
  */
-export type QuantitativeSchemes = DivergingSchemes | SequentialSchemes | CyclicalSchemes;
+type QuantitativeSchemes = DivergingSchemes | SequentialSchemes | CyclicalSchemes;
 
 /**
  * Diverging color schemes
@@ -972,7 +969,7 @@ type CyclicalSchemes = "rainbow" | "sinebow";
 /**
  * The context in which Plot operates
  */
-export interface Context {
+interface Context {
   document: Document;
 }
 
@@ -980,7 +977,7 @@ export interface Context {
  * Know symbols for dots
  * @link https://github.com/observablehq/plot/blob/main/README.md#dot
  */
-export type SymbolName =
+type SymbolName =
   | "asterisk"
   | "circle"
   | "cross"
@@ -1000,12 +997,12 @@ export type SymbolName =
  * A symbol object with a draw function
  * @link https://github.com/d3/d3-shape/blob/main/README.md#custom-symbol-types
  */
-export type SymbolObject = {draw: (context: CanvasPath, size: number) => void};
+type SymbolObject = {draw: (context: CanvasPath, size: number) => void};
 
 /**
  * A restrictive definition of D3 selections
  */
-export type Selection = {
+type Selection = {
   append: (name: string) => Selection;
   attr: (name: string, value: any) => Selection;
   call: (callback: (selection: Selection, ...args: any[]) => void, ...args: any[]) => Selection;

--- a/src/types.ts
+++ b/src/types.ts
@@ -795,7 +795,7 @@ type OffsetFunction = (stacks: Series[][], Y1: Float64Array, Y2: Float64Array, Z
  *
  * @link https://github.com/observablehq/plot/blob/main/README.md#plotwindowk
  */
-type WindowOptions = {
+export type WindowOptions = {
   k?: number;
   anchor?: "start" | "middle" | "end";
   reduce?:

--- a/src/types.ts
+++ b/src/types.ts
@@ -333,6 +333,7 @@ export type StyleOptions = {
   paintOrder?: string;
   pointerEvents?: string;
   shapeRendering?: string;
+  clip?: boolean | null | undefined;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ type Datum = Row | Value | Value[];
  * The marks data; typically an array of Datum, but can also
  * be defined as an iterable compatible with Array.from.
  */
-type Data<T extends Datum> = ArrayLike<T> | Iterable<T> | TypedArray;
+export type Data<T extends Datum = Datum> = ArrayLike<T> | Iterable<T> | TypedArray;
 
 /**
  * The data is then arrayified, and a range of indices is computed, serving as pointers
@@ -706,7 +706,7 @@ type SelectorFunction = "min" | "max" | ((I: Series, X: ValueArray) => Series);
  * Stack options
  * @link https://github.com/observablehq/plot/blob/main/README.md#stack
  */
-type StackOptions = {offset?: Offset; order?: StackOrder; reverse?: boolean};
+export type StackOptions = {offset?: Offset; order?: StackOrder; reverse?: boolean};
 
 /**
  * Stack order options:

--- a/test/plots/index.html
+++ b/test/plots/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <head>
-  <meta charset="utf-8">
+  <meta charset="utf-8" />
 </head>
 <style>
   body {


### PR DESCRIPTION
This PR uses a `types.ts` file for authoring the types (this is just for convenience, since I find it easier to write typescript types than use the JSDoc syntax), and we import those types as jsdoc tags where appropriate.

This PR covers Plot.plot and all of the marks.

Known issues:
- Some types are too broad, e.g. tickX doesn't accept x1 and y1, but those appear in the completions

TODO:
- [ ] Plot.image : move the description of options from the `### Image` section to the Plot.image jsdocs