### PR TITLE
avoid spurious facet anchor

### DIFF
--- a/src/facet.js
+++ b/src/facet.js
@@ -117,42 +117,38 @@ function facetAnchorRight(facets, {x: X}, {x}) {
   return X ? X.indexOf(x) === X.length - 1 : true;
 }
 
-function facetAnchorTopEmpty(facets, {y: Y}, {x, y}) {
+function facetAnchorTopEmpty(facets, {y: Y}, {x, y, empty}) {
+  if (empty) return false;
   const i = Y?.indexOf(y);
-  if (i > 0) {
-    const y = Y[i - 1];
-    return facets.find((f) => f.x === x && f.y === y)?.empty;
-  }
+  if (i > 0) return isEmptyFacet(facets, {x, y: Y[i - 1]});
 }
 
-function facetAnchorBottomEmpty(facets, {y: Y}, {x, y}) {
+function facetAnchorBottomEmpty(facets, {y: Y}, {x, y, empty}) {
+  if (empty) return false;
   const i = Y?.indexOf(y);
-  if (i < Y?.length - 1) {
-    const y = Y[i + 1];
-    return facets.find((f) => f.x === x && f.y === y)?.empty;
-  }
+  if (i < Y?.length - 1) return isEmptyFacet(facets, {x, y: Y[i + 1]});
 }
 
-function facetAnchorLeftEmpty(facets, {x: X}, {x, y}) {
+function facetAnchorLeftEmpty(facets, {x: X}, {x, y, empty}) {
+  if (empty) return false;
   const i = X?.indexOf(x);
-  if (i > 0) {
-    const x = X[i - 1];
-    return facets.find((f) => f.x === x && f.y === y)?.empty;
-  }
+  if (i > 0) return isEmptyFacet(facets, {x: X[i - 1], y});
 }
 
-function facetAnchorRightEmpty(facets, {x: X}, {x, y}) {
+function facetAnchorRightEmpty(facets, {x: X}, {x, y, empty}) {
+  if (empty) return false;
   const i = X?.indexOf(x);
-  if (i < X?.length - 1) {
-    const x = X[i + 1];
-    return facets.find((f) => f.x === x && f.y === y)?.empty;
-  }
+  if (i < X?.length - 1) return isEmptyFacet(facets, {x: X[i + 1], y});
 }
 
 function and(a, b) {
   return function () {
     return a.apply(null, arguments) && b.apply(null, arguments);
   };
+}
+
+function isEmptyFacet(facets, {x, y}) {
+  return facets.find((f) => f.x === x && f.y === y)?.empty;
 }
 
 // Facet filter, by mark; for now only the "eq" filter is provided.

--- a/src/facet.js
+++ b/src/facet.js
@@ -120,35 +120,43 @@ function facetAnchorRight(facets, {x: X}, {x}) {
 function facetAnchorTopEmpty(facets, {y: Y}, {x, y, empty}) {
   if (empty) return false;
   const i = Y?.indexOf(y);
-  if (i > 0) return isEmptyFacet(facets, {x, y: Y[i - 1]});
+  if (i > 0) {
+    const y = Y[i - 1];
+    return facets.find((f) => f.x === x && f.y === y)?.empty;
+  }
 }
 
 function facetAnchorBottomEmpty(facets, {y: Y}, {x, y, empty}) {
   if (empty) return false;
   const i = Y?.indexOf(y);
-  if (i < Y?.length - 1) return isEmptyFacet(facets, {x, y: Y[i + 1]});
+  if (i < Y?.length - 1) {
+    const y = Y[i + 1];
+    return facets.find((f) => f.x === x && f.y === y)?.empty;
+  }
 }
 
 function facetAnchorLeftEmpty(facets, {x: X}, {x, y, empty}) {
   if (empty) return false;
   const i = X?.indexOf(x);
-  if (i > 0) return isEmptyFacet(facets, {x: X[i - 1], y});
+  if (i > 0) {
+    const x = X[i - 1];
+    return facets.find((f) => f.x === x && f.y === y)?.empty;
+  }
 }
 
 function facetAnchorRightEmpty(facets, {x: X}, {x, y, empty}) {
   if (empty) return false;
   const i = X?.indexOf(x);
-  if (i < X?.length - 1) return isEmptyFacet(facets, {x: X[i + 1], y});
+  if (i < X?.length - 1) {
+    const x = X[i + 1];
+    return facets.find((f) => f.x === x && f.y === y)?.empty;
+  }
 }
 
 function and(a, b) {
   return function () {
     return a.apply(null, arguments) && b.apply(null, arguments);
   };
-}
-
-function isEmptyFacet(facets, {x, y}) {
-  return facets.find((f) => f.x === x && f.y === y)?.empty;
 }
 
 // Facet filter, by mark; for now only the "eq" filter is provided.

--- a/test/output/autoDotFacet2.svg
+++ b/test/output/autoDotFacet2.svg
@@ -13,9 +13,9 @@
       white-space: pre;
     }
   </style>
-  <g aria-label="facet" transform="translate(1,0)">
+  <g aria-label="facet" transform="translate(0,0)">
     <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
-      <text transform="translate(122,30)">Biscoe</text>
+      <text transform="translate(127,30)">Biscoe</text>
     </g>
     <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
       <path transform="translate(40,155.23636363636365)" d="M0,0L-6,0"></path>
@@ -32,66 +32,62 @@
       <text y="0.32em" transform="translate(40,53.41818181818183)">55</text>
     </g>
     <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-      <path transform="translate(53.666666666666664,170)" d="M0,0L0,6"></path>
-      <path transform="translate(99.22222222222223,170)" d="M0,0L0,6"></path>
-      <path transform="translate(144.77777777777777,170)" d="M0,0L0,6"></path>
-      <path transform="translate(190.33333333333334,170)" d="M0,0L0,6"></path>
+      <path transform="translate(102.83333333333333,170)" d="M0,0L0,6"></path>
+      <path transform="translate(199.5,170)" d="M0,0L0,6"></path>
     </g>
     <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-      <text y="0.71em" transform="translate(53.666666666666664,170)">3,000</text>
-      <text y="0.71em" transform="translate(99.22222222222223,170)">4,000</text>
-      <text y="0.71em" transform="translate(144.77777777777777,170)">5,000</text>
-      <text y="0.71em" transform="translate(190.33333333333334,170)">6,000</text>
+      <text y="0.71em" transform="translate(102.83333333333333,170)">4,000</text>
+      <text y="0.71em" transform="translate(199.5,170)">6,000</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="71.88888888888889" cy="140.98181818181823" r="3" stroke="#4e79a7"></circle>
-      <circle cx="81" cy="141.4909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="90.11111111111111" cy="150.65454545454548" r="3" stroke="#4e79a7"></circle>
-      <circle cx="96.94444444444444" cy="138.94545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="90.11111111111111" cy="135.89090909090913" r="3" stroke="#f28e2c"></circle>
-      <circle cx="90.11111111111111" cy="153.70909090909095" r="3" stroke="#4e79a7"></circle>
-      <circle cx="78.72222222222221" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="62.77777777777778" cy="127.23636363636363" r="3" stroke="#4e79a7"></circle>
-      <circle cx="60.5" cy="140.47272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="96.94444444444444" cy="127.23636363636363" r="3" stroke="#f28e2c"></circle>
-      <circle cx="76.44444444444444" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="112.88888888888889" cy="129.27272727272728" r="3" stroke="#f28e2c"></circle>
-      <circle cx="74.16666666666666" cy="155.23636363636365" r="3" stroke="#4e79a7"></circle>
-      <circle cx="101.5" cy="119.60000000000002" r="3" stroke="#f28e2c"></circle>
-      <circle cx="49.111111111111114" cy="157.7818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="85.55555555555556" cy="122.65454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="78.72222222222221" cy="134.87272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="90.11111111111111" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="46.833333333333336" cy="147.60000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="87.83333333333334" cy="142" r="3" stroke="#f28e2c"></circle>
-      <circle cx="60.5" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.44444444444444" cy="123.16363636363639" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81" cy="142" r="3" stroke="#4e79a7"></circle>
-      <circle cx="101.5" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="46.833333333333336" cy="148.10909090909092" r="3" stroke="#4e79a7"></circle>
-      <circle cx="96.94444444444444" cy="121.63636363636363" r="3" stroke="#f28e2c"></circle>
-      <circle cx="69.61111111111111" cy="152.69090909090912" r="3" stroke="#4e79a7"></circle>
-      <circle cx="103.77777777777777" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="86.69444444444444" cy="155.23636363636365" r="3" stroke="#4e79a7"></circle>
-      <circle cx="132.25" cy="124.69090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="57.083333333333336" cy="141.4909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="110.61111111111111" cy="140.98181818181823" r="3" stroke="#f28e2c"></circle>
-      <circle cx="50.25" cy="140.47272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="78.72222222222221" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="87.83333333333334" cy="136.9090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="94.66666666666667" cy="138.94545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="61.638888888888886" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
-      <circle cx="134.52777777777777" cy="113.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="91.25" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
-      <circle cx="126.55555555555556" cy="101.27272727272725" r="3" stroke="#f28e2c"></circle>
-      <circle cx="62.77777777777778" cy="131.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="111.75" cy="118.58181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="94.66666666666667" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="102.63888888888889" cy="116.03636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="73.83333333333334" cy="140.98181818181823" r="3" stroke="#4e79a7"></circle>
+      <circle cx="83.5" cy="141.4909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="93.16666666666669" cy="150.65454545454548" r="3" stroke="#4e79a7"></circle>
+      <circle cx="100.41666666666667" cy="138.94545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="93.16666666666669" cy="135.89090909090913" r="3" stroke="#f28e2c"></circle>
+      <circle cx="93.16666666666669" cy="153.70909090909095" r="3" stroke="#4e79a7"></circle>
+      <circle cx="81.08333333333333" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="64.16666666666667" cy="127.23636363636363" r="3" stroke="#4e79a7"></circle>
+      <circle cx="61.75" cy="140.47272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="100.41666666666667" cy="127.23636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="78.66666666666666" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.33333333333331" cy="129.27272727272728" r="3" stroke="#f28e2c"></circle>
+      <circle cx="76.25" cy="155.23636363636365" r="3" stroke="#4e79a7"></circle>
+      <circle cx="105.25" cy="119.60000000000002" r="3" stroke="#f28e2c"></circle>
+      <circle cx="49.666666666666664" cy="157.7818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="88.33333333333334" cy="122.65454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81.08333333333333" cy="134.87272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="93.16666666666669" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="47.25" cy="147.60000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="90.75" cy="142" r="3" stroke="#f28e2c"></circle>
+      <circle cx="61.75" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
+      <circle cx="122.16666666666667" cy="123.16363636363639" r="3" stroke="#f28e2c"></circle>
+      <circle cx="83.5" cy="142" r="3" stroke="#4e79a7"></circle>
+      <circle cx="105.25" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="47.25" cy="148.10909090909092" r="3" stroke="#4e79a7"></circle>
+      <circle cx="100.41666666666667" cy="121.63636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.41666666666666" cy="152.69090909090912" r="3" stroke="#4e79a7"></circle>
+      <circle cx="107.66666666666667" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="89.54166666666666" cy="155.23636363636365" r="3" stroke="#4e79a7"></circle>
+      <circle cx="137.875" cy="124.69090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="58.125" cy="141.4909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="114.91666666666669" cy="140.98181818181823" r="3" stroke="#f28e2c"></circle>
+      <circle cx="50.875" cy="140.47272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="81.08333333333333" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.75" cy="136.9090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="98" cy="138.94545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="62.95833333333333" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
+      <circle cx="140.29166666666666" cy="113.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="94.375" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
+      <circle cx="131.83333333333334" cy="101.27272727272725" r="3" stroke="#f28e2c"></circle>
+      <circle cx="64.16666666666667" cy="131.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="116.125" cy="118.58181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="98" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="106.45833333333331" cy="116.03636363636363" r="3" stroke="#f28e2c"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(1,310)">
+  <g aria-label="facet" transform="translate(0,310)">
     <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
       <path transform="translate(40,155.23636363636365)" d="M0,0L-6,0"></path>
       <path transform="translate(40,129.78181818181818)" d="M0,0L-6,0"></path>
@@ -107,209 +103,205 @@
       <text y="0.32em" transform="translate(40,53.41818181818183)">55</text>
     </g>
     <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-      <path transform="translate(53.666666666666664,170)" d="M0,0L0,6"></path>
-      <path transform="translate(99.22222222222223,170)" d="M0,0L0,6"></path>
-      <path transform="translate(144.77777777777777,170)" d="M0,0L0,6"></path>
-      <path transform="translate(190.33333333333334,170)" d="M0,0L0,6"></path>
+      <path transform="translate(102.83333333333333,170)" d="M0,0L0,6"></path>
+      <path transform="translate(199.5,170)" d="M0,0L0,6"></path>
     </g>
     <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-      <text y="0.71em" transform="translate(53.666666666666664,170)">3,000</text>
-      <text y="0.71em" transform="translate(99.22222222222223,170)">4,000</text>
-      <text y="0.71em" transform="translate(144.77777777777777,170)">5,000</text>
-      <text y="0.71em" transform="translate(190.33333333333334,170)">6,000</text>
+      <text y="0.71em" transform="translate(102.83333333333333,170)">4,000</text>
+      <text y="0.71em" transform="translate(199.5,170)">6,000</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="122" cy="98.72727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="176.66666666666666" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="119.72222222222223" cy="85.49090909090908" r="3" stroke="#4e79a7"></circle>
-      <circle cx="176.66666666666666" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="163" cy="91.0909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="124.27777777777777" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="135.66666666666669" cy="102.2909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="153.88888888888889" cy="95.67272727272726" r="3" stroke="#f28e2c"></circle>
-      <circle cx="117.44444444444444" cy="112.98181818181821" r="3" stroke="#4e79a7"></circle>
-      <circle cx="151.61111111111111" cy="95.16363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="128.83333333333331" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="169.83333333333334" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="128.83333333333331" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="183.5" cy="87.01818181818183" r="3" stroke="#f28e2c"></circle>
-      <circle cx="108.33333333333333" cy="100.25454545454546" r="3" stroke="#4e79a7"></circle>
-      <circle cx="183.5" cy="82.43636363636367" r="3" stroke="#f28e2c"></circle>
-      <circle cx="106.05555555555556" cy="119.60000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="204" cy="82.94545454545455" r="3" stroke="#f28e2c"></circle>
-      <circle cx="135.66666666666669" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="160.72222222222223" cy="85.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="176.66666666666666" cy="77.85454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="144.77777777777777" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.44444444444444" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="147.05555555555554" cy="97.70909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="144.77777777777777" cy="115.01818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="149.33333333333334" cy="98.72727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="103.77777777777777" cy="106.87272727272727" r="3" stroke="#e15759"></circle>
-      <circle cx="174.38888888888889" cy="90.0727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="126.55555555555556" cy="88.03636363636362" r="3" stroke="#4e79a7"></circle>
-      <circle cx="169.83333333333334" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="156.16666666666666" cy="92.61818181818184" r="3" stroke="#f28e2c"></circle>
-      <circle cx="131.11111111111111" cy="115.52727272727276" r="3" stroke="#4e79a7"></circle>
-      <circle cx="147.05555555555554" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="192.61111111111111" cy="30" r="3" stroke="#f28e2c"></circle>
-      <circle cx="151.61111111111111" cy="83.45454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="163" cy="87.01818181818183" r="3" stroke="#f28e2c"></circle>
-      <circle cx="142.5" cy="116.54545454545455" r="3" stroke="#4e79a7"></circle>
-      <circle cx="156.16666666666666" cy="107.3818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="115.16666666666667" cy="109.41818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="160.72222222222223" cy="85.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="96.94444444444444" cy="116.03636363636363" r="3" stroke="#4e79a7"></circle>
-      <circle cx="176.66666666666666" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="112.88888888888889" cy="102.80000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="133.38888888888889" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="169.83333333333334" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="140.22222222222223" cy="111.45454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="108.33333333333333" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="163" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="149.33333333333334" cy="104.83636363636364" r="3" stroke="#4e79a7"></circle>
-      <circle cx="158.44444444444446" cy="103.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="137.94444444444443" cy="96.18181818181819" r="3" stroke="#4e79a7"></circle>
-      <circle cx="158.44444444444446" cy="86.50909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="117.44444444444444" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="144.77777777777777" cy="78.36363636363636" r="3" stroke="#f28e2c"></circle>
-      <circle cx="140.22222222222223" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="147.05555555555554" cy="104.32727272727274" r="3" stroke="#f28e2c"></circle>
-      <circle cx="112.88888888888889" cy="110.43636363636367" r="3" stroke="#4e79a7"></circle>
-      <circle cx="144.77777777777777" cy="101.78181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="119.72222222222223" cy="113.49090909090908" r="3" stroke="#4e79a7"></circle>
-      <circle cx="169.83333333333334" cy="76.83636363636366" r="3" stroke="#f28e2c"></circle>
-      <circle cx="108.33333333333333" cy="102.80000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="158.44444444444446" cy="98.21818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="117.44444444444444" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="174.38888888888889" cy="56.9818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="131.11111111111111" cy="100.25454545454546" r="3" stroke="#4e79a7"></circle>
-      <circle cx="176.66666666666666" cy="79.89090909090912" r="3" stroke="#f28e2c"></circle>
-      <circle cx="128.83333333333331" cy="98.21818181818182" r="3" stroke="#e15759"></circle>
-      <circle cx="181.22222222222223" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="131.11111111111111" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="169.83333333333334" cy="75.30909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="133.38888888888889" cy="90.58181818181816" r="3" stroke="#4e79a7"></circle>
-      <circle cx="144.77777777777777" cy="97.20000000000002" r="3" stroke="#f28e2c"></circle>
-      <circle cx="149.33333333333334" cy="88.03636363636362" r="3" stroke="#f28e2c"></circle>
-      <circle cx="153.88888888888889" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="131.11111111111111" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="181.22222222222223" cy="86" r="3" stroke="#f28e2c"></circle>
-      <circle cx="126.55555555555556" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="190.33333333333334" cy="73.27272727272728" r="3" stroke="#f28e2c"></circle>
-      <circle cx="133.38888888888889" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="188.05555555555554" cy="103.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="127.69444444444444" cy="83.45454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="165.27777777777777" cy="66.14545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="132.25" cy="92.10909090909092" r="3" stroke="#4e79a7"></circle>
-      <circle cx="160.72222222222223" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="133.38888888888889" cy="104.83636363636364" r="3" stroke="#4e79a7"></circle>
-      <circle cx="172.11111111111111" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
-      <circle cx="126.55555555555556" cy="112.4727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="158.44444444444446" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="139.08333333333331" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="169.83333333333334" cy="68.18181818181819" r="3" stroke="#f28e2c"></circle>
-      <circle cx="142.5" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="163" cy="67.67272727272726" r="3" stroke="#f28e2c"></circle>
-      <circle cx="133.38888888888889" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="174.38888888888889" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="137.94444444444443" cy="106.87272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="153.88888888888889" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
-      <circle cx="141.36111111111111" cy="81.92727272727274" r="3" stroke="#f28e2c"></circle>
-      <circle cx="139.08333333333331" cy="94.65454545454547" r="3" stroke="#4e79a7"></circle>
-      <circle cx="127.69444444444444" cy="87.01818181818183" r="3" stroke="#4e79a7"></circle>
-      <circle cx="156.16666666666666" cy="73.27272727272728" r="3" stroke="#f28e2c"></circle>
-      <circle cx="137.94444444444443" cy="86.50909090909092" r="3" stroke="#4e79a7"></circle>
-      <circle cx="172.11111111111111" cy="48.83636363636365" r="3" stroke="#f28e2c"></circle>
-      <circle cx="143.63888888888889" cy="93.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="167.55555555555554" cy="83.45454545454545" r="3" stroke="#f28e2c"></circle>
-      <circle cx="132.25" cy="92.61818181818184" r="3" stroke="#e15759"></circle>
-      <circle cx="167.55555555555554" cy="95.16363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="131.11111111111111" cy="121.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="167.55555555555554" cy="61.563636363636384" r="3" stroke="#f28e2c"></circle>
-      <circle cx="125.41666666666669" cy="112.98181818181821" r="3" stroke="#4e79a7"></circle>
-      <circle cx="167.55555555555554" cy="88.54545454545455" r="3" stroke="#f28e2c"></circle>
-      <circle cx="144.77777777777777" cy="76.32727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="188.05555555555554" cy="79.89090909090912" r="3" stroke="#f28e2c"></circle>
-      <circle cx="128.83333333333331" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="167.55555555555554" cy="71.23636363636365" r="3" stroke="#f28e2c"></circle>
-      <circle cx="116.30555555555556" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="183.5" cy="52.90909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="139.08333333333331" cy="106.87272727272727" r="3" stroke="#e15759"></circle>
-      <circle cx="190.33333333333334" cy="84.9818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="141.36111111111111" cy="93.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="137.94444444444443" cy="95.16363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="178.94444444444446" cy="76.83636363636366" r="3" stroke="#f28e2c"></circle>
-      <circle cx="153.88888888888889" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="163" cy="79.38181818181819" r="3" stroke="#f28e2c"></circle>
+      <circle cx="127" cy="98.72727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="185" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="124.58333333333333" cy="85.49090909090908" r="3" stroke="#4e79a7"></circle>
+      <circle cx="185" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="170.5" cy="91.0909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="129.41666666666666" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="141.5" cy="102.2909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="160.83333333333334" cy="95.67272727272726" r="3" stroke="#f28e2c"></circle>
+      <circle cx="122.16666666666667" cy="112.98181818181821" r="3" stroke="#4e79a7"></circle>
+      <circle cx="158.41666666666666" cy="95.16363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="134.25" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="177.75" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="134.25" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="192.25" cy="87.01818181818183" r="3" stroke="#f28e2c"></circle>
+      <circle cx="112.5" cy="100.25454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="192.25" cy="82.43636363636367" r="3" stroke="#f28e2c"></circle>
+      <circle cx="110.08333333333333" cy="119.60000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="214" cy="82.94545454545455" r="3" stroke="#f28e2c"></circle>
+      <circle cx="141.5" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="168.08333333333334" cy="85.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="185" cy="77.85454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="151.16666666666666" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="122.16666666666667" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.58333333333334" cy="97.70909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="151.16666666666666" cy="115.01818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="156" cy="98.72727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="107.66666666666667" cy="106.87272727272727" r="3" stroke="#e15759"></circle>
+      <circle cx="182.58333333333334" cy="90.0727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="131.83333333333334" cy="88.03636363636362" r="3" stroke="#4e79a7"></circle>
+      <circle cx="177.75" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="163.25" cy="92.61818181818184" r="3" stroke="#f28e2c"></circle>
+      <circle cx="136.66666666666669" cy="115.52727272727276" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.58333333333334" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="201.91666666666666" cy="30" r="3" stroke="#f28e2c"></circle>
+      <circle cx="158.41666666666666" cy="83.45454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="170.5" cy="87.01818181818183" r="3" stroke="#f28e2c"></circle>
+      <circle cx="148.75" cy="116.54545454545455" r="3" stroke="#4e79a7"></circle>
+      <circle cx="163.25" cy="107.3818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="119.75" cy="109.41818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="168.08333333333334" cy="85.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="100.41666666666667" cy="116.03636363636363" r="3" stroke="#4e79a7"></circle>
+      <circle cx="185" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="117.33333333333331" cy="102.80000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="139.08333333333331" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="177.75" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="146.33333333333334" cy="111.45454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="112.5" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="170.5" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="156" cy="104.83636363636364" r="3" stroke="#4e79a7"></circle>
+      <circle cx="165.66666666666666" cy="103.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="143.91666666666666" cy="96.18181818181819" r="3" stroke="#4e79a7"></circle>
+      <circle cx="165.66666666666666" cy="86.50909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="122.16666666666667" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="151.16666666666666" cy="78.36363636363636" r="3" stroke="#f28e2c"></circle>
+      <circle cx="146.33333333333334" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.58333333333334" cy="104.32727272727274" r="3" stroke="#f28e2c"></circle>
+      <circle cx="117.33333333333331" cy="110.43636363636367" r="3" stroke="#4e79a7"></circle>
+      <circle cx="151.16666666666666" cy="101.78181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="124.58333333333333" cy="113.49090909090908" r="3" stroke="#4e79a7"></circle>
+      <circle cx="177.75" cy="76.83636363636366" r="3" stroke="#f28e2c"></circle>
+      <circle cx="112.5" cy="102.80000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="165.66666666666666" cy="98.21818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="122.16666666666667" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="182.58333333333334" cy="56.9818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="136.66666666666669" cy="100.25454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="185" cy="79.89090909090912" r="3" stroke="#f28e2c"></circle>
+      <circle cx="134.25" cy="98.21818181818182" r="3" stroke="#e15759"></circle>
+      <circle cx="189.83333333333334" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="136.66666666666669" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="177.75" cy="75.30909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="139.08333333333331" cy="90.58181818181816" r="3" stroke="#4e79a7"></circle>
+      <circle cx="151.16666666666666" cy="97.20000000000002" r="3" stroke="#f28e2c"></circle>
+      <circle cx="156" cy="88.03636363636362" r="3" stroke="#f28e2c"></circle>
+      <circle cx="160.83333333333334" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="136.66666666666669" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="189.83333333333334" cy="86" r="3" stroke="#f28e2c"></circle>
+      <circle cx="131.83333333333334" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="199.5" cy="73.27272727272728" r="3" stroke="#f28e2c"></circle>
+      <circle cx="139.08333333333331" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="197.08333333333334" cy="103.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="133.04166666666666" cy="83.45454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="172.91666666666666" cy="66.14545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="137.875" cy="92.10909090909092" r="3" stroke="#4e79a7"></circle>
+      <circle cx="168.08333333333334" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="139.08333333333331" cy="104.83636363636364" r="3" stroke="#4e79a7"></circle>
+      <circle cx="180.16666666666666" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
+      <circle cx="131.83333333333334" cy="112.4727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="165.66666666666666" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="145.125" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="177.75" cy="68.18181818181819" r="3" stroke="#f28e2c"></circle>
+      <circle cx="148.75" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="170.5" cy="67.67272727272726" r="3" stroke="#f28e2c"></circle>
+      <circle cx="139.08333333333331" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="182.58333333333334" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="143.91666666666666" cy="106.87272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="160.83333333333334" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
+      <circle cx="147.54166666666666" cy="81.92727272727274" r="3" stroke="#f28e2c"></circle>
+      <circle cx="145.125" cy="94.65454545454547" r="3" stroke="#4e79a7"></circle>
+      <circle cx="133.04166666666666" cy="87.01818181818183" r="3" stroke="#4e79a7"></circle>
+      <circle cx="163.25" cy="73.27272727272728" r="3" stroke="#f28e2c"></circle>
+      <circle cx="143.91666666666666" cy="86.50909090909092" r="3" stroke="#4e79a7"></circle>
+      <circle cx="180.16666666666666" cy="48.83636363636365" r="3" stroke="#f28e2c"></circle>
+      <circle cx="149.95833333333334" cy="93.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="175.33333333333334" cy="83.45454545454545" r="3" stroke="#f28e2c"></circle>
+      <circle cx="137.875" cy="92.61818181818184" r="3" stroke="#e15759"></circle>
+      <circle cx="175.33333333333334" cy="95.16363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="136.66666666666669" cy="121.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="175.33333333333334" cy="61.563636363636384" r="3" stroke="#f28e2c"></circle>
+      <circle cx="130.625" cy="112.98181818181821" r="3" stroke="#4e79a7"></circle>
+      <circle cx="175.33333333333334" cy="88.54545454545455" r="3" stroke="#f28e2c"></circle>
+      <circle cx="151.16666666666666" cy="76.32727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="197.08333333333334" cy="79.89090909090912" r="3" stroke="#f28e2c"></circle>
+      <circle cx="134.25" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="175.33333333333334" cy="71.23636363636365" r="3" stroke="#f28e2c"></circle>
+      <circle cx="120.95833333333333" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="192.25" cy="52.90909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="145.125" cy="106.87272727272727" r="3" stroke="#e15759"></circle>
+      <circle cx="199.5" cy="84.9818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="147.54166666666666" cy="93.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="143.91666666666666" cy="95.16363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="187.41666666666666" cy="76.83636363636366" r="3" stroke="#f28e2c"></circle>
+      <circle cx="160.83333333333334" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="170.5" cy="79.38181818181819" r="3" stroke="#f28e2c"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(183,0)">
+  <g aria-label="facet" transform="translate(193,0)">
     <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
-      <text transform="translate(122,30)">Dream</text>
+      <text transform="translate(127,30)">Dream</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="65.05555555555556" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
-      <circle cx="94.66666666666667" cy="144.03636363636363" r="3" stroke="#f28e2c"></circle>
-      <circle cx="67.33333333333334" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
-      <circle cx="94.66666666666667" cy="125.20000000000002" r="3" stroke="#f28e2c"></circle>
-      <circle cx="68.47222222222223" cy="148.10909090909092" r="3" stroke="#4e79a7"></circle>
-      <circle cx="106.05555555555556" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
-      <circle cx="96.94444444444444" cy="135.89090909090913" r="3" stroke="#f28e2c"></circle>
-      <circle cx="78.72222222222221" cy="118.58181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="67.33333333333334" cy="142" r="3" stroke="#4e79a7"></circle>
-      <circle cx="128.83333333333331" cy="130.80000000000004" r="3" stroke="#f28e2c"></circle>
-      <circle cx="60.5" cy="147.60000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="94.66666666666667" cy="125.70909090909093" r="3" stroke="#f28e2c"></circle>
-      <circle cx="58.22222222222222" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.44444444444444" cy="108.90909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="53.666666666666664" cy="145.05454545454546" r="3" stroke="#4e79a7"></circle>
-      <circle cx="126.55555555555556" cy="131.8181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="73.02777777777779" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="52.52777777777778" cy="142.5090909090909" r="3" stroke="#e15759"></circle>
-      <circle cx="74.16666666666666" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="106.05555555555556" cy="118.07272727272729" r="3" stroke="#f28e2c"></circle>
-      <circle cx="69.61111111111111" cy="143.52727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="78.72222222222221" cy="123.16363636363639" r="3" stroke="#f28e2c"></circle>
-      <circle cx="90.11111111111111" cy="148.61818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="76.44444444444444" cy="145.56363636363636" r="3" stroke="#4e79a7"></circle>
-      <circle cx="96.94444444444444" cy="138.43636363636364" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81" cy="135.3818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="78.72222222222221" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
-      <circle cx="112.88888888888889" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.88888888888889" cy="160.3272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="119.72222222222223" cy="131.8181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="67.33333333333334" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="112.88888888888889" cy="125.70909090909093" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.55555555555556" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
-      <circle cx="115.16666666666667" cy="128.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="49.111111111111114" cy="164.9090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="103.77777777777777" cy="113.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="76.44444444444444" cy="146.0727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="120.86111111111111" cy="142.5090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="73.02777777777779" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
-      <circle cx="94.66666666666667" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="61.638888888888886" cy="152.1818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="98.08333333333333" cy="128.76363636363635" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.88888888888889" cy="145.05454545454546" r="3" stroke="#4e79a7"></circle>
-      <circle cx="110.61111111111111" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.88888888888889" cy="128.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="75.30555555555556" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="55.94444444444444" cy="170" r="3" stroke="#4e79a7"></circle>
-      <circle cx="86.69444444444444" cy="126.21818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="53.666666666666664" cy="143.52727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="83.27777777777779" cy="134.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="110.61111111111111" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
-      <circle cx="75.30555555555556" cy="147.0909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="74.16666666666666" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="87.83333333333334" cy="140.98181818181823" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.55555555555556" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="99.22222222222223" cy="122.14545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="66.58333333333334" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
+      <circle cx="98" cy="144.03636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="69" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
+      <circle cx="98" cy="125.20000000000002" r="3" stroke="#f28e2c"></circle>
+      <circle cx="70.20833333333334" cy="148.10909090909092" r="3" stroke="#4e79a7"></circle>
+      <circle cx="110.08333333333333" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
+      <circle cx="100.41666666666667" cy="135.89090909090913" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81.08333333333333" cy="118.58181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="69" cy="142" r="3" stroke="#4e79a7"></circle>
+      <circle cx="134.25" cy="130.80000000000004" r="3" stroke="#f28e2c"></circle>
+      <circle cx="61.75" cy="147.60000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="98" cy="125.70909090909093" r="3" stroke="#f28e2c"></circle>
+      <circle cx="59.33333333333333" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="122.16666666666667" cy="108.90909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="54.5" cy="145.05454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="131.83333333333334" cy="131.8181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="75.04166666666667" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="53.29166666666667" cy="142.5090909090909" r="3" stroke="#e15759"></circle>
+      <circle cx="76.25" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="110.08333333333333" cy="118.07272727272729" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.41666666666666" cy="143.52727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="81.08333333333333" cy="123.16363636363639" r="3" stroke="#f28e2c"></circle>
+      <circle cx="93.16666666666669" cy="148.61818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="78.66666666666666" cy="145.56363636363636" r="3" stroke="#4e79a7"></circle>
+      <circle cx="100.41666666666667" cy="138.43636363636364" r="3" stroke="#f28e2c"></circle>
+      <circle cx="83.5" cy="135.3818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="81.08333333333333" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.33333333333331" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="73.83333333333334" cy="160.3272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="124.58333333333333" cy="131.8181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="69" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.33333333333331" cy="125.70909090909093" r="3" stroke="#f28e2c"></circle>
+      <circle cx="88.33333333333334" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
+      <circle cx="119.75" cy="128.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="49.666666666666664" cy="164.9090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="107.66666666666667" cy="113.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="78.66666666666666" cy="146.0727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="125.79166666666669" cy="142.5090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="75.04166666666667" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
+      <circle cx="98" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="62.95833333333333" cy="152.1818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="101.625" cy="128.76363636363635" r="3" stroke="#f28e2c"></circle>
+      <circle cx="73.83333333333334" cy="145.05454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="114.91666666666669" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="73.83333333333334" cy="128.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="77.45833333333334" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="56.91666666666667" cy="170" r="3" stroke="#4e79a7"></circle>
+      <circle cx="89.54166666666666" cy="126.21818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="54.5" cy="143.52727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="85.91666666666667" cy="134.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="114.91666666666669" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
+      <circle cx="77.45833333333334" cy="147.0909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="76.25" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="90.75" cy="140.98181818181823" r="3" stroke="#f28e2c"></circle>
+      <circle cx="88.33333333333334" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="102.83333333333333" cy="122.14545454545454" r="3" stroke="#f28e2c"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(183,155)">
+  <g aria-label="facet" transform="translate(193,155)">
     <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
       <path transform="translate(40,155.23636363636365)" d="M0,0L-6,0"></path>
       <path transform="translate(40,129.78181818181818)" d="M0,0L-6,0"></path>
@@ -325,183 +317,175 @@
       <text y="0.32em" transform="translate(40,53.41818181818183)">55</text>
     </g>
     <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-      <path transform="translate(53.666666666666664,170)" d="M0,0L0,6"></path>
-      <path transform="translate(99.22222222222223,170)" d="M0,0L0,6"></path>
-      <path transform="translate(144.77777777777777,170)" d="M0,0L0,6"></path>
-      <path transform="translate(190.33333333333334,170)" d="M0,0L0,6"></path>
+      <path transform="translate(102.83333333333333,170)" d="M0,0L0,6"></path>
+      <path transform="translate(199.5,170)" d="M0,0L0,6"></path>
     </g>
     <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-      <text y="0.71em" transform="translate(53.666666666666664,170)">3,000</text>
-      <text y="0.71em" transform="translate(99.22222222222223,170)">4,000</text>
-      <text y="0.71em" transform="translate(144.77777777777777,170)">5,000</text>
-      <text y="0.71em" transform="translate(190.33333333333334,170)">6,000</text>
+      <text y="0.71em" transform="translate(102.83333333333333,170)">4,000</text>
+      <text y="0.71em" transform="translate(199.5,170)">6,000</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="76.44444444444444" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="94.66666666666667" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="83.27777777777779" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="77.58333333333334" cy="102.2909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="86.69444444444444" cy="65.12727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="96.94444444444444" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="65.05555555555556" cy="98.72727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="87.83333333333334" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="106.05555555555556" cy="99.23636363636365" r="3" stroke="#4e79a7"></circle>
-      <circle cx="85.55555555555556" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="90.11111111111111" cy="96.18181818181819" r="3" stroke="#4e79a7"></circle>
-      <circle cx="88.97222222222221" cy="70.21818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.55555555555556" cy="94.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="101.5" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="79.86111111111111" cy="99.74545454545455" r="3" stroke="#4e79a7"></circle>
-      <circle cx="101.5" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="67.33333333333334" cy="77.34545454545457" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.55555555555556" cy="38.145454545454555" r="3" stroke="#4e79a7"></circle>
-      <circle cx="74.16666666666666" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.44444444444444" cy="82.94545454545455" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81" cy="117.56363636363636" r="3" stroke="#4e79a7"></circle>
-      <circle cx="71.88888888888889" cy="86.50909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="49.111111111111114" cy="113.49090909090908" r="3" stroke="#4e79a7"></circle>
-      <circle cx="90.11111111111111" cy="75.81818181818181" r="3" stroke="#f28e2c"></circle>
-      <circle cx="67.33333333333334" cy="95.67272727272726" r="3" stroke="#4e79a7"></circle>
-      <circle cx="106.05555555555556" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.88888888888889" cy="76.32727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="90.11111111111111" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.55555555555556" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="124.27777777777777" cy="64.61818181818184" r="3" stroke="#f28e2c"></circle>
-      <circle cx="62.77777777777778" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="112.88888888888889" cy="57.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="69.61111111111111" cy="117.05454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="103.77777777777777" cy="73.78181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81" cy="80.39999999999999" r="3" stroke="#f28e2c"></circle>
-      <circle cx="94.66666666666667" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="92.38888888888889" cy="91.0909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="135.66666666666669" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="78.66666666666666" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="98" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.91666666666667" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="79.875" cy="102.2909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="89.54166666666666" cy="65.12727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="100.41666666666667" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="66.58333333333334" cy="98.72727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="90.75" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="110.08333333333333" cy="99.23636363636365" r="3" stroke="#4e79a7"></circle>
+      <circle cx="88.33333333333334" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="93.16666666666669" cy="96.18181818181819" r="3" stroke="#4e79a7"></circle>
+      <circle cx="91.95833333333333" cy="70.21818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="88.33333333333334" cy="94.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="105.25" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="82.29166666666666" cy="99.74545454545455" r="3" stroke="#4e79a7"></circle>
+      <circle cx="105.25" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="69" cy="77.34545454545457" r="3" stroke="#f28e2c"></circle>
+      <circle cx="88.33333333333334" cy="38.145454545454555" r="3" stroke="#4e79a7"></circle>
+      <circle cx="76.25" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="122.16666666666667" cy="82.94545454545455" r="3" stroke="#f28e2c"></circle>
+      <circle cx="83.5" cy="117.56363636363636" r="3" stroke="#4e79a7"></circle>
+      <circle cx="73.83333333333334" cy="86.50909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="49.666666666666664" cy="113.49090909090908" r="3" stroke="#4e79a7"></circle>
+      <circle cx="93.16666666666669" cy="75.81818181818181" r="3" stroke="#f28e2c"></circle>
+      <circle cx="69" cy="95.67272727272726" r="3" stroke="#4e79a7"></circle>
+      <circle cx="110.08333333333333" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="73.83333333333334" cy="76.32727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="93.16666666666669" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="88.33333333333334" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="129.41666666666666" cy="64.61818181818184" r="3" stroke="#f28e2c"></circle>
+      <circle cx="64.16666666666667" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.33333333333331" cy="57.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.41666666666666" cy="117.05454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="107.66666666666667" cy="73.78181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="83.5" cy="80.39999999999999" r="3" stroke="#f28e2c"></circle>
+      <circle cx="98" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="95.58333333333331" cy="91.0909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="141.5" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
       <circle cx="40" cy="94.65454545454547" r="3" stroke="#4e79a7"></circle>
-      <circle cx="122" cy="61.05454545454547" r="3" stroke="#f28e2c"></circle>
-      <circle cx="96.94444444444444" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="83.27777777777779" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="78.72222222222221" cy="74.29090909090911" r="3" stroke="#f28e2c"></circle>
-      <circle cx="76.44444444444444" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="84.41666666666666" cy="74.29090909090911" r="3" stroke="#4e79a7"></circle>
-      <circle cx="119.72222222222223" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.88888888888889" cy="78.36363636363636" r="3" stroke="#4e79a7"></circle>
-      <circle cx="112.88888888888889" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="65.05555555555556" cy="71.23636363636365" r="3" stroke="#f28e2c"></circle>
-      <circle cx="84.41666666666666" cy="79.89090909090912" r="3" stroke="#4e79a7"></circle>
-      <circle cx="68.47222222222223" cy="88.54545454545455" r="3" stroke="#4e79a7"></circle>
-      <circle cx="96.94444444444444" cy="71.74545454545456" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="101.5" cy="75.30909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="69.61111111111111" cy="117.05454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="74.16666666666666" cy="67.67272727272726" r="3" stroke="#f28e2c"></circle>
-      <circle cx="65.05555555555556" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="101.5" cy="82.43636363636367" r="3" stroke="#f28e2c"></circle>
-      <circle cx="90.11111111111111" cy="77.85454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="77.58333333333334" cy="101.27272727272725" r="3" stroke="#4e79a7"></circle>
-      <circle cx="96.94444444444444" cy="69.20000000000002" r="3" stroke="#f28e2c"></circle>
-      <circle cx="83.27777777777779" cy="95.16363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="83.27777777777779" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="99.22222222222223" cy="49.34545454545456" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.88888888888889" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="88.97222222222221" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="103.77777777777777" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
-      <circle cx="88.97222222222221" cy="77.85454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="127" cy="61.05454545454547" r="3" stroke="#f28e2c"></circle>
+      <circle cx="100.41666666666667" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.91666666666667" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="81.08333333333333" cy="74.29090909090911" r="3" stroke="#f28e2c"></circle>
+      <circle cx="78.66666666666666" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="87.125" cy="74.29090909090911" r="3" stroke="#4e79a7"></circle>
+      <circle cx="124.58333333333333" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
+      <circle cx="73.83333333333334" cy="78.36363636363636" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.33333333333331" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="66.58333333333334" cy="71.23636363636365" r="3" stroke="#f28e2c"></circle>
+      <circle cx="87.125" cy="79.89090909090912" r="3" stroke="#4e79a7"></circle>
+      <circle cx="70.20833333333334" cy="88.54545454545455" r="3" stroke="#4e79a7"></circle>
+      <circle cx="100.41666666666667" cy="71.74545454545456" r="3" stroke="#f28e2c"></circle>
+      <circle cx="83.5" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="105.25" cy="75.30909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.41666666666666" cy="117.05454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="76.25" cy="67.67272727272726" r="3" stroke="#f28e2c"></circle>
+      <circle cx="66.58333333333334" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="105.25" cy="82.43636363636367" r="3" stroke="#f28e2c"></circle>
+      <circle cx="93.16666666666669" cy="77.85454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="79.875" cy="101.27272727272725" r="3" stroke="#4e79a7"></circle>
+      <circle cx="100.41666666666667" cy="69.20000000000002" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.91666666666667" cy="95.16363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="85.91666666666667" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="102.83333333333333" cy="49.34545454545456" r="3" stroke="#f28e2c"></circle>
+      <circle cx="73.83333333333334" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="91.95833333333333" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="107.66666666666667" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
+      <circle cx="91.95833333333333" cy="77.85454545454546" r="3" stroke="#4e79a7"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(365,0)">
+  <g aria-label="facet" transform="translate(386,0)">
     <g aria-label="fy-axis tick label" text-anchor="start" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(204,100)">Adelie</text>
+      <text y="0.32em" transform="translate(214,100)">Adelie</text>
     </g>
     <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
-      <text transform="translate(122,30)">Torgersen</text>
+      <text transform="translate(127,30)">Torgersen</text>
     </g>
     <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-      <path transform="translate(53.666666666666664,170)" d="M0,0L0,6"></path>
-      <path transform="translate(99.22222222222223,170)" d="M0,0L0,6"></path>
-      <path transform="translate(144.77777777777777,170)" d="M0,0L0,6"></path>
-      <path transform="translate(190.33333333333334,170)" d="M0,0L0,6"></path>
+      <path transform="translate(102.83333333333333,170)" d="M0,0L0,6"></path>
+      <path transform="translate(199.5,170)" d="M0,0L0,6"></path>
     </g>
     <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-      <text y="0.71em" transform="translate(53.666666666666664,170)">3,000</text>
-      <text y="0.71em" transform="translate(99.22222222222223,170)">4,000</text>
-      <text y="0.71em" transform="translate(144.77777777777777,170)">5,000</text>
-      <text y="0.71em" transform="translate(190.33333333333334,170)">6,000</text>
+      <text y="0.71em" transform="translate(102.83333333333333,170)">4,000</text>
+      <text y="0.71em" transform="translate(199.5,170)">6,000</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="87.83333333333334" cy="134.36363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="90.11111111111111" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
-      <circle cx="65.05555555555556" cy="128.25454545454548" r="3" stroke="#4e79a7"></circle>
-      <circle cx="74.16666666666666" cy="146.5818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="83.27777777777779" cy="133.34545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="82.13888888888889" cy="135.3818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="129.97222222222223" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
-      <circle cx="75.30555555555556" cy="159.8181818181818" r="3" stroke="#e15759"></circle>
-      <circle cx="110.61111111111111" cy="119.60000000000002" r="3" stroke="#e15759"></circle>
-      <circle cx="67.33333333333334" cy="140.98181818181823" r="3" stroke="#e15759"></circle>
-      <circle cx="85.55555555555556" cy="140.98181818181823" r="3" stroke="#e15759"></circle>
-      <circle cx="62.77777777777778" cy="124.18181818181817" r="3" stroke="#4e79a7"></circle>
-      <circle cx="90.11111111111111" cy="136.9090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="117.44444444444444" cy="157.27272727272725" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.55555555555556" cy="147.0909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="74.16666666666666" cy="136.39999999999998" r="3" stroke="#4e79a7"></circle>
-      <circle cx="122" cy="117.05454545454545" r="3" stroke="#f28e2c"></circle>
-      <circle cx="68.47222222222223" cy="158.2909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="108.33333333333333" cy="99.23636363636365" r="3" stroke="#f28e2c"></circle>
-      <circle cx="55.94444444444444" cy="150.65454545454548" r="3" stroke="#4e79a7"></circle>
-      <circle cx="119.72222222222223" cy="120.61818181818184" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81" cy="162.87272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="94.66666666666667" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="78.72222222222221" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="106.05555555555556" cy="100.25454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.55555555555556" cy="152.69090909090912" r="3" stroke="#4e79a7"></circle>
-      <circle cx="110.61111111111111" cy="115.52727272727276" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.55555555555556" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="94.66666666666667" cy="144.03636363636363" r="3" stroke="#f28e2c"></circle>
-      <circle cx="78.72222222222221" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="99.22222222222223" cy="119.0909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="62.77777777777778" cy="157.27272727272725" r="3" stroke="#4e79a7"></circle>
-      <circle cx="131.11111111111111" cy="115.01818181818184" r="3" stroke="#f28e2c"></circle>
-      <circle cx="90.11111111111111" cy="146.5818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="108.33333333333333" cy="154.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="49.111111111111114" cy="136.9090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="88.97222222222221" cy="143.52727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="69.61111111111111" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
-      <circle cx="68.47222222222223" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="60.5" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="76.44444444444444" cy="141.4909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="74.16666666666666" cy="128.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="93.52777777777777" cy="122.65454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="55.94444444444444" cy="154.2181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="99.22222222222223" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="66.19444444444444" cy="135.89090909090913" r="3" stroke="#4e79a7"></circle>
-      <circle cx="112.88888888888889" cy="122.14545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="55.94444444444444" cy="134.87272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="99.22222222222223" cy="108.90909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="68.47222222222223" cy="137.4181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="76.44444444444444" cy="114" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.75" cy="134.36363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="93.16666666666669" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
+      <circle cx="66.58333333333334" cy="128.25454545454548" r="3" stroke="#4e79a7"></circle>
+      <circle cx="76.25" cy="146.5818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="85.91666666666667" cy="133.34545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="84.70833333333333" cy="135.3818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="135.45833333333334" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
+      <circle cx="77.45833333333334" cy="159.8181818181818" r="3" stroke="#e15759"></circle>
+      <circle cx="114.91666666666669" cy="119.60000000000002" r="3" stroke="#e15759"></circle>
+      <circle cx="69" cy="140.98181818181823" r="3" stroke="#e15759"></circle>
+      <circle cx="88.33333333333334" cy="140.98181818181823" r="3" stroke="#e15759"></circle>
+      <circle cx="64.16666666666667" cy="124.18181818181817" r="3" stroke="#4e79a7"></circle>
+      <circle cx="93.16666666666669" cy="136.9090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="122.16666666666667" cy="157.27272727272725" r="3" stroke="#f28e2c"></circle>
+      <circle cx="88.33333333333334" cy="147.0909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="76.25" cy="136.39999999999998" r="3" stroke="#4e79a7"></circle>
+      <circle cx="127" cy="117.05454545454545" r="3" stroke="#f28e2c"></circle>
+      <circle cx="70.20833333333334" cy="158.2909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="112.5" cy="99.23636363636365" r="3" stroke="#f28e2c"></circle>
+      <circle cx="56.91666666666667" cy="150.65454545454548" r="3" stroke="#4e79a7"></circle>
+      <circle cx="124.58333333333333" cy="120.61818181818184" r="3" stroke="#f28e2c"></circle>
+      <circle cx="83.5" cy="162.87272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="98" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81.08333333333333" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="110.08333333333333" cy="100.25454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="88.33333333333334" cy="152.69090909090912" r="3" stroke="#4e79a7"></circle>
+      <circle cx="114.91666666666669" cy="115.52727272727276" r="3" stroke="#f28e2c"></circle>
+      <circle cx="88.33333333333334" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="98" cy="144.03636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81.08333333333333" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="102.83333333333333" cy="119.0909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="64.16666666666667" cy="157.27272727272725" r="3" stroke="#4e79a7"></circle>
+      <circle cx="136.66666666666669" cy="115.01818181818184" r="3" stroke="#f28e2c"></circle>
+      <circle cx="93.16666666666669" cy="146.5818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="112.5" cy="154.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="49.666666666666664" cy="136.9090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="91.95833333333333" cy="143.52727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.41666666666666" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
+      <circle cx="70.20833333333334" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="61.75" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.66666666666666" cy="141.4909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="76.25" cy="128.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="96.79166666666667" cy="122.65454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="56.91666666666667" cy="154.2181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="102.83333333333333" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="67.79166666666666" cy="135.89090909090913" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.33333333333331" cy="122.14545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="56.91666666666667" cy="134.87272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="102.83333333333333" cy="108.90909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="70.20833333333334" cy="137.4181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.66666666666666" cy="114" r="3" stroke="#f28e2c"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(365,155)">
+  <g aria-label="facet" transform="translate(386,155)">
     <g aria-label="fy-axis tick label" text-anchor="start" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(204,100)">Chinstrap</text>
+      <text y="0.32em" transform="translate(214,100)">Chinstrap</text>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(365,310)">
+  <g aria-label="facet" transform="translate(386,310)">
     <g aria-label="fy-axis tick label" text-anchor="start" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(204,100)">Gentoo</text>
+      <text y="0.32em" transform="translate(214,100)">Gentoo</text>
     </g>
   </g>
-  <g aria-label="fy-axis label" transform="translate(68.5,0.5)">
-    <text transform="translate(569,255) rotate(-90)">species</text>
+  <g aria-label="fy-axis label" transform="translate(37.5,0.5)">
+    <text transform="translate(600,255) rotate(-90)">species</text>
   </g>
   <g aria-label="fx-axis label" transform="translate(0.5,-26.5)">
-    <text y="0.71em" transform="translate(305,30)">island</text>
+    <text y="0.71em" transform="translate(320,30)">island</text>
   </g>
   <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-26.5)">
-    <text y="0.71em" transform="translate(41,30)">↑ culmen_length_mm</text>
+    <text y="0.71em" transform="translate(40,30)">↑ culmen_length_mm</text>
   </g>
-  <g aria-label="x-axis label" text-anchor="end" transform="translate(67.5,27.5)">
-    <text transform="translate(569,480)">body_mass_g →</text>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(37.5,27.5)">
+    <text transform="translate(600,480)">body_mass_g →</text>
   </g>
 </svg>

--- a/test/output/autoDotFacet2.svg
+++ b/test/output/autoDotFacet2.svg
@@ -13,9 +13,9 @@
       white-space: pre;
     }
   </style>
-  <g aria-label="facet" transform="translate(0,0)">
+  <g aria-label="facet" transform="translate(1,0)">
     <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
-      <text transform="translate(127,30)">Biscoe</text>
+      <text transform="translate(122,30)">Biscoe</text>
     </g>
     <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
       <path transform="translate(40,155.23636363636365)" d="M0,0L-6,0"></path>
@@ -32,62 +32,66 @@
       <text y="0.32em" transform="translate(40,53.41818181818183)">55</text>
     </g>
     <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-      <path transform="translate(102.83333333333333,170)" d="M0,0L0,6"></path>
-      <path transform="translate(199.5,170)" d="M0,0L0,6"></path>
+      <path transform="translate(53.666666666666664,170)" d="M0,0L0,6"></path>
+      <path transform="translate(99.22222222222223,170)" d="M0,0L0,6"></path>
+      <path transform="translate(144.77777777777777,170)" d="M0,0L0,6"></path>
+      <path transform="translate(190.33333333333334,170)" d="M0,0L0,6"></path>
     </g>
     <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-      <text y="0.71em" transform="translate(102.83333333333333,170)">4,000</text>
-      <text y="0.71em" transform="translate(199.5,170)">6,000</text>
+      <text y="0.71em" transform="translate(53.666666666666664,170)">3,000</text>
+      <text y="0.71em" transform="translate(99.22222222222223,170)">4,000</text>
+      <text y="0.71em" transform="translate(144.77777777777777,170)">5,000</text>
+      <text y="0.71em" transform="translate(190.33333333333334,170)">6,000</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="73.83333333333334" cy="140.98181818181823" r="3" stroke="#4e79a7"></circle>
-      <circle cx="83.5" cy="141.4909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="93.16666666666669" cy="150.65454545454548" r="3" stroke="#4e79a7"></circle>
-      <circle cx="100.41666666666667" cy="138.94545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="93.16666666666669" cy="135.89090909090913" r="3" stroke="#f28e2c"></circle>
-      <circle cx="93.16666666666669" cy="153.70909090909095" r="3" stroke="#4e79a7"></circle>
-      <circle cx="81.08333333333333" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="64.16666666666667" cy="127.23636363636363" r="3" stroke="#4e79a7"></circle>
-      <circle cx="61.75" cy="140.47272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="100.41666666666667" cy="127.23636363636363" r="3" stroke="#f28e2c"></circle>
-      <circle cx="78.66666666666666" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.33333333333331" cy="129.27272727272728" r="3" stroke="#f28e2c"></circle>
-      <circle cx="76.25" cy="155.23636363636365" r="3" stroke="#4e79a7"></circle>
-      <circle cx="105.25" cy="119.60000000000002" r="3" stroke="#f28e2c"></circle>
-      <circle cx="49.666666666666664" cy="157.7818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="88.33333333333334" cy="122.65454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81.08333333333333" cy="134.87272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="93.16666666666669" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="47.25" cy="147.60000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="90.75" cy="142" r="3" stroke="#f28e2c"></circle>
-      <circle cx="61.75" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
-      <circle cx="122.16666666666667" cy="123.16363636363639" r="3" stroke="#f28e2c"></circle>
-      <circle cx="83.5" cy="142" r="3" stroke="#4e79a7"></circle>
-      <circle cx="105.25" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="47.25" cy="148.10909090909092" r="3" stroke="#4e79a7"></circle>
-      <circle cx="100.41666666666667" cy="121.63636363636363" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.41666666666666" cy="152.69090909090912" r="3" stroke="#4e79a7"></circle>
-      <circle cx="107.66666666666667" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="89.54166666666666" cy="155.23636363636365" r="3" stroke="#4e79a7"></circle>
-      <circle cx="137.875" cy="124.69090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="58.125" cy="141.4909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="114.91666666666669" cy="140.98181818181823" r="3" stroke="#f28e2c"></circle>
-      <circle cx="50.875" cy="140.47272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="81.08333333333333" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="90.75" cy="136.9090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="98" cy="138.94545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="62.95833333333333" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
-      <circle cx="140.29166666666666" cy="113.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="94.375" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
-      <circle cx="131.83333333333334" cy="101.27272727272725" r="3" stroke="#f28e2c"></circle>
-      <circle cx="64.16666666666667" cy="131.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="116.125" cy="118.58181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="98" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="106.45833333333331" cy="116.03636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.88888888888889" cy="140.98181818181823" r="3" stroke="#4e79a7"></circle>
+      <circle cx="81" cy="141.4909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.11111111111111" cy="150.65454545454548" r="3" stroke="#4e79a7"></circle>
+      <circle cx="96.94444444444444" cy="138.94545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.11111111111111" cy="135.89090909090913" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.11111111111111" cy="153.70909090909095" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.72222222222221" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="62.77777777777778" cy="127.23636363636363" r="3" stroke="#4e79a7"></circle>
+      <circle cx="60.5" cy="140.47272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="96.94444444444444" cy="127.23636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="76.44444444444444" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="112.88888888888889" cy="129.27272727272728" r="3" stroke="#f28e2c"></circle>
+      <circle cx="74.16666666666666" cy="155.23636363636365" r="3" stroke="#4e79a7"></circle>
+      <circle cx="101.5" cy="119.60000000000002" r="3" stroke="#f28e2c"></circle>
+      <circle cx="49.111111111111114" cy="157.7818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="85.55555555555556" cy="122.65454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="78.72222222222221" cy="134.87272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="90.11111111111111" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="46.833333333333336" cy="147.60000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="87.83333333333334" cy="142" r="3" stroke="#f28e2c"></circle>
+      <circle cx="60.5" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.44444444444444" cy="123.16363636363639" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81" cy="142" r="3" stroke="#4e79a7"></circle>
+      <circle cx="101.5" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="46.833333333333336" cy="148.10909090909092" r="3" stroke="#4e79a7"></circle>
+      <circle cx="96.94444444444444" cy="121.63636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="69.61111111111111" cy="152.69090909090912" r="3" stroke="#4e79a7"></circle>
+      <circle cx="103.77777777777777" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="86.69444444444444" cy="155.23636363636365" r="3" stroke="#4e79a7"></circle>
+      <circle cx="132.25" cy="124.69090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="57.083333333333336" cy="141.4909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="110.61111111111111" cy="140.98181818181823" r="3" stroke="#f28e2c"></circle>
+      <circle cx="50.25" cy="140.47272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.72222222222221" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="87.83333333333334" cy="136.9090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="94.66666666666667" cy="138.94545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="61.638888888888886" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
+      <circle cx="134.52777777777777" cy="113.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="91.25" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
+      <circle cx="126.55555555555556" cy="101.27272727272725" r="3" stroke="#f28e2c"></circle>
+      <circle cx="62.77777777777778" cy="131.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="111.75" cy="118.58181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="94.66666666666667" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="102.63888888888889" cy="116.03636363636363" r="3" stroke="#f28e2c"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(0,310)">
+  <g aria-label="facet" transform="translate(1,310)">
     <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
       <path transform="translate(40,155.23636363636365)" d="M0,0L-6,0"></path>
       <path transform="translate(40,129.78181818181818)" d="M0,0L-6,0"></path>
@@ -103,205 +107,209 @@
       <text y="0.32em" transform="translate(40,53.41818181818183)">55</text>
     </g>
     <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-      <path transform="translate(102.83333333333333,170)" d="M0,0L0,6"></path>
-      <path transform="translate(199.5,170)" d="M0,0L0,6"></path>
+      <path transform="translate(53.666666666666664,170)" d="M0,0L0,6"></path>
+      <path transform="translate(99.22222222222223,170)" d="M0,0L0,6"></path>
+      <path transform="translate(144.77777777777777,170)" d="M0,0L0,6"></path>
+      <path transform="translate(190.33333333333334,170)" d="M0,0L0,6"></path>
     </g>
     <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-      <text y="0.71em" transform="translate(102.83333333333333,170)">4,000</text>
-      <text y="0.71em" transform="translate(199.5,170)">6,000</text>
+      <text y="0.71em" transform="translate(53.666666666666664,170)">3,000</text>
+      <text y="0.71em" transform="translate(99.22222222222223,170)">4,000</text>
+      <text y="0.71em" transform="translate(144.77777777777777,170)">5,000</text>
+      <text y="0.71em" transform="translate(190.33333333333334,170)">6,000</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="127" cy="98.72727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="185" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="124.58333333333333" cy="85.49090909090908" r="3" stroke="#4e79a7"></circle>
-      <circle cx="185" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="170.5" cy="91.0909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="129.41666666666666" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="141.5" cy="102.2909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="160.83333333333334" cy="95.67272727272726" r="3" stroke="#f28e2c"></circle>
-      <circle cx="122.16666666666667" cy="112.98181818181821" r="3" stroke="#4e79a7"></circle>
-      <circle cx="158.41666666666666" cy="95.16363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="134.25" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="177.75" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="134.25" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="192.25" cy="87.01818181818183" r="3" stroke="#f28e2c"></circle>
-      <circle cx="112.5" cy="100.25454545454546" r="3" stroke="#4e79a7"></circle>
-      <circle cx="192.25" cy="82.43636363636367" r="3" stroke="#f28e2c"></circle>
-      <circle cx="110.08333333333333" cy="119.60000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="214" cy="82.94545454545455" r="3" stroke="#f28e2c"></circle>
-      <circle cx="141.5" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="168.08333333333334" cy="85.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="185" cy="77.85454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="151.16666666666666" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="122.16666666666667" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="153.58333333333334" cy="97.70909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="151.16666666666666" cy="115.01818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="156" cy="98.72727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="107.66666666666667" cy="106.87272727272727" r="3" stroke="#e15759"></circle>
-      <circle cx="182.58333333333334" cy="90.0727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="131.83333333333334" cy="88.03636363636362" r="3" stroke="#4e79a7"></circle>
-      <circle cx="177.75" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="163.25" cy="92.61818181818184" r="3" stroke="#f28e2c"></circle>
-      <circle cx="136.66666666666669" cy="115.52727272727276" r="3" stroke="#4e79a7"></circle>
-      <circle cx="153.58333333333334" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="201.91666666666666" cy="30" r="3" stroke="#f28e2c"></circle>
-      <circle cx="158.41666666666666" cy="83.45454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="170.5" cy="87.01818181818183" r="3" stroke="#f28e2c"></circle>
-      <circle cx="148.75" cy="116.54545454545455" r="3" stroke="#4e79a7"></circle>
-      <circle cx="163.25" cy="107.3818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="119.75" cy="109.41818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="168.08333333333334" cy="85.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="100.41666666666667" cy="116.03636363636363" r="3" stroke="#4e79a7"></circle>
-      <circle cx="185" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="117.33333333333331" cy="102.80000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="139.08333333333331" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="177.75" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="146.33333333333334" cy="111.45454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="112.5" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="170.5" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="156" cy="104.83636363636364" r="3" stroke="#4e79a7"></circle>
-      <circle cx="165.66666666666666" cy="103.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="143.91666666666666" cy="96.18181818181819" r="3" stroke="#4e79a7"></circle>
-      <circle cx="165.66666666666666" cy="86.50909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="122.16666666666667" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
-      <circle cx="151.16666666666666" cy="78.36363636363636" r="3" stroke="#f28e2c"></circle>
-      <circle cx="146.33333333333334" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="153.58333333333334" cy="104.32727272727274" r="3" stroke="#f28e2c"></circle>
-      <circle cx="117.33333333333331" cy="110.43636363636367" r="3" stroke="#4e79a7"></circle>
-      <circle cx="151.16666666666666" cy="101.78181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="124.58333333333333" cy="113.49090909090908" r="3" stroke="#4e79a7"></circle>
-      <circle cx="177.75" cy="76.83636363636366" r="3" stroke="#f28e2c"></circle>
-      <circle cx="112.5" cy="102.80000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="165.66666666666666" cy="98.21818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="122.16666666666667" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="182.58333333333334" cy="56.9818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="136.66666666666669" cy="100.25454545454546" r="3" stroke="#4e79a7"></circle>
-      <circle cx="185" cy="79.89090909090912" r="3" stroke="#f28e2c"></circle>
-      <circle cx="134.25" cy="98.21818181818182" r="3" stroke="#e15759"></circle>
-      <circle cx="189.83333333333334" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="136.66666666666669" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="177.75" cy="75.30909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="139.08333333333331" cy="90.58181818181816" r="3" stroke="#4e79a7"></circle>
-      <circle cx="151.16666666666666" cy="97.20000000000002" r="3" stroke="#f28e2c"></circle>
-      <circle cx="156" cy="88.03636363636362" r="3" stroke="#f28e2c"></circle>
-      <circle cx="160.83333333333334" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="136.66666666666669" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="189.83333333333334" cy="86" r="3" stroke="#f28e2c"></circle>
-      <circle cx="131.83333333333334" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="199.5" cy="73.27272727272728" r="3" stroke="#f28e2c"></circle>
-      <circle cx="139.08333333333331" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="197.08333333333334" cy="103.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="133.04166666666666" cy="83.45454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="172.91666666666666" cy="66.14545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="137.875" cy="92.10909090909092" r="3" stroke="#4e79a7"></circle>
-      <circle cx="168.08333333333334" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="139.08333333333331" cy="104.83636363636364" r="3" stroke="#4e79a7"></circle>
-      <circle cx="180.16666666666666" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
-      <circle cx="131.83333333333334" cy="112.4727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="165.66666666666666" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="145.125" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="177.75" cy="68.18181818181819" r="3" stroke="#f28e2c"></circle>
-      <circle cx="148.75" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="170.5" cy="67.67272727272726" r="3" stroke="#f28e2c"></circle>
-      <circle cx="139.08333333333331" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="182.58333333333334" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="143.91666666666666" cy="106.87272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="160.83333333333334" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
-      <circle cx="147.54166666666666" cy="81.92727272727274" r="3" stroke="#f28e2c"></circle>
-      <circle cx="145.125" cy="94.65454545454547" r="3" stroke="#4e79a7"></circle>
-      <circle cx="133.04166666666666" cy="87.01818181818183" r="3" stroke="#4e79a7"></circle>
-      <circle cx="163.25" cy="73.27272727272728" r="3" stroke="#f28e2c"></circle>
-      <circle cx="143.91666666666666" cy="86.50909090909092" r="3" stroke="#4e79a7"></circle>
-      <circle cx="180.16666666666666" cy="48.83636363636365" r="3" stroke="#f28e2c"></circle>
-      <circle cx="149.95833333333334" cy="93.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="175.33333333333334" cy="83.45454545454545" r="3" stroke="#f28e2c"></circle>
-      <circle cx="137.875" cy="92.61818181818184" r="3" stroke="#e15759"></circle>
-      <circle cx="175.33333333333334" cy="95.16363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="136.66666666666669" cy="121.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="175.33333333333334" cy="61.563636363636384" r="3" stroke="#f28e2c"></circle>
-      <circle cx="130.625" cy="112.98181818181821" r="3" stroke="#4e79a7"></circle>
-      <circle cx="175.33333333333334" cy="88.54545454545455" r="3" stroke="#f28e2c"></circle>
-      <circle cx="151.16666666666666" cy="76.32727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="197.08333333333334" cy="79.89090909090912" r="3" stroke="#f28e2c"></circle>
-      <circle cx="134.25" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="175.33333333333334" cy="71.23636363636365" r="3" stroke="#f28e2c"></circle>
-      <circle cx="120.95833333333333" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="192.25" cy="52.90909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="145.125" cy="106.87272727272727" r="3" stroke="#e15759"></circle>
-      <circle cx="199.5" cy="84.9818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="147.54166666666666" cy="93.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="143.91666666666666" cy="95.16363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="187.41666666666666" cy="76.83636363636366" r="3" stroke="#f28e2c"></circle>
-      <circle cx="160.83333333333334" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="170.5" cy="79.38181818181819" r="3" stroke="#f28e2c"></circle>
+      <circle cx="122" cy="98.72727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="176.66666666666666" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="119.72222222222223" cy="85.49090909090908" r="3" stroke="#4e79a7"></circle>
+      <circle cx="176.66666666666666" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="163" cy="91.0909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="124.27777777777777" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="135.66666666666669" cy="102.2909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.88888888888889" cy="95.67272727272726" r="3" stroke="#f28e2c"></circle>
+      <circle cx="117.44444444444444" cy="112.98181818181821" r="3" stroke="#4e79a7"></circle>
+      <circle cx="151.61111111111111" cy="95.16363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="128.83333333333331" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="169.83333333333334" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="128.83333333333331" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="183.5" cy="87.01818181818183" r="3" stroke="#f28e2c"></circle>
+      <circle cx="108.33333333333333" cy="100.25454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="183.5" cy="82.43636363636367" r="3" stroke="#f28e2c"></circle>
+      <circle cx="106.05555555555556" cy="119.60000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="204" cy="82.94545454545455" r="3" stroke="#f28e2c"></circle>
+      <circle cx="135.66666666666669" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="160.72222222222223" cy="85.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="176.66666666666666" cy="77.85454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="144.77777777777777" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.44444444444444" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="147.05555555555554" cy="97.70909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="144.77777777777777" cy="115.01818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="149.33333333333334" cy="98.72727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="103.77777777777777" cy="106.87272727272727" r="3" stroke="#e15759"></circle>
+      <circle cx="174.38888888888889" cy="90.0727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="126.55555555555556" cy="88.03636363636362" r="3" stroke="#4e79a7"></circle>
+      <circle cx="169.83333333333334" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="156.16666666666666" cy="92.61818181818184" r="3" stroke="#f28e2c"></circle>
+      <circle cx="131.11111111111111" cy="115.52727272727276" r="3" stroke="#4e79a7"></circle>
+      <circle cx="147.05555555555554" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="192.61111111111111" cy="30" r="3" stroke="#f28e2c"></circle>
+      <circle cx="151.61111111111111" cy="83.45454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="163" cy="87.01818181818183" r="3" stroke="#f28e2c"></circle>
+      <circle cx="142.5" cy="116.54545454545455" r="3" stroke="#4e79a7"></circle>
+      <circle cx="156.16666666666666" cy="107.3818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="115.16666666666667" cy="109.41818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="160.72222222222223" cy="85.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="96.94444444444444" cy="116.03636363636363" r="3" stroke="#4e79a7"></circle>
+      <circle cx="176.66666666666666" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="112.88888888888889" cy="102.80000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="133.38888888888889" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="169.83333333333334" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="140.22222222222223" cy="111.45454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="108.33333333333333" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="163" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="149.33333333333334" cy="104.83636363636364" r="3" stroke="#4e79a7"></circle>
+      <circle cx="158.44444444444446" cy="103.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="137.94444444444443" cy="96.18181818181819" r="3" stroke="#4e79a7"></circle>
+      <circle cx="158.44444444444446" cy="86.50909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="117.44444444444444" cy="103.81818181818184" r="3" stroke="#4e79a7"></circle>
+      <circle cx="144.77777777777777" cy="78.36363636363636" r="3" stroke="#f28e2c"></circle>
+      <circle cx="140.22222222222223" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="147.05555555555554" cy="104.32727272727274" r="3" stroke="#f28e2c"></circle>
+      <circle cx="112.88888888888889" cy="110.43636363636367" r="3" stroke="#4e79a7"></circle>
+      <circle cx="144.77777777777777" cy="101.78181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="119.72222222222223" cy="113.49090909090908" r="3" stroke="#4e79a7"></circle>
+      <circle cx="169.83333333333334" cy="76.83636363636366" r="3" stroke="#f28e2c"></circle>
+      <circle cx="108.33333333333333" cy="102.80000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="158.44444444444446" cy="98.21818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="117.44444444444444" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="174.38888888888889" cy="56.9818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="131.11111111111111" cy="100.25454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="176.66666666666666" cy="79.89090909090912" r="3" stroke="#f28e2c"></circle>
+      <circle cx="128.83333333333331" cy="98.21818181818182" r="3" stroke="#e15759"></circle>
+      <circle cx="181.22222222222223" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="131.11111111111111" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="169.83333333333334" cy="75.30909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="133.38888888888889" cy="90.58181818181816" r="3" stroke="#4e79a7"></circle>
+      <circle cx="144.77777777777777" cy="97.20000000000002" r="3" stroke="#f28e2c"></circle>
+      <circle cx="149.33333333333334" cy="88.03636363636362" r="3" stroke="#f28e2c"></circle>
+      <circle cx="153.88888888888889" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="131.11111111111111" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="181.22222222222223" cy="86" r="3" stroke="#f28e2c"></circle>
+      <circle cx="126.55555555555556" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="190.33333333333334" cy="73.27272727272728" r="3" stroke="#f28e2c"></circle>
+      <circle cx="133.38888888888889" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="188.05555555555554" cy="103.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="127.69444444444444" cy="83.45454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="165.27777777777777" cy="66.14545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="132.25" cy="92.10909090909092" r="3" stroke="#4e79a7"></circle>
+      <circle cx="160.72222222222223" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="133.38888888888889" cy="104.83636363636364" r="3" stroke="#4e79a7"></circle>
+      <circle cx="172.11111111111111" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
+      <circle cx="126.55555555555556" cy="112.4727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="158.44444444444446" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="139.08333333333331" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="169.83333333333334" cy="68.18181818181819" r="3" stroke="#f28e2c"></circle>
+      <circle cx="142.5" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="163" cy="67.67272727272726" r="3" stroke="#f28e2c"></circle>
+      <circle cx="133.38888888888889" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="174.38888888888889" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="137.94444444444443" cy="106.87272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.88888888888889" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
+      <circle cx="141.36111111111111" cy="81.92727272727274" r="3" stroke="#f28e2c"></circle>
+      <circle cx="139.08333333333331" cy="94.65454545454547" r="3" stroke="#4e79a7"></circle>
+      <circle cx="127.69444444444444" cy="87.01818181818183" r="3" stroke="#4e79a7"></circle>
+      <circle cx="156.16666666666666" cy="73.27272727272728" r="3" stroke="#f28e2c"></circle>
+      <circle cx="137.94444444444443" cy="86.50909090909092" r="3" stroke="#4e79a7"></circle>
+      <circle cx="172.11111111111111" cy="48.83636363636365" r="3" stroke="#f28e2c"></circle>
+      <circle cx="143.63888888888889" cy="93.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="167.55555555555554" cy="83.45454545454545" r="3" stroke="#f28e2c"></circle>
+      <circle cx="132.25" cy="92.61818181818184" r="3" stroke="#e15759"></circle>
+      <circle cx="167.55555555555554" cy="95.16363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="131.11111111111111" cy="121.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="167.55555555555554" cy="61.563636363636384" r="3" stroke="#f28e2c"></circle>
+      <circle cx="125.41666666666669" cy="112.98181818181821" r="3" stroke="#4e79a7"></circle>
+      <circle cx="167.55555555555554" cy="88.54545454545455" r="3" stroke="#f28e2c"></circle>
+      <circle cx="144.77777777777777" cy="76.32727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="188.05555555555554" cy="79.89090909090912" r="3" stroke="#f28e2c"></circle>
+      <circle cx="128.83333333333331" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="167.55555555555554" cy="71.23636363636365" r="3" stroke="#f28e2c"></circle>
+      <circle cx="116.30555555555556" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="183.5" cy="52.90909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="139.08333333333331" cy="106.87272727272727" r="3" stroke="#e15759"></circle>
+      <circle cx="190.33333333333334" cy="84.9818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="141.36111111111111" cy="93.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="137.94444444444443" cy="95.16363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="178.94444444444446" cy="76.83636363636366" r="3" stroke="#f28e2c"></circle>
+      <circle cx="153.88888888888889" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="163" cy="79.38181818181819" r="3" stroke="#f28e2c"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(193,0)">
+  <g aria-label="facet" transform="translate(183,0)">
     <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
-      <text transform="translate(127,30)">Dream</text>
+      <text transform="translate(122,30)">Dream</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="66.58333333333334" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
-      <circle cx="98" cy="144.03636363636363" r="3" stroke="#f28e2c"></circle>
-      <circle cx="69" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
-      <circle cx="98" cy="125.20000000000002" r="3" stroke="#f28e2c"></circle>
-      <circle cx="70.20833333333334" cy="148.10909090909092" r="3" stroke="#4e79a7"></circle>
-      <circle cx="110.08333333333333" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
-      <circle cx="100.41666666666667" cy="135.89090909090913" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81.08333333333333" cy="118.58181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="69" cy="142" r="3" stroke="#4e79a7"></circle>
-      <circle cx="134.25" cy="130.80000000000004" r="3" stroke="#f28e2c"></circle>
-      <circle cx="61.75" cy="147.60000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="98" cy="125.70909090909093" r="3" stroke="#f28e2c"></circle>
-      <circle cx="59.33333333333333" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="122.16666666666667" cy="108.90909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="54.5" cy="145.05454545454546" r="3" stroke="#4e79a7"></circle>
-      <circle cx="131.83333333333334" cy="131.8181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="75.04166666666667" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="53.29166666666667" cy="142.5090909090909" r="3" stroke="#e15759"></circle>
-      <circle cx="76.25" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="110.08333333333333" cy="118.07272727272729" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.41666666666666" cy="143.52727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="81.08333333333333" cy="123.16363636363639" r="3" stroke="#f28e2c"></circle>
-      <circle cx="93.16666666666669" cy="148.61818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="78.66666666666666" cy="145.56363636363636" r="3" stroke="#4e79a7"></circle>
-      <circle cx="100.41666666666667" cy="138.43636363636364" r="3" stroke="#f28e2c"></circle>
-      <circle cx="83.5" cy="135.3818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="81.08333333333333" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.33333333333331" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="73.83333333333334" cy="160.3272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="124.58333333333333" cy="131.8181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="69" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.33333333333331" cy="125.70909090909093" r="3" stroke="#f28e2c"></circle>
-      <circle cx="88.33333333333334" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
-      <circle cx="119.75" cy="128.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="49.666666666666664" cy="164.9090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="107.66666666666667" cy="113.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="78.66666666666666" cy="146.0727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="125.79166666666669" cy="142.5090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="75.04166666666667" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
-      <circle cx="98" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="62.95833333333333" cy="152.1818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="101.625" cy="128.76363636363635" r="3" stroke="#f28e2c"></circle>
-      <circle cx="73.83333333333334" cy="145.05454545454546" r="3" stroke="#4e79a7"></circle>
-      <circle cx="114.91666666666669" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="73.83333333333334" cy="128.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="77.45833333333334" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="56.91666666666667" cy="170" r="3" stroke="#4e79a7"></circle>
-      <circle cx="89.54166666666666" cy="126.21818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="54.5" cy="143.52727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="85.91666666666667" cy="134.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="114.91666666666669" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
-      <circle cx="77.45833333333334" cy="147.0909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="76.25" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="90.75" cy="140.98181818181823" r="3" stroke="#f28e2c"></circle>
-      <circle cx="88.33333333333334" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="102.83333333333333" cy="122.14545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="65.05555555555556" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
+      <circle cx="94.66666666666667" cy="144.03636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="67.33333333333334" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
+      <circle cx="94.66666666666667" cy="125.20000000000002" r="3" stroke="#f28e2c"></circle>
+      <circle cx="68.47222222222223" cy="148.10909090909092" r="3" stroke="#4e79a7"></circle>
+      <circle cx="106.05555555555556" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
+      <circle cx="96.94444444444444" cy="135.89090909090913" r="3" stroke="#f28e2c"></circle>
+      <circle cx="78.72222222222221" cy="118.58181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="67.33333333333334" cy="142" r="3" stroke="#4e79a7"></circle>
+      <circle cx="128.83333333333331" cy="130.80000000000004" r="3" stroke="#f28e2c"></circle>
+      <circle cx="60.5" cy="147.60000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="94.66666666666667" cy="125.70909090909093" r="3" stroke="#f28e2c"></circle>
+      <circle cx="58.22222222222222" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.44444444444444" cy="108.90909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="53.666666666666664" cy="145.05454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="126.55555555555556" cy="131.8181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="73.02777777777779" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="52.52777777777778" cy="142.5090909090909" r="3" stroke="#e15759"></circle>
+      <circle cx="74.16666666666666" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="106.05555555555556" cy="118.07272727272729" r="3" stroke="#f28e2c"></circle>
+      <circle cx="69.61111111111111" cy="143.52727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.72222222222221" cy="123.16363636363639" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.11111111111111" cy="148.61818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="76.44444444444444" cy="145.56363636363636" r="3" stroke="#4e79a7"></circle>
+      <circle cx="96.94444444444444" cy="138.43636363636364" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81" cy="135.3818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.72222222222221" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
+      <circle cx="112.88888888888889" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.88888888888889" cy="160.3272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="119.72222222222223" cy="131.8181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="67.33333333333334" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="112.88888888888889" cy="125.70909090909093" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.55555555555556" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
+      <circle cx="115.16666666666667" cy="128.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="49.111111111111114" cy="164.9090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="103.77777777777777" cy="113.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="76.44444444444444" cy="146.0727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="120.86111111111111" cy="142.5090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="73.02777777777779" cy="139.45454545454544" r="3" stroke="#4e79a7"></circle>
+      <circle cx="94.66666666666667" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="61.638888888888886" cy="152.1818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="98.08333333333333" cy="128.76363636363635" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.88888888888889" cy="145.05454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="110.61111111111111" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.88888888888889" cy="128.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="75.30555555555556" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="55.94444444444444" cy="170" r="3" stroke="#4e79a7"></circle>
+      <circle cx="86.69444444444444" cy="126.21818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="53.666666666666664" cy="143.52727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="83.27777777777779" cy="134.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="110.61111111111111" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
+      <circle cx="75.30555555555556" cy="147.0909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="74.16666666666666" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="87.83333333333334" cy="140.98181818181823" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.55555555555556" cy="150.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="99.22222222222223" cy="122.14545454545454" r="3" stroke="#f28e2c"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(193,155)">
+  <g aria-label="facet" transform="translate(183,155)">
     <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
       <path transform="translate(40,155.23636363636365)" d="M0,0L-6,0"></path>
       <path transform="translate(40,129.78181818181818)" d="M0,0L-6,0"></path>
@@ -317,197 +325,183 @@
       <text y="0.32em" transform="translate(40,53.41818181818183)">55</text>
     </g>
     <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-      <path transform="translate(102.83333333333333,170)" d="M0,0L0,6"></path>
-      <path transform="translate(199.5,170)" d="M0,0L0,6"></path>
+      <path transform="translate(53.666666666666664,170)" d="M0,0L0,6"></path>
+      <path transform="translate(99.22222222222223,170)" d="M0,0L0,6"></path>
+      <path transform="translate(144.77777777777777,170)" d="M0,0L0,6"></path>
+      <path transform="translate(190.33333333333334,170)" d="M0,0L0,6"></path>
     </g>
     <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-      <text y="0.71em" transform="translate(102.83333333333333,170)">4,000</text>
-      <text y="0.71em" transform="translate(199.5,170)">6,000</text>
+      <text y="0.71em" transform="translate(53.666666666666664,170)">3,000</text>
+      <text y="0.71em" transform="translate(99.22222222222223,170)">4,000</text>
+      <text y="0.71em" transform="translate(144.77777777777777,170)">5,000</text>
+      <text y="0.71em" transform="translate(190.33333333333334,170)">6,000</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="78.66666666666666" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="98" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.91666666666667" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="79.875" cy="102.2909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="89.54166666666666" cy="65.12727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="100.41666666666667" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="66.58333333333334" cy="98.72727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="90.75" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="110.08333333333333" cy="99.23636363636365" r="3" stroke="#4e79a7"></circle>
-      <circle cx="88.33333333333334" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
-      <circle cx="93.16666666666669" cy="96.18181818181819" r="3" stroke="#4e79a7"></circle>
-      <circle cx="91.95833333333333" cy="70.21818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="88.33333333333334" cy="94.14545454545456" r="3" stroke="#4e79a7"></circle>
-      <circle cx="105.25" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="82.29166666666666" cy="99.74545454545455" r="3" stroke="#4e79a7"></circle>
-      <circle cx="105.25" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="69" cy="77.34545454545457" r="3" stroke="#f28e2c"></circle>
-      <circle cx="88.33333333333334" cy="38.145454545454555" r="3" stroke="#4e79a7"></circle>
-      <circle cx="76.25" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="122.16666666666667" cy="82.94545454545455" r="3" stroke="#f28e2c"></circle>
-      <circle cx="83.5" cy="117.56363636363636" r="3" stroke="#4e79a7"></circle>
-      <circle cx="73.83333333333334" cy="86.50909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="49.666666666666664" cy="113.49090909090908" r="3" stroke="#4e79a7"></circle>
-      <circle cx="93.16666666666669" cy="75.81818181818181" r="3" stroke="#f28e2c"></circle>
-      <circle cx="69" cy="95.67272727272726" r="3" stroke="#4e79a7"></circle>
-      <circle cx="110.08333333333333" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="73.83333333333334" cy="76.32727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="93.16666666666669" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
-      <circle cx="88.33333333333334" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="129.41666666666666" cy="64.61818181818184" r="3" stroke="#f28e2c"></circle>
-      <circle cx="64.16666666666667" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.33333333333331" cy="57.49090909090908" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.41666666666666" cy="117.05454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="107.66666666666667" cy="73.78181818181818" r="3" stroke="#f28e2c"></circle>
-      <circle cx="83.5" cy="80.39999999999999" r="3" stroke="#f28e2c"></circle>
-      <circle cx="98" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
-      <circle cx="95.58333333333331" cy="91.0909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="141.5" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="76.44444444444444" cy="96.6909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="94.66666666666667" cy="78.87272727272727" r="3" stroke="#f28e2c"></circle>
+      <circle cx="83.27777777777779" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="77.58333333333334" cy="102.2909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="86.69444444444444" cy="65.12727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="96.94444444444444" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="65.05555555555556" cy="98.72727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="87.83333333333334" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="106.05555555555556" cy="99.23636363636365" r="3" stroke="#4e79a7"></circle>
+      <circle cx="85.55555555555556" cy="72.25454545454548" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.11111111111111" cy="96.18181818181819" r="3" stroke="#4e79a7"></circle>
+      <circle cx="88.97222222222221" cy="70.21818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.55555555555556" cy="94.14545454545456" r="3" stroke="#4e79a7"></circle>
+      <circle cx="101.5" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="79.86111111111111" cy="99.74545454545455" r="3" stroke="#4e79a7"></circle>
+      <circle cx="101.5" cy="76.32727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="67.33333333333334" cy="77.34545454545457" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.55555555555556" cy="38.145454545454555" r="3" stroke="#4e79a7"></circle>
+      <circle cx="74.16666666666666" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="117.44444444444444" cy="82.94545454545455" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81" cy="117.56363636363636" r="3" stroke="#4e79a7"></circle>
+      <circle cx="71.88888888888889" cy="86.50909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="49.111111111111114" cy="113.49090909090908" r="3" stroke="#4e79a7"></circle>
+      <circle cx="90.11111111111111" cy="75.81818181818181" r="3" stroke="#f28e2c"></circle>
+      <circle cx="67.33333333333334" cy="95.67272727272726" r="3" stroke="#4e79a7"></circle>
+      <circle cx="106.05555555555556" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.88888888888889" cy="76.32727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="90.11111111111111" cy="81.41818181818182" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.55555555555556" cy="97.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="124.27777777777777" cy="64.61818181818184" r="3" stroke="#f28e2c"></circle>
+      <circle cx="62.77777777777778" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="112.88888888888889" cy="57.49090909090908" r="3" stroke="#f28e2c"></circle>
+      <circle cx="69.61111111111111" cy="117.05454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="103.77777777777777" cy="73.78181818181818" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81" cy="80.39999999999999" r="3" stroke="#f28e2c"></circle>
+      <circle cx="94.66666666666667" cy="91.60000000000001" r="3" stroke="#4e79a7"></circle>
+      <circle cx="92.38888888888889" cy="91.0909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="135.66666666666669" cy="68.69090909090909" r="3" stroke="#f28e2c"></circle>
       <circle cx="40" cy="94.65454545454547" r="3" stroke="#4e79a7"></circle>
-      <circle cx="127" cy="61.05454545454547" r="3" stroke="#f28e2c"></circle>
-      <circle cx="100.41666666666667" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.91666666666667" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="81.08333333333333" cy="74.29090909090911" r="3" stroke="#f28e2c"></circle>
-      <circle cx="78.66666666666666" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="87.125" cy="74.29090909090911" r="3" stroke="#4e79a7"></circle>
-      <circle cx="124.58333333333333" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
-      <circle cx="73.83333333333334" cy="78.36363636363636" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.33333333333331" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="66.58333333333334" cy="71.23636363636365" r="3" stroke="#f28e2c"></circle>
-      <circle cx="87.125" cy="79.89090909090912" r="3" stroke="#4e79a7"></circle>
-      <circle cx="70.20833333333334" cy="88.54545454545455" r="3" stroke="#4e79a7"></circle>
-      <circle cx="100.41666666666667" cy="71.74545454545456" r="3" stroke="#f28e2c"></circle>
-      <circle cx="83.5" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="105.25" cy="75.30909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.41666666666666" cy="117.05454545454545" r="3" stroke="#4e79a7"></circle>
-      <circle cx="76.25" cy="67.67272727272726" r="3" stroke="#f28e2c"></circle>
-      <circle cx="66.58333333333334" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="105.25" cy="82.43636363636367" r="3" stroke="#f28e2c"></circle>
-      <circle cx="93.16666666666669" cy="77.85454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="79.875" cy="101.27272727272725" r="3" stroke="#4e79a7"></circle>
-      <circle cx="100.41666666666667" cy="69.20000000000002" r="3" stroke="#f28e2c"></circle>
-      <circle cx="85.91666666666667" cy="95.16363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="85.91666666666667" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="102.83333333333333" cy="49.34545454545456" r="3" stroke="#f28e2c"></circle>
-      <circle cx="73.83333333333334" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
-      <circle cx="91.95833333333333" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="107.66666666666667" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
-      <circle cx="91.95833333333333" cy="77.85454545454546" r="3" stroke="#4e79a7"></circle>
+      <circle cx="122" cy="61.05454545454547" r="3" stroke="#f28e2c"></circle>
+      <circle cx="96.94444444444444" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="83.27777777777779" cy="98.21818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.72222222222221" cy="74.29090909090911" r="3" stroke="#f28e2c"></circle>
+      <circle cx="76.44444444444444" cy="101.78181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="84.41666666666666" cy="74.29090909090911" r="3" stroke="#4e79a7"></circle>
+      <circle cx="119.72222222222223" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.88888888888889" cy="78.36363636363636" r="3" stroke="#4e79a7"></circle>
+      <circle cx="112.88888888888889" cy="83.96363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="65.05555555555556" cy="71.23636363636365" r="3" stroke="#f28e2c"></circle>
+      <circle cx="84.41666666666666" cy="79.89090909090912" r="3" stroke="#4e79a7"></circle>
+      <circle cx="68.47222222222223" cy="88.54545454545455" r="3" stroke="#4e79a7"></circle>
+      <circle cx="96.94444444444444" cy="71.74545454545456" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="101.5" cy="75.30909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="69.61111111111111" cy="117.05454545454545" r="3" stroke="#4e79a7"></circle>
+      <circle cx="74.16666666666666" cy="67.67272727272726" r="3" stroke="#f28e2c"></circle>
+      <circle cx="65.05555555555556" cy="103.3090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="101.5" cy="82.43636363636367" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.11111111111111" cy="77.85454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="77.58333333333334" cy="101.27272727272725" r="3" stroke="#4e79a7"></circle>
+      <circle cx="96.94444444444444" cy="69.20000000000002" r="3" stroke="#f28e2c"></circle>
+      <circle cx="83.27777777777779" cy="95.16363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="83.27777777777779" cy="100.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="99.22222222222223" cy="49.34545454545456" r="3" stroke="#f28e2c"></circle>
+      <circle cx="71.88888888888889" cy="111.96363636363637" r="3" stroke="#4e79a7"></circle>
+      <circle cx="88.97222222222221" cy="80.9090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="103.77777777777777" cy="74.80000000000003" r="3" stroke="#f28e2c"></circle>
+      <circle cx="88.97222222222221" cy="77.85454545454546" r="3" stroke="#4e79a7"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(386,0)">
+  <g aria-label="facet" transform="translate(365,0)">
     <g aria-label="fy-axis tick label" text-anchor="start" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(214,100)">Adelie</text>
+      <text y="0.32em" transform="translate(204,100)">Adelie</text>
     </g>
     <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
-      <text transform="translate(127,30)">Torgersen</text>
+      <text transform="translate(122,30)">Torgersen</text>
     </g>
     <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-      <path transform="translate(102.83333333333333,170)" d="M0,0L0,6"></path>
-      <path transform="translate(199.5,170)" d="M0,0L0,6"></path>
+      <path transform="translate(53.666666666666664,170)" d="M0,0L0,6"></path>
+      <path transform="translate(99.22222222222223,170)" d="M0,0L0,6"></path>
+      <path transform="translate(144.77777777777777,170)" d="M0,0L0,6"></path>
+      <path transform="translate(190.33333333333334,170)" d="M0,0L0,6"></path>
     </g>
     <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-      <text y="0.71em" transform="translate(102.83333333333333,170)">4,000</text>
-      <text y="0.71em" transform="translate(199.5,170)">6,000</text>
+      <text y="0.71em" transform="translate(53.666666666666664,170)">3,000</text>
+      <text y="0.71em" transform="translate(99.22222222222223,170)">4,000</text>
+      <text y="0.71em" transform="translate(144.77777777777777,170)">5,000</text>
+      <text y="0.71em" transform="translate(190.33333333333334,170)">6,000</text>
     </g>
-    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="174" height="140"></rect>
+    <rect aria-label="frame" fill="none" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0.5)" x="40" y="30" width="164" height="140"></rect>
     <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
-      <circle cx="90.75" cy="134.36363636363637" r="3" stroke="#f28e2c"></circle>
-      <circle cx="93.16666666666669" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
-      <circle cx="66.58333333333334" cy="128.25454545454548" r="3" stroke="#4e79a7"></circle>
-      <circle cx="76.25" cy="146.5818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="85.91666666666667" cy="133.34545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="84.70833333333333" cy="135.3818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="135.45833333333334" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
-      <circle cx="77.45833333333334" cy="159.8181818181818" r="3" stroke="#e15759"></circle>
-      <circle cx="114.91666666666669" cy="119.60000000000002" r="3" stroke="#e15759"></circle>
-      <circle cx="69" cy="140.98181818181823" r="3" stroke="#e15759"></circle>
-      <circle cx="88.33333333333334" cy="140.98181818181823" r="3" stroke="#e15759"></circle>
-      <circle cx="64.16666666666667" cy="124.18181818181817" r="3" stroke="#4e79a7"></circle>
-      <circle cx="93.16666666666669" cy="136.9090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="122.16666666666667" cy="157.27272727272725" r="3" stroke="#f28e2c"></circle>
-      <circle cx="88.33333333333334" cy="147.0909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="76.25" cy="136.39999999999998" r="3" stroke="#4e79a7"></circle>
-      <circle cx="127" cy="117.05454545454545" r="3" stroke="#f28e2c"></circle>
-      <circle cx="70.20833333333334" cy="158.2909090909091" r="3" stroke="#4e79a7"></circle>
-      <circle cx="112.5" cy="99.23636363636365" r="3" stroke="#f28e2c"></circle>
-      <circle cx="56.91666666666667" cy="150.65454545454548" r="3" stroke="#4e79a7"></circle>
-      <circle cx="124.58333333333333" cy="120.61818181818184" r="3" stroke="#f28e2c"></circle>
-      <circle cx="83.5" cy="162.87272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="98" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81.08333333333333" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="110.08333333333333" cy="100.25454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="88.33333333333334" cy="152.69090909090912" r="3" stroke="#4e79a7"></circle>
-      <circle cx="114.91666666666669" cy="115.52727272727276" r="3" stroke="#f28e2c"></circle>
-      <circle cx="88.33333333333334" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
-      <circle cx="98" cy="144.03636363636363" r="3" stroke="#f28e2c"></circle>
-      <circle cx="81.08333333333333" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="102.83333333333333" cy="119.0909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="64.16666666666667" cy="157.27272727272725" r="3" stroke="#4e79a7"></circle>
-      <circle cx="136.66666666666669" cy="115.01818181818184" r="3" stroke="#f28e2c"></circle>
-      <circle cx="93.16666666666669" cy="146.5818181818182" r="3" stroke="#4e79a7"></circle>
-      <circle cx="112.5" cy="154.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="49.666666666666664" cy="136.9090909090909" r="3" stroke="#4e79a7"></circle>
-      <circle cx="91.95833333333333" cy="143.52727272727273" r="3" stroke="#f28e2c"></circle>
-      <circle cx="71.41666666666666" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
-      <circle cx="70.20833333333334" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
-      <circle cx="61.75" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
-      <circle cx="78.66666666666666" cy="141.4909090909091" r="3" stroke="#f28e2c"></circle>
-      <circle cx="76.25" cy="128.76363636363635" r="3" stroke="#4e79a7"></circle>
-      <circle cx="96.79166666666667" cy="122.65454545454546" r="3" stroke="#f28e2c"></circle>
-      <circle cx="56.91666666666667" cy="154.2181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="102.83333333333333" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
-      <circle cx="67.79166666666666" cy="135.89090909090913" r="3" stroke="#4e79a7"></circle>
-      <circle cx="117.33333333333331" cy="122.14545454545454" r="3" stroke="#f28e2c"></circle>
-      <circle cx="56.91666666666667" cy="134.87272727272727" r="3" stroke="#4e79a7"></circle>
-      <circle cx="102.83333333333333" cy="108.90909090909092" r="3" stroke="#f28e2c"></circle>
-      <circle cx="70.20833333333334" cy="137.4181818181818" r="3" stroke="#4e79a7"></circle>
-      <circle cx="78.66666666666666" cy="114" r="3" stroke="#f28e2c"></circle>
+      <circle cx="87.83333333333334" cy="134.36363636363637" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.11111111111111" cy="132.32727272727274" r="3" stroke="#4e79a7"></circle>
+      <circle cx="65.05555555555556" cy="128.25454545454548" r="3" stroke="#4e79a7"></circle>
+      <circle cx="74.16666666666666" cy="146.5818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="83.27777777777779" cy="133.34545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="82.13888888888889" cy="135.3818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="129.97222222222223" cy="133.85454545454544" r="3" stroke="#f28e2c"></circle>
+      <circle cx="75.30555555555556" cy="159.8181818181818" r="3" stroke="#e15759"></circle>
+      <circle cx="110.61111111111111" cy="119.60000000000002" r="3" stroke="#e15759"></circle>
+      <circle cx="67.33333333333334" cy="140.98181818181823" r="3" stroke="#e15759"></circle>
+      <circle cx="85.55555555555556" cy="140.98181818181823" r="3" stroke="#e15759"></circle>
+      <circle cx="62.77777777777778" cy="124.18181818181817" r="3" stroke="#4e79a7"></circle>
+      <circle cx="90.11111111111111" cy="136.9090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="117.44444444444444" cy="157.27272727272725" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.55555555555556" cy="147.0909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="74.16666666666666" cy="136.39999999999998" r="3" stroke="#4e79a7"></circle>
+      <circle cx="122" cy="117.05454545454545" r="3" stroke="#f28e2c"></circle>
+      <circle cx="68.47222222222223" cy="158.2909090909091" r="3" stroke="#4e79a7"></circle>
+      <circle cx="108.33333333333333" cy="99.23636363636365" r="3" stroke="#f28e2c"></circle>
+      <circle cx="55.94444444444444" cy="150.65454545454548" r="3" stroke="#4e79a7"></circle>
+      <circle cx="119.72222222222223" cy="120.61818181818184" r="3" stroke="#f28e2c"></circle>
+      <circle cx="81" cy="162.87272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="94.66666666666667" cy="131.3090909090909" r="3" stroke="#f28e2c"></circle>
+      <circle cx="78.72222222222221" cy="131.8181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="106.05555555555556" cy="100.25454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.55555555555556" cy="152.69090909090912" r="3" stroke="#4e79a7"></circle>
+      <circle cx="110.61111111111111" cy="115.52727272727276" r="3" stroke="#f28e2c"></circle>
+      <circle cx="85.55555555555556" cy="125.20000000000002" r="3" stroke="#4e79a7"></circle>
+      <circle cx="94.66666666666667" cy="144.03636363636363" r="3" stroke="#f28e2c"></circle>
+      <circle cx="78.72222222222221" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="99.22222222222223" cy="119.0909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="62.77777777777778" cy="157.27272727272725" r="3" stroke="#4e79a7"></circle>
+      <circle cx="131.11111111111111" cy="115.01818181818184" r="3" stroke="#f28e2c"></circle>
+      <circle cx="90.11111111111111" cy="146.5818181818182" r="3" stroke="#4e79a7"></circle>
+      <circle cx="108.33333333333333" cy="154.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="49.111111111111114" cy="136.9090909090909" r="3" stroke="#4e79a7"></circle>
+      <circle cx="88.97222222222221" cy="143.52727272727273" r="3" stroke="#f28e2c"></circle>
+      <circle cx="69.61111111111111" cy="151.67272727272726" r="3" stroke="#4e79a7"></circle>
+      <circle cx="68.47222222222223" cy="124.18181818181817" r="3" stroke="#f28e2c"></circle>
+      <circle cx="60.5" cy="149.12727272727273" r="3" stroke="#4e79a7"></circle>
+      <circle cx="76.44444444444444" cy="141.4909090909091" r="3" stroke="#f28e2c"></circle>
+      <circle cx="74.16666666666666" cy="128.76363636363635" r="3" stroke="#4e79a7"></circle>
+      <circle cx="93.52777777777777" cy="122.65454545454546" r="3" stroke="#f28e2c"></circle>
+      <circle cx="55.94444444444444" cy="154.2181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="99.22222222222223" cy="126.72727272727272" r="3" stroke="#f28e2c"></circle>
+      <circle cx="66.19444444444444" cy="135.89090909090913" r="3" stroke="#4e79a7"></circle>
+      <circle cx="112.88888888888889" cy="122.14545454545454" r="3" stroke="#f28e2c"></circle>
+      <circle cx="55.94444444444444" cy="134.87272727272727" r="3" stroke="#4e79a7"></circle>
+      <circle cx="99.22222222222223" cy="108.90909090909092" r="3" stroke="#f28e2c"></circle>
+      <circle cx="68.47222222222223" cy="137.4181818181818" r="3" stroke="#4e79a7"></circle>
+      <circle cx="76.44444444444444" cy="114" r="3" stroke="#f28e2c"></circle>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(386,155)">
+  <g aria-label="facet" transform="translate(365,155)">
     <g aria-label="fy-axis tick label" text-anchor="start" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(214,100)">Chinstrap</text>
-    </g>
-    <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-      <path transform="translate(102.83333333333333,170)" d="M0,0L0,6"></path>
-      <path transform="translate(199.5,170)" d="M0,0L0,6"></path>
-    </g>
-    <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-      <text y="0.71em" transform="translate(102.83333333333333,170)">4,000</text>
-      <text y="0.71em" transform="translate(199.5,170)">6,000</text>
+      <text y="0.32em" transform="translate(204,100)">Chinstrap</text>
     </g>
   </g>
-  <g aria-label="facet" transform="translate(386,310)">
+  <g aria-label="facet" transform="translate(365,310)">
     <g aria-label="fy-axis tick label" text-anchor="start" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(214,100)">Gentoo</text>
-    </g>
-    <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
-      <path transform="translate(40,155.23636363636365)" d="M0,0L-6,0"></path>
-      <path transform="translate(40,129.78181818181818)" d="M0,0L-6,0"></path>
-      <path transform="translate(40,104.32727272727274)" d="M0,0L-6,0"></path>
-      <path transform="translate(40,78.87272727272727)" d="M0,0L-6,0"></path>
-      <path transform="translate(40,53.41818181818183)" d="M0,0L-6,0"></path>
-    </g>
-    <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
-      <text y="0.32em" transform="translate(40,155.23636363636365)">35</text>
-      <text y="0.32em" transform="translate(40,129.78181818181818)">40</text>
-      <text y="0.32em" transform="translate(40,104.32727272727274)">45</text>
-      <text y="0.32em" transform="translate(40,78.87272727272727)">50</text>
-      <text y="0.32em" transform="translate(40,53.41818181818183)">55</text>
+      <text y="0.32em" transform="translate(204,100)">Gentoo</text>
     </g>
   </g>
-  <g aria-label="fy-axis label" transform="translate(37.5,0.5)">
-    <text transform="translate(600,255) rotate(-90)">species</text>
+  <g aria-label="fy-axis label" transform="translate(68.5,0.5)">
+    <text transform="translate(569,255) rotate(-90)">species</text>
   </g>
   <g aria-label="fx-axis label" transform="translate(0.5,-26.5)">
-    <text y="0.71em" transform="translate(320,30)">island</text>
+    <text y="0.71em" transform="translate(305,30)">island</text>
   </g>
   <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-26.5)">
