### PR TITLE
sampler requires a function

### DIFF
--- a/src/marks/contour.js
+++ b/src/marks/contour.js
@@ -50,7 +50,7 @@ export class Contour extends AbstractRaster {
     // by the sampler initializer, and hence is not passed to super to avoid
     // computing it before there’s data.
     if (data == null) {
-      if (typeof value !== "function") throw new Error("invalid contour value");
+      if (value == null) throw new Error("missing contour value");
       options = sampler("value", {value, ...options});
       value = null;
     }

--- a/src/marks/raster.js
+++ b/src/marks/raster.js
@@ -2,6 +2,7 @@ import {blurImage, Delaunay, randomLcg, rgb} from "d3";
 import {valueObject} from "../channel.js";
 import {create} from "../context.js";
 import {map, first, second, third, isTuples, isNumeric, isTemporal, take, identity} from "../options.js";
+import {maybeColorChannel, maybeNumberChannel} from "../options.js";
 import {Mark} from "../plot.js";
 import {applyAttr, applyDirectStyles, applyIndirectStyles, applyTransform, impliedString} from "../style.js";
 import {initializer} from "../transforms/basic.js";
@@ -84,7 +85,12 @@ export class AbstractRaster extends Mark {
 export class Raster extends AbstractRaster {
   constructor(data, options = {}) {
     const {imageRendering} = options;
-    super(data, undefined, data == null ? sampler("fill", sampler("fillOpacity", options)) : options, defaults);
+    if (data == null) {
+      const {fill, fillOpacity} = options;
+      if (maybeNumberChannel(fillOpacity)[0] !== undefined) options = sampler("fillOpacity", options);
+      if (maybeColorChannel(fill)[0] !== undefined) options = sampler("fill", options);
+    }
+    super(data, undefined, options, defaults);
     this.imageRendering = impliedString(imageRendering, "auto");
   }
   // Ignore the color scale, so the fill channel is returned unscaled.
@@ -217,7 +223,6 @@ export function rasterBounds({x1, y1, x2, y2}, scales, dimensions, context) {
 // generating a channel of the same name.
 export function sampler(name, options = {}) {
   const {[name]: value} = options;
-  if (value == null) return options;
   if (typeof value !== "function") throw new Error(`invalid ${name}: not a function`);
   return initializer({...options, [name]: undefined}, function (data, facets, channels, scales, dimensions, context) {
     const {x, y} = scales;

--- a/src/marks/raster.js
+++ b/src/marks/raster.js
@@ -218,7 +218,7 @@ export function rasterBounds({x1, y1, x2, y2}, scales, dimensions, context) {
 export function sampler(name, options = {}) {
   const {[name]: value} = options;
   if (value == null) return options;
-  if (typeof value !== "function") throw new Error(`${name} is not a function: ${value}`);
+  if (typeof value !== "function") throw new Error(`invalid ${name}: not a function`);
   return initializer({...options, [name]: undefined}, function (data, facets, channels, scales, dimensions, context) {
     const {x, y} = scales;
     // TODO Allow projections, if invertible.

--- a/src/marks/raster.js
+++ b/src/marks/raster.js
@@ -217,7 +217,8 @@ export function rasterBounds({x1, y1, x2, y2}, scales, dimensions, context) {
 // generating a channel of the same name.
 export function sampler(name, options = {}) {
   const {[name]: value} = options;
-  if (typeof value !== "function") return options;
+  if (value == null) return options;
+  if (typeof value !== "function") throw new Error(`${name} is not a function: ${value}`);
   return initializer({...options, [name]: undefined}, function (data, facets, channels, scales, dimensions, context) {
     const {x, y} = scales;
     // TODO Allow projections, if invertible.

--- a/test/plots/raster-vapor.js
+++ b/test/plots/raster-vapor.js
@@ -13,7 +13,7 @@ export async function rasterVapor() {
     color: {scheme: "blues"},
     x: {transform: (x) => x - 180},
     y: {transform: (y) => 90 - y},
-    marks: [Plot.raster({fill: await vapor(), width: 360, height: 180})]
+    marks: [Plot.raster(await vapor(), {width: 360, height: 180})]
   });
 }
 


### PR DESCRIPTION
Throws an error in this case:

```js
Plot.raster({width: volcano.width, height: volcano.height, fill: volcano.values}).plot()
```

Instead you should say:

```js
Plot.raster(volcano.values, {width: volcano.width, height: volcano.height}).plot()
```

The dense grid in screen coordinates is only possible when _fill_ is specified as a function (and sampled by inverting the _x_ and _y_ scales).