### PR TITLE
projection.inset

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,11 @@ If the **projection** option is specified as an object, the following additional
 * projection.**parallels** - the [standard parallels](https://github.com/d3/d3-geo/blob/main/README.md#conic_parallels) (for conic projections only)
 * projection.**precision** - the [sampling threshold](https://github.com/d3/d3-geo/blob/main/README.md#projection_precision)
 * projection.**rotate** - a two- or three- element array of Euler angles to rotate the sphere
+* projection.**inset** - inset the frame by the specified amount in pixels when fitting the projection to the frame
+* projection.**insetLeft** - left inset, defaults to inset
+* projection.**insetRight** - right inset, defaults to inset
+* projection.**insetTop** - top inset, defaults to inset
+* projection.**insetBottom** - bottom inset, defaults to inset
 
 ### Color options
 

--- a/README.md
+++ b/README.md
@@ -342,10 +342,10 @@ If the **projection** option is specified as an object, the following additional
 * projection.**precision** - the [sampling threshold](https://github.com/d3/d3-geo/blob/main/README.md#projection_precision)
 * projection.**rotate** - a two- or three- element array of Euler angles to rotate the sphere
 * projection.**inset** - inset by the given amount in pixels when fitting to the frame (default zero)
-* projection.**insetLeft** - left inset (defaults to inset)
-* projection.**insetRight** - right inset (defaults to inset)
-* projection.**insetTop** - top inset (defaults to inset)
-* projection.**insetBottom** - bottom inset (defaults to inset)
+* projection.**insetLeft** - inset for the left edge of the frame (defaults to inset)
+* projection.**insetRight** - inset for the right edge of the frame (defaults to inset)
+* projection.**insetTop** - inset for the top edge of the frame (defaults to inset)
+* projection.**insetBottom** - inset for the bottom edge of the frame (defaults to inset)
 
 ### Color options
 

--- a/README.md
+++ b/README.md
@@ -341,11 +341,11 @@ If the **projection** option is specified as an object, the following additional
 * projection.**parallels** - the [standard parallels](https://github.com/d3/d3-geo/blob/main/README.md#conic_parallels) (for conic projections only)
 * projection.**precision** - the [sampling threshold](https://github.com/d3/d3-geo/blob/main/README.md#projection_precision)
 * projection.**rotate** - a two- or three- element array of Euler angles to rotate the sphere
-* projection.**inset** - inset the frame by the specified amount in pixels when fitting the projection to the frame
-* projection.**insetLeft** - left inset, defaults to inset
-* projection.**insetRight** - right inset, defaults to inset
-* projection.**insetTop** - top inset, defaults to inset
-* projection.**insetBottom** - bottom inset, defaults to inset
+* projection.**inset** - inset by the given amount in pixels when fitting to the frame (default zero)
+* projection.**insetLeft** - left inset (defaults to inset)
+* projection.**insetRight** - right inset (defaults to inset)
+* projection.**insetTop** - top inset (defaults to inset)
+* projection.**insetBottom** - bottom inset (defaults to inset)
 
 ### Color options
 

--- a/src/projection.js
+++ b/src/projection.js
@@ -21,19 +21,25 @@ import {isObject} from "./options.js";
 export function maybeProjection(projection, dimensions) {
   if (projection == null) return;
   if (typeof projection.stream === "function") return projection; // d3 projection
-  let options;
-  if (isObject(projection)) ({type: projection, ...options} = projection);
+  let options, inset, insetLeft, insetRight, insetTop, insetBottom;
+  if (isObject(projection))
+    ({type: projection, inset, insetLeft, insetRight, insetTop, insetBottom, ...options} = projection);
+  if (inset === undefined) inset = 0;
+  if (insetLeft === undefined) insetLeft = inset;
+  if (insetRight === undefined) insetRight = inset;
+  if (insetTop === undefined) insetTop = inset;
+  if (insetBottom === undefined) insetBottom = inset;
   if (typeof projection !== "function") projection = namedProjection(projection);
   const {width, height, marginLeft, marginRight, marginTop, marginBottom} = dimensions;
   projection = projection?.({
-    width: width - marginLeft - marginRight,
-    height: height - marginTop - marginBottom,
+    width: width - marginLeft - marginRight - insetLeft - insetRight,
+    height: height - marginTop - marginBottom - insetTop - insetBottom,
     ...options
   });
   if (projection == null) return;
   // wrap the projection stream to shift its origin to <marginLeft, marginTop>
-  if (marginLeft === 0 && marginTop === 0) return projection;
-  const shiftStream = geoIdentity().translate([marginLeft, marginTop]).stream;
+  if (marginLeft + insetLeft === 0 && marginTop + insetTop === 0) return projection;
+  const shiftStream = geoIdentity().translate([marginLeft + insetLeft, marginTop + insetTop]).stream;
   return {stream: (s) => projection.stream(shiftStream(s))};
 }
 


### PR DESCRIPTION
as part of #1125 and an addition to #1124: specifying a projection inset, in pixels, will fit the projection slightly towards the interior of the frame

this is not urgent and should be thought about with the rest of #1125