### PR TITLE
move Mark class

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
   "_moduleAliases": {
     "@observablehq/plot": "./src/index.js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/plot.js"
+  ],
   "devDependencies": {
     "@esbuild-kit/core-utils": "^2.0.2",
     "@rollup/plugin-commonjs": "^23.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-export {plot, Mark, marks} from "./plot.js";
+export {plot, marks} from "./plot.js";
+export {Mark} from "./mark.js";
 export {Area, area, areaX, areaY} from "./marks/area.js";
 export {Arrow, arrow} from "./marks/arrow.js";
 export {BarX, BarY, barX, barY} from "./marks/bar.js";

--- a/src/mark.js
+++ b/src/mark.js
@@ -1,0 +1,73 @@
+import {Channels, channelDomain, valueObject} from "./channel.js";
+import {defined} from "./defined.js";
+import {arrayify, isDomainSort, range} from "./options.js";
+import {keyword, maybeNamed} from "./options.js";
+import {maybeProject} from "./projection.js";
+import {maybeClip, styles} from "./style.js";
+import {basic, initializer} from "./transforms/basic.js";
+
+export class Mark {
+  constructor(data, channels = {}, options = {}, defaults) {
+    const {facet = "auto", fx, fy, sort, dx, dy, clip, channels: extraChannels} = options;
+    this.data = data;
+    this.sort = isDomainSort(sort) ? sort : null;
+    this.initializer = initializer(options).initializer;
+    this.transform = this.initializer ? options.transform : basic(options).transform;
+    if (facet === null || facet === false) {
+      this.facet = null;
+    } else {
+      this.facet = keyword(facet === true ? "include" : facet, "facet", ["auto", "include", "exclude"]);
+      this.fx = fx;
+      this.fy = fy;
+    }
+    channels = maybeNamed(channels);
+    if (extraChannels !== undefined) channels = {...maybeNamed(extraChannels), ...channels};
+    if (defaults !== undefined) channels = {...styles(this, options, defaults), ...channels};
+    this.channels = Object.fromEntries(
+      Object.entries(channels).filter(([name, {value, optional}]) => {
+        if (value != null) return true;
+        if (optional) return false;
+        throw new Error(`missing channel value: ${name}`);
+      })
+    );
+    this.dx = +dx || 0;
+    this.dy = +dy || 0;
+    this.clip = maybeClip(clip);
+  }
+  initialize(facets, facetChannels) {
+    let data = arrayify(this.data);
+    if (facets === undefined && data != null) facets = [range(data)];
+    if (this.transform != null) ({facets, data} = this.transform(data, facets)), (data = arrayify(data));
+    const channels = Channels(this.channels, data);
+    if (this.sort != null) channelDomain(channels, facetChannels, data, this.sort); // mutates facetChannels!
+    return {data, facets, channels};
+  }
+  filter(index, channels, values) {
+    for (const name in channels) {
+      const {filter = defined} = channels[name];
+      if (filter !== null) {
+        const value = values[name];
+        index = index.filter((i) => filter(value[i]));
+      }
+    }
+    return index;
+  }
+  // If there is a projection, and there are both x and y channels (or x1 and
+  // y1, or x2 and y2 channels), and those channels are associated with the x
+  // and y scale respectively (and not already in screen coordinates as with an
+  // initializer), then apply the projection, replacing the x and y values. Note
+  // that the x and y scales themselves don’t exist if there is a projection,
+  // but whether the channels are associated with scales still determines
+  // whether the projection should apply; think of the projection as a
+  // combination xy-scale.
+  project(channels, values, context) {
+    maybeProject("x", "y", channels, values, context);
+    maybeProject("x1", "y1", channels, values, context);
+    maybeProject("x2", "y2", channels, values, context);
+  }
+  scale(channels, scales, context) {
+    const values = valueObject(channels, scales);
+    if (context.projection) this.project(channels, values, context);
+    return values;
+  }
+}

--- a/src/marks/area.js
+++ b/src/marks/area.js
@@ -2,7 +2,7 @@ import {area as shapeArea} from "d3";
 import {create} from "../context.js";
 import {Curve} from "../curve.js";
 import {first, indexOf, maybeZ, second} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {
   applyDirectStyles,
   applyIndirectStyles,

--- a/src/marks/arrow.js
+++ b/src/marks/arrow.js
@@ -1,7 +1,7 @@
 import {create} from "../context.js";
 import {radians} from "../math.js";
 import {constant} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransform} from "../style.js";
 import {maybeSameValue} from "./link.js";
 

--- a/src/marks/bar.js
+++ b/src/marks/bar.js
@@ -1,6 +1,6 @@
 import {create} from "../context.js";
 import {identity, indexOf, number} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {isCollapsed} from "../scales.js";
 import {
   applyDirectStyles,

--- a/src/marks/delaunay.js
+++ b/src/marks/delaunay.js
@@ -2,7 +2,7 @@ import {group, pathRound as path, select, Delaunay} from "d3";
 import {create} from "../context.js";
 import {Curve} from "../curve.js";
 import {constant, maybeTuple, maybeZ} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {
   applyChannelStyles,
   applyDirectStyles,

--- a/src/marks/density.js
+++ b/src/marks/density.js
@@ -1,6 +1,6 @@
 import {contourDensity, create, geoPath} from "d3";
 import {isTypedArray, maybeTuple, maybeZ} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {Position} from "../projection.js";
 import {coerceNumbers} from "../scales.js";
 import {

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -2,7 +2,7 @@ import {pathRound as path, symbolCircle} from "d3";
 import {create} from "../context.js";
 import {negative, positive} from "../defined.js";
 import {identity, maybeFrameAnchor, maybeNumberChannel, maybeTuple} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {
   applyChannelStyles,
   applyDirectStyles,

--- a/src/marks/frame.js
+++ b/src/marks/frame.js
@@ -1,6 +1,6 @@
 import {create} from "../context.js";
 import {number} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform} from "../style.js";
 
 const defaults = {

--- a/src/marks/geo.js
+++ b/src/marks/geo.js
@@ -2,7 +2,7 @@ import {geoGraticule10, geoPath, geoTransform} from "d3";
 import {create} from "../context.js";
 import {negative, positive} from "../defined.js";
 import {identity, maybeNumberChannel} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransform} from "../style.js";
 import {withDefaultSort} from "./dot.js";
 

--- a/src/marks/hexgrid.js
+++ b/src/marks/hexgrid.js
@@ -1,6 +1,6 @@
 import {create} from "../context.js";
 import {number} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, offset} from "../style.js";
 import {sqrt4_3} from "../symbols.js";
 import {ox, oy} from "../transforms/hexbin.js";

--- a/src/marks/image.js
+++ b/src/marks/image.js
@@ -1,7 +1,7 @@
 import {create} from "../context.js";
 import {positive} from "../defined.js";
 import {maybeFrameAnchor, maybeNumberChannel, maybeTuple, string} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {
   applyChannelStyles,
   applyDirectStyles,

--- a/src/marks/line.js
+++ b/src/marks/line.js
@@ -2,7 +2,7 @@ import {curveLinear, geoPath, line as shapeLine} from "d3";
 import {create} from "../context.js";
 import {Curve} from "../curve.js";
 import {indexOf, identity, maybeTuple, maybeZ} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {coerceNumbers} from "../scales.js";
 import {
   applyDirectStyles,

--- a/src/marks/linearRegression.js
+++ b/src/marks/linearRegression.js
@@ -1,7 +1,7 @@
 import {extent, range, sum, area as shapeArea, namespaces} from "d3";
 import {create} from "../context.js";
 import {identity, indexOf, isNone, isNoneish, maybeZ} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {qt} from "../stats.js";
 import {applyDirectStyles, applyGroupedChannelStyles, applyIndirectStyles, applyTransform, groupZ} from "../style.js";
 import {maybeDenseIntervalX, maybeDenseIntervalY} from "../transforms/bin.js";

--- a/src/marks/link.js
+++ b/src/marks/link.js
@@ -1,7 +1,7 @@
 import {pathRound as path} from "d3";
 import {create} from "../context.js";
 import {Curve} from "../curve.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransform} from "../style.js";
 import {markers, applyMarkers} from "./marker.js";
 

--- a/src/marks/raster.js
+++ b/src/marks/raster.js
@@ -3,7 +3,7 @@ import {valueObject} from "../channel.js";
 import {create} from "../context.js";
 import {map, first, second, third, isTuples, isNumeric, isTemporal, take, identity} from "../options.js";
 import {maybeColorChannel, maybeNumberChannel} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {applyAttr, applyDirectStyles, applyIndirectStyles, applyTransform, impliedString} from "../style.js";
 import {initializer} from "../transforms/basic.js";
 

--- a/src/marks/rect.js
+++ b/src/marks/rect.js
@@ -1,6 +1,6 @@
 import {create} from "../context.js";
 import {identity, indexOf, number} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {isCollapsed} from "../scales.js";
 import {
   applyDirectStyles,

--- a/src/marks/rule.js
+++ b/src/marks/rule.js
@@ -1,6 +1,6 @@
 import {create} from "../context.js";
 import {identity, number} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {isCollapsed} from "../scales.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyChannelStyles, offset} from "../style.js";
 import {maybeIntervalX, maybeIntervalY} from "../transforms/interval.js";

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -16,7 +16,7 @@ import {
   isTextual,
   isIterable
 } from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {
   applyChannelStyles,
   applyDirectStyles,

--- a/src/marks/tick.js
+++ b/src/marks/tick.js
@@ -1,6 +1,6 @@
 import {create} from "../context.js";
 import {identity, number} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyChannelStyles, offset} from "../style.js";
 
 const defaults = {

--- a/src/marks/vector.js
+++ b/src/marks/vector.js
@@ -1,7 +1,7 @@
 import {pathRound as path} from "d3";
 import {create} from "../context.js";
 import {maybeFrameAnchor, maybeNumberChannel, maybeTuple, keyword, identity} from "../options.js";
-import {Mark} from "../plot.js";
+import {Mark} from "../mark.js";
 import {
   applyChannelStyles,
   applyDirectStyles,

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,17 +1,14 @@
 import {cross, group, sum, select, sort, InternMap, rollup} from "d3";
 import {Axes, autoAxisTicks, autoScaleLabels} from "./axes.js";
-import {Channel, Channels, channelDomain, valueObject} from "./channel.js";
+import {Channel} from "./channel.js";
 import {Context, create} from "./context.js";
-import {defined} from "./defined.js";
 import {Dimensions} from "./dimensions.js";
 import {Legends, exposeLegends} from "./legends.js";
-import {arrayify, isDomainSort, isScaleOptions, keyword, map, range, where, yes} from "./options.js";
-import {maybeNamed, maybeInterval} from "./options.js";
-import {maybeProject} from "./projection.js";
+import {Mark} from "./mark.js";
+import {arrayify, isScaleOptions, map, range, where, yes, maybeInterval} from "./options.js";
 import {Scales, ScaleFunctions, autoScaleRange, exposeScales} from "./scales.js";
 import {position, registry as scaleRegistry} from "./scales/index.js";
-import {applyInlineStyles, maybeClassName, maybeClip, styles} from "./style.js";
-import {basic, initializer} from "./transforms/basic.js";
+import {applyInlineStyles, maybeClassName} from "./style.js";
 import {consumeWarnings, warn} from "./warnings.js";
 
 /** @jsdoc plot */
@@ -22,7 +19,7 @@ export function plot(options = {}) {
   const className = maybeClassName(options.className);
 
   // Flatten any nested marks.
-  const marks = options.marks === undefined ? [] : options.marks.flat(Infinity).map(markify);
+  const marks = options.marks === undefined ? [] : flatMarks(options.marks);
 
   // Compute the top-level facet state. This has roughly the same structure as
   // mark-specific facet state, except there isn’t a facetsIndex, and there’s a
@@ -360,90 +357,34 @@ export function plot(options = {}) {
   return figure;
 }
 
-export class Mark {
-  constructor(data, channels = {}, options = {}, defaults) {
-    const {facet = "auto", fx, fy, sort, dx, dy, clip, channels: extraChannels} = options;
-    this.data = data;
-    this.sort = isDomainSort(sort) ? sort : null;
-    this.initializer = initializer(options).initializer;
-    this.transform = this.initializer ? options.transform : basic(options).transform;
-    if (facet === null || facet === false) {
-      this.facet = null;
-    } else {
-      this.facet = keyword(facet === true ? "include" : facet, "facet", ["auto", "include", "exclude"]);
-      this.fx = fx;
-      this.fy = fy;
-    }
-    channels = maybeNamed(channels);
-    if (extraChannels !== undefined) channels = {...maybeNamed(extraChannels), ...channels};
-    if (defaults !== undefined) channels = {...styles(this, options, defaults), ...channels};
-    this.channels = Object.fromEntries(
-      Object.entries(channels).filter(([name, {value, optional}]) => {
-        if (value != null) return true;
-        if (optional) return false;
-        throw new Error(`missing channel value: ${name}`);
-      })
-    );
-    this.dx = +dx || 0;
-    this.dy = +dy || 0;
-    this.clip = maybeClip(clip);
-  }
-  initialize(facets, facetChannels) {
-    let data = arrayify(this.data);
-    if (facets === undefined && data != null) facets = [range(data)];
-    if (this.transform != null) ({facets, data} = this.transform(data, facets)), (data = arrayify(data));
-    const channels = Channels(this.channels, data);
-    if (this.sort != null) channelDomain(channels, facetChannels, data, this.sort); // mutates facetChannels!
-    return {data, facets, channels};
-  }
-  filter(index, channels, values) {
-    for (const name in channels) {
-      const {filter = defined} = channels[name];
-      if (filter !== null) {
-        const value = values[name];
-        index = index.filter((i) => filter(value[i]));
-      }
-    }
-    return index;
-  }
-  // If there is a projection, and there are both x and y channels (or x1 and
-  // y1, or x2 and y2 channels), and those channels are associated with the x
-  // and y scale respectively (and not already in screen coordinates as with an
-  // initializer), then apply the projection, replacing the x and y values. Note
-  // that the x and y scales themselves don’t exist if there is a projection,
-  // but whether the channels are associated with scales still determines
-  // whether the projection should apply; think of the projection as a
-  // combination xy-scale.
-  project(channels, values, context) {
-    maybeProject("x", "y", channels, values, context);
-    maybeProject("x1", "y1", channels, values, context);
-    maybeProject("x2", "y2", channels, values, context);
-  }
-  scale(channels, scales, context) {
-    const values = valueObject(channels, scales);
-    if (context.projection) this.project(channels, values, context);
-    return values;
-  }
-  plot({marks = [], ...options} = {}) {
-    return plot({...options, marks: [...marks, this]});
-  }
+function plotThis({marks = [], ...options} = {}) {
+  return plot({...options, marks: [...marks, this]});
 }
+
+// Note: This side-effect avoids a circular dependency.
+Mark.prototype.plot = plotThis;
 
 /** @jsdoc marks */
 export function marks(...marks) {
-  marks.plot = Mark.prototype.plot;
+  marks.plot = plotThis;
   return marks;
 }
 
+function flatMarks(marks) {
+  return marks
+    .flat(Infinity)
+    .filter((mark) => mark != null)
+    .map(markify);
+}
+
 function markify(mark) {
-  return typeof mark?.render === "function" ? mark : new Render(mark);
+  return typeof mark.render === "function" ? mark : new Render(mark);
 }
 
 class Render extends Mark {
   constructor(render) {
-    super();
-    if (render == null) return;
     if (typeof render !== "function") throw new TypeError("invalid mark; missing render function");
+    super();
     this.render = render;
   }
   render() {}


### PR DESCRIPTION
This is broken out of #1197 so that we can minimize the drift from main and make it easier to keep the axis mark branch up-to-date with changes. There are no functional changes in this PR; just moving code (and tweaking how we handle null marks, but the difference should not be externally visible).