### PR TITLE
Plot.image rotate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1331,10 +1331,11 @@ In addition to the [standard mark options](#marks), the following optional chann
 * **y** - the vertical position; bound to the *y* scale
 * **width** - the image width (in pixels)
 * **height** - the image height (in pixels)
+* **rotate** - the image rotation angle (in degrees, defaults to 0)
 
 If either of the **x** or **y** channels are not specified, the corresponding position is controlled by the **frameAnchor** option.
 
-The **width** and **height** options default to 16 pixels and can be specified as either a channel or constant. When the width or height is specified as a number, it is interpreted as a constant; otherwise it is interpreted as a channel. Images with a nonpositive width or height are not drawn. If a **width** is specified but not a **height**, or *vice versa*, the one defaults to the other. Images do not support either a fill or a stroke.
+The **width** and **height** options default to 16 pixels and can be specified as either a channel or constant. When the width, height, or rotate is specified as a number, it is interpreted as a constant; otherwise it is interpreted as a channel. Images with a nonpositive width or height are not drawn. If a **width** is specified but not a **height**, or *vice versa*, the one defaults to the other. Images do not support either a fill or a stroke.
 
 The following image-specific constant options are also supported:
 


### PR DESCRIPTION
Demo: https://observablehq.com/@observablehq/plot-image-rotate-1084

closes #1083

todo:
- [ ] unit test
- [ ] dx, dy— & anticipate what will happen if dx and dy become variable (as in #909)