### PR TITLE
Export DTS files so that dependent packages can see the types

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "types": "./types/index.d.ts"
 }


### PR DESCRIPTION
I couldn't see a reason why this wasn't set, but setting it means that the types in `types/*` as exported by the module can be used by other typescript dependencies, i.e. you don't get the "this module doesn't have types" warning.