### PR TITLE
show a warning for missing/invalid values in channels.

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -661,7 +661,7 @@ export function plot(options = {}) {
 
 export class Mark {
   constructor(data, channels = {}, options = {}, defaults) {
-    const {facet = "auto", sort, dx, dy, clip, channels: extraChannels} = options;
+    const {facet = "auto", sort, dx, dy, clip, ignoreMissing, channels: extraChannels} = options;
     this.data = data;
     this.sort = isDomainSort(sort) ? sort : null;
     this.initializer = initializer(options).initializer;
@@ -683,6 +683,7 @@ export class Mark {
     this.dx = +dx || 0;
     this.dy = +dy || 0;
     this.clip = maybeClip(clip);
+    this.ignoreMissing = !!ignoreMissing;
   }
   initialize(facets, facetChannels) {
     let data = arrayify(this.data);
@@ -697,7 +698,14 @@ export class Mark {
       const {filter = defined} = channels[name];
       if (filter !== null) {
         const value = values[name];
+        const n = index.length;
         index = index.filter((i) => filter(value[i]));
+        if (!this.ignoreMissing && index.length < n)
+          warn(
+            `The ${this.ariaLabel} mark ignored ${
+              n - index.length
+            } elements with a missing or invalid ${name}. Set ignoreMissing to true in the mark to hide this warning.`
+          );
       }
     }
     return index;


### PR DESCRIPTION
For discussion, as a way to address #493.

Q: should this be opt-in or opt-out?


<img width="717" alt="Capture d’écran 2022-10-17 à 16 14 59" src="https://user-images.githubusercontent.com/7001/196300772-af0ab5d5-cce9-4c1f-a229-c20f78f8fbb4.png">

closes #invalid