-    <text y="0.71em" transform="translate(40,30)">↑ culmen_length_mm</text>
+    <text y="0.71em" transform="translate(41,30)">↑ culmen_length_mm</text>
   </g>
-  <g aria-label="x-axis label" text-anchor="end" transform="translate(37.5,27.5)">
-    <text transform="translate(600,480)">body_mass_g →</text>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(67.5,27.5)">
+    <text transform="translate(569,480)">body_mass_g →</text>
   </g>
 </svg>

--- a/test/plots/autoplot.js
+++ b/test/plots/autoplot.js
@@ -210,5 +210,5 @@ export async function autoDotFacet2() {
     fx: "island",
     fy: "species",
     color: "sex"
-  }).plot({marginRight: 70, x: {ticks: 5}});
+  }).plot();
 }

--- a/test/plots/autoplot.js
+++ b/test/plots/autoplot.js
@@ -210,5 +210,5 @@ export async function autoDotFacet2() {
     fx: "island",
     fy: "species",
     color: "sex"
-  }).plot();
+  }).plot({marginRight: 70, x: {ticks: 5}});
 }


### PR DESCRIPTION
fixes https://github.com/observablehq/plot/issues/1254

When a facet is empty, we could return undefined and repeat the test on f.empty after the `??`. However it felt more logical to return false, as we have “settled the matter”, so to speak.
https://github.com/observablehq/plot/blob/a7f76ef66fc7f7e6d6727e935ffdd370e69013b8/src/plot.js#L257