### PR TITLE
Add margin support to ordinal legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "readme:update": "tsx scripts/jsdoc-to-readme.ts",
     "prepublishOnly": "rm -rf dist && rollup -c && tsc",
     "postpublish": "git push && git push --tags",
-    "dev": "vite"
+    "dev": "vite",
+    "prettier": "prettier . --check",
+    "prettier-fix": "prettier . --write"
   },
   "_moduleAliases": {
     "@observablehq/plot": "./src/index.js"

--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     "readme:update": "tsx scripts/jsdoc-to-readme.ts",
     "prepublishOnly": "rm -rf dist && rollup -c && tsc",
     "postpublish": "git push && git push --tags",
-    "dev": "vite",
-    "prettier": "prettier . --check",
-    "prettier-fix": "prettier . --write"
+    "dev": "vite"
   },
   "_moduleAliases": {
     "@observablehq/plot": "./src/index.js"

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -1,10 +1,10 @@
-import {path} from "d3";
-import {inferFontVariant} from "../axes.js";
-import {maybeAutoTickFormat} from "../axis.js";
-import {Context, create} from "../context.js";
-import {isNoneish, maybeColorChannel, maybeNumberChannel} from "../options.js";
-import {isOrdinalScale, isThresholdScale} from "../scales.js";
-import {applyInlineStyles, impliedString, maybeClassName} from "../style.js";
+import { path } from "d3";
+import { inferFontVariant } from "../axes.js";
+import { maybeAutoTickFormat } from "../axis.js";
+import { Context, create } from "../context.js";
+import { isNoneish, maybeColorChannel, maybeNumberChannel } from "../options.js";
+import { isOrdinalScale, isThresholdScale } from "../scales.js";
+import { applyInlineStyles, impliedString, maybeClassName } from "../style.js";
 
 function maybeScale(scale, key) {
   if (key == null) return key;
@@ -88,6 +88,9 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
     swatchSize = 15,
     swatchWidth = swatchSize,
     swatchHeight = swatchSize,
+    marginTop = 0,
+    marginRight = 0,
+    marginBottom = 0,
     marginLeft = 0,
     className,
     style,
@@ -170,18 +173,22 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
       div.insert("style", "*").text(`
         .${className} {
           font-family: system-ui, sans-serif;
-          font-size: 10px;
-          margin-bottom: 0.5em;${
-            marginLeft === undefined
-              ? ""
-              : `
-          margin-left: ${+marginLeft}px;`
-          }${
-        width === undefined
+          font-size: 10px;${marginTop === undefined
           ? ""
-          : `
-          width: ${width}px;`
-      }
+          : `margin-top: ${+marginTop}px;`
+        }${marginRight === undefined
+          ? ""
+          : `margin-right: ${+marginRight}px;`
+        }${marginBottom === undefined
+          ? `margin-bottom: 0.5em;`
+          : `margin-bottom: ${+marginBottom}px;`
+        }${marginLeft === undefined
+          ? ""
+          : `margin-left: ${+marginLeft}px;`
+        }${width === undefined
+          ? ""
+          : `width: ${width}px;`
+        }
         }
         ${swatchStyle(className)}
         ${extraStyle}

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -175,9 +175,9 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
           font-family: system-ui, sans-serif;
           font-size: 10px;${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${
         marginRight === undefined ? "" : `margin-right: ${+marginRight}px;`
-        }${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${`margin-bottom: ${+marginBottom}px;`}${marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`}${
-        width === undefined ? "" : `width: ${+width}px;`
-      }
+      }${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${`margin-bottom: ${+marginBottom}px;`}${
+        marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`
+      }${width === undefined ? "" : `width: ${+width}px;`}
         }
         ${swatchStyle(className)}
         ${extraStyle}

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -1,10 +1,10 @@
-import { path } from "d3";
-import { inferFontVariant } from "../axes.js";
-import { maybeAutoTickFormat } from "../axis.js";
-import { Context, create } from "../context.js";
-import { isNoneish, maybeColorChannel, maybeNumberChannel } from "../options.js";
-import { isOrdinalScale, isThresholdScale } from "../scales.js";
-import { applyInlineStyles, impliedString, maybeClassName } from "../style.js";
+import {path} from "d3";
+import {inferFontVariant} from "../axes.js";
+import {maybeAutoTickFormat} from "../axis.js";
+import {Context, create} from "../context.js";
+import {isNoneish, maybeColorChannel, maybeNumberChannel} from "../options.js";
+import {isOrdinalScale, isThresholdScale} from "../scales.js";
+import {applyInlineStyles, impliedString, maybeClassName} from "../style.js";
 
 function maybeScale(scale, key) {
   if (key == null) return key;
@@ -90,7 +90,7 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
     swatchHeight = swatchSize,
     marginTop = 0,
     marginRight = 0,
-    marginBottom = 0,
+    marginBottom = 8,
     marginLeft = 0,
     className,
     style,
@@ -173,22 +173,11 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
       div.insert("style", "*").text(`
         .${className} {
           font-family: system-ui, sans-serif;
-          font-size: 10px;${marginTop === undefined
-          ? ""
-          : `margin-top: ${+marginTop}px;`
-        }${marginRight === undefined
-          ? ""
-          : `margin-right: ${+marginRight}px;`
-        }${marginBottom === undefined
-          ? `margin-bottom: 0.5em;`
-          : `margin-bottom: ${+marginBottom}px;`
-        }${marginLeft === undefined
-          ? ""
-          : `margin-left: ${+marginLeft}px;`
-        }${width === undefined
-          ? ""
-          : `width: ${width}px;`
-        }
+          font-size: 10px;${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${
+        marginRight === undefined ? "" : `margin-right: ${+marginRight}px;`
+      }${`margin-bottom: ${+marginBottom}px;`}${
+        marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`
+      }${width === undefined ? "" : `width: ${+width}px;`}
         }
         ${swatchStyle(className)}
         ${extraStyle}

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -90,7 +90,7 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
     swatchHeight = swatchSize,
     marginTop = 0,
     marginRight = 0,
-    marginBottom = 8,
+    marginBottom = 5,
     marginLeft = 0,
     className,
     style,

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -88,10 +88,10 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
     swatchSize = 15,
     swatchWidth = swatchSize,
     swatchHeight = swatchSize,
-    marginTop = 0,
-    marginRight = 0,
-    marginBottom = 5,
-    marginLeft = 0,
+    marginTop,
+    marginBottom,
+    marginLeft,
+    marginRight,
     className,
     style,
     width
@@ -173,11 +173,16 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
       div.insert("style", "*").text(`
         .${className} {
           font-family: system-ui, sans-serif;
-          font-size: 10px;${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${
-        marginRight === undefined ? "" : `margin-right: ${+marginRight}px;`
-      }${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${`margin-bottom: ${+marginBottom}px;`}${
-        marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`
-      }${width === undefined ? "" : `width: ${+width}px;`}
+          font-size: 10px;
+          ${[
+            marginTop === undefined ? null : `margin-top: ${+marginTop}px;`,
+            marginBottom === undefined ? `margin-bottom: 0.5em;` : `margin-bottom: ${+marginBottom}px;`,
+            `margin-left: ${marginLeft === undefined ? 0 : +marginLeft}px;`,
+            marginRight === undefined ? null : `margin-right: ${+marginRight}px;`,
+            width === undefined ? null : `width: ${+width}px;`
+          ]
+            .filter((d) => d)
+            .join("\n          ")}
         }
         ${swatchStyle(className)}
         ${extraStyle}

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -175,9 +175,9 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
           font-family: system-ui, sans-serif;
           font-size: 10px;${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${
         marginRight === undefined ? "" : `margin-right: ${+marginRight}px;`
-      }${`margin-bottom: ${+marginBottom}px;`}${
-        marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`
-      }${width === undefined ? "" : `width: ${+width}px;`}
+      }${`margin-bottom: ${+marginBottom}px;`}${marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`}${
+        width === undefined ? "" : `width: ${+width}px;`
+      }
         }
         ${swatchStyle(className)}
         ${extraStyle}

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -173,11 +173,9 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
       div.insert("style", "*").text(`
         .${className} {
           font-family: system-ui, sans-serif;
-          font-size: 10px;${`margin-bottom: ${+marginBottom}px;`}${
-        marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`
-      }${marginRight === undefined ? "" : `margin-right: ${+marginRight}px;`}${
-        marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`
-      }${marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`}${
+          font-size: 10px;${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${
+        marginRight === undefined ? "" : `margin-right: ${+marginRight}px;`
+        }${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${`margin-bottom: ${+marginBottom}px;`}${marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`}${
         width === undefined ? "" : `width: ${+width}px;`
       }
         }

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -173,9 +173,11 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
       div.insert("style", "*").text(`
         .${className} {
           font-family: system-ui, sans-serif;
-          font-size: 10px;${marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`}${
-        marginRight === undefined ? "" : `margin-right: ${+marginRight}px;`
-      }${`margin-bottom: ${+marginBottom}px;`}${marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`}${
+          font-size: 10px;${`margin-bottom: ${+marginBottom}px;`}${
+        marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`
+      }${marginRight === undefined ? "" : `margin-right: ${+marginRight}px;`}${
+        marginTop === undefined ? "" : `margin-top: ${+marginTop}px;`
+      }${marginLeft === undefined ? "" : `margin-left: ${+marginLeft}px;`}${
         width === undefined ? "" : `width: ${+width}px;`
       }
         }


### PR DESCRIPTION
This adds support for marginTop, marginBottom and marginRight (in pixels), but keeps the existing defaults (margin-left: 0px, margin-bottom: 0.5em;) to minimize churn.
We might want to revisit at a later time and support both numbers (as pixels) and lengths (as strings).

Contributed by @dgwyer

supersedes #1082