### PR TITLE
support shorthand projection: {domain: "sphere"}

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ If the **projection** option is specified as an object, the following additional
 * projection.**parallels** - the [standard parallels](https://github.com/d3/d3-geo/blob/main/README.md#conic_parallels) (for conic projections only)
 * projection.**precision** - the [sampling threshold](https://github.com/d3/d3-geo/blob/main/README.md#projection_precision)
 * projection.**rotate** - a two- or three- element array of Euler angles to rotate the sphere
-* projection.**domain** - a GeoJSON object (or an iterable of GeoJSON objects) to fit in the center of the frame
+* projection.**domain** - a GeoJSON object (or an iterable of GeoJSON objects, or the "sphere" shorthand) to fit in the center of the frame
 * projection.**inset** - inset by the given amount in pixels when fitting to the frame (default zero)
 * projection.**insetLeft** - inset from the left edge of the frame (defaults to inset)
 * projection.**insetRight** - inset from the right edge of the frame (defaults to inset)

--- a/src/projection.js
+++ b/src/projection.js
@@ -74,7 +74,7 @@ export function Projection(
   // Otherwise wrap the projection stream with a suitable transform. If a domain
   // is specified, fit the projection to the frame. Otherwise, translate.
   if (domain) {
-    const fitDomain = domain.type ? [domain] : domain;
+    const fitDomain = domain.type ? [domain] : domain === "sphere" ? {type: "Sphere"} : domain;
     let x0 = Infinity,
       y0 = x0,
       x1 = -x0,


### PR DESCRIPTION
As a complement to #1153 (suggested in #1148). Might come in handy, but I'm not sure we want too many special cases.