### PR TITLE
fix empty facet bug

### DIFF
--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -89,7 +89,7 @@ function stack(x, y = one, ky, {offset, order, reverse}, options) {
       const Y2 = setY2(new Float64Array(n));
       const facetstacks = [];
       for (const facet of facets) {
-        const stacks = X ? Array.from(group(facet, (i) => X[i]).values()) : [facet];
+        const stacks = X ? Array.from(group(facet ?? [], (i) => X[i]).values()) : [facet];
         if (O) applyOrder(stacks, O);
         for (const stack of stacks) {
           let yn = 0,

--- a/test/output/emptyFacet.svg
+++ b/test/output/emptyFacet.svg
@@ -1,0 +1,47 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="430" viewBox="0 0 640 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis" aria-description="VALUE" transform="translate(40,0)" fill="none" text-anchor="end" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0,215.5)">
+      <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-9" dy="0.32em">0</text>
+    </g><text fill="currentColor" font-variant="normal" transform="translate(-40,30)" dy="-1em" text-anchor="start">VALUE</text>
+  </g>
+  <g aria-label="fx-axis" aria-description="TYPE" transform="translate(0,30)" fill="none" text-anchor="middle">
+    <g class="tick" opacity="1" transform="translate(177.5,0)">
+      <line stroke="currentColor" y2="0"></line><text fill="currentColor" y="-9" dy="0em">a</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(482.5,0)">
+      <line stroke="currentColor" y2="0"></line><text fill="currentColor" y="-9" dy="0em">b</text>
+    </g><text fill="currentColor" transform="translate(330,-30)" dy="1em" text-anchor="middle">TYPE</text>
+  </g>
+  <g aria-label="x-axis" transform="translate(40,400)" fill="none" text-anchor="middle">
+    <g class="tick" opacity="1" transform="translate(72.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(202.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">2</text>
+    </g>
+  </g>
+  <g aria-label="x-axis" aria-description="PERIOD" transform="translate(345,400)" fill="none" text-anchor="middle">
+    <g class="tick" opacity="1" transform="translate(72.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">1</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(202.5,0)">
+      <line stroke="currentColor" y2="6"></line><text fill="currentColor" y="9" dy="0.71em">2</text>
+    </g><text fill="currentColor" transform="translate(137.5,30)" dy="-0.32em" text-anchor="middle">PERIOD</text>
+  </g>
+  <g aria-label="facet" transform="translate(40,0)"></g>
+  <g aria-label="facet" transform="translate(345,0)"></g>
+</svg>

--- a/test/plots/empty-facet.js
+++ b/test/plots/empty-facet.js
@@ -1,0 +1,13 @@
+import * as Plot from "@observablehq/plot";
+
+export default async function () {
+  const data = [
+    {PERIOD: 1, VALUE: 3, TYPE: "c"},
+    {PERIOD: 2, VALUE: 4, TYPE: "c"}
+  ];
+  return Plot.plot({
+    facet: {data, x: "TYPE"},
+    fx: {domain: ["a", "b"]},
+    marks: [Plot.barY(data, {x: "PERIOD", y: "VALUE"})]
+  });
+}

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -64,6 +64,7 @@ export {default as downloads} from "./downloads.js";
 export {default as downloadsOrdinal} from "./downloads-ordinal.js";
 export {default as driving} from "./driving.js";
 export {default as empty} from "./empty.js";
+export {default as emptyFacet} from "./empty-facet.js";
 export {default as emptyLegend} from "./empty-legend.js";
 export {default as emptyX} from "./empty-x.js";
 export {default as energyProduction} from "./energy-production.js";


### PR DESCRIPTION
When the facet domain does not include any value from the actual contents, the facet index is undefined instead of [].

I'm not sure this is the correct fix, I have an alternative that moves a bit more things but seems better in #TKTK.

~~~diff
--- a/src/plot.js
+++ b/src/plot.js
@@ -645,8 +645,8 @@ function maybeMarkFacet(mark, topFacetState, options) {
 // Facet filter, by mark; for now only the "eq" filter is provided.
 function filterFacets(facets, {channels: {fx, fy}, groups}) {
   return fx && fy
-    ? facets.map(({x, y}) => groups.get(x)?.get(y))
+    ? facets.map(({x, y}) => groups.get(x)?.get(y) ?? [])
     : fx
-    ? facets.map(({x}) => groups.get(x))
-    : facets.map(({y}) => groups.get(y));
+    ? facets.map(({x}) => groups.get(x) ?? [])
+    : facets.map(({y}) => groups.get(y) ?? []);
 }
~~~

closes #1212