### PR TITLE
Ignore falsy marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Renders a new plot given the specified *options* and returns the corresponding S
 
 ### Mark options
 
-The **marks** option specifies an array of [marks](#marks) to render. Each mark has its own data and options; see the respective mark type (*e.g.*, [bar](#bar) or [dot](#dot)) for which mark options are supported. Each mark may be a nested array of marks, allowing composition. Marks may also be a function which returns an SVG element, if you wish to insert some arbitrary content into your plot. And marks may be null or undefined, which produce no output; this is useful for showing marks conditionally (*e.g.*, when a box is checked). Marks are drawn in *z* order, last on top. For example, here a single rule at *y* = 0 is drawn on top of blue bars for the [*alphabet* dataset](./test/data/alphabet.csv).
+The **marks** option specifies an array of [marks](#marks) to render. Each mark has its own data and options; see the respective mark type (*e.g.*, [bar](#bar) or [dot](#dot)) for which mark options are supported. Each mark may be a nested array of marks, allowing composition. Marks may also be a function which returns an SVG element, if you wish to insert some arbitrary content into your plot. And marks may be any falsy value, which produce no output; this is useful for showing marks conditionally (*e.g.*, when a box is checked). Marks are drawn in *z* order, last on top. For example, here a single rule at *y* = 0 is drawn on top of blue bars for the [*alphabet* dataset](./test/data/alphabet.csv).
 
 ```js
 Plot.plot({

--- a/src/plot.js
+++ b/src/plot.js
@@ -376,7 +376,7 @@ function markify(mark) {
 class Render extends Mark {
   constructor(render) {
     super();
-    if (render == null) return;
+    if (!render) return;
     if (typeof render !== "function") throw new TypeError("invalid mark; missing render function");
     this.render = render;
   }

--- a/test/plots/empty.js
+++ b/test/plots/empty.js
@@ -11,6 +11,8 @@ export default async function () {
       Plot.frame(),
       undefined,
       null,
+      false,
+      "",
       () => null,
       () => undefined,
       () => svg`<circle cx=50% cy=50% r=5 fill=green>`

--- a/test/plots/empty.js
+++ b/test/plots/empty.js
@@ -13,6 +13,7 @@ export default async function () {
       null,
       false,
       "",
+      0,
       () => null,
       () => undefined,
       () => svg`<circle cx=50% cy=50% r=5 fill=green>`


### PR DESCRIPTION
Skips not only `null` and `undefined`, but any falsy mark. It simplifies usage of conditional marks and makes behaviour similar to React (React does not throw on falsy components, but Plot does).

Before:
```
marks: [
  condition ? Plot.dot(...) : null
]
```

After:
```
marks: [
  condition && Plot.dot(...)
]
```