### PR TITLE
fix bars with maybe-ordinal reducers

### DIFF
--- a/test/output/autoBarMode.svg
+++ b/test/output/autoBarMode.svg
@@ -1,0 +1,47 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,10.5)">
+    <path transform="translate(40,23)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,45)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,67)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" transform="translate(-8.5,10.5)">
+    <text y="0.32em" transform="translate(40,23)">Adelie</text>
+    <text y="0.32em" transform="translate(40,45)">Chinstrap</text>
+    <text y="0.32em" transform="translate(40,67)">Gentoo</text>
+  </g>
+  <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
+    <text y="0.71em" transform="translate(40,55) rotate(-90)">species</text>
+  </g>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(84.5,0)">
+    <path transform="translate(59,90)" d="M0,0L0,6"></path>
+    <path transform="translate(246,90)" d="M0,0L0,6"></path>
+    <path transform="translate(433,90)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(84.5,9.5)">
+    <text y="0.71em" transform="translate(59,90)">Biscoe</text>
+    <text y="0.71em" transform="translate(246,90)">Dream</text>
+    <text y="0.71em" transform="translate(433,90)">Torgersen</text>
+  </g>
+  <g aria-label="x-axis label" transform="translate(0.5,27.5)">
+    <text transform="translate(330,90)">island</text>
+  </g>
+  <g aria-label="cell">
+    <rect x="59" width="168" y="67" height="20"></rect>
+    <rect x="246" width="168" y="45" height="20"></rect>
+    <rect x="433" width="168" y="23" height="20"></rect>
+  </g>
+</svg>

--- a/test/plots/autoplot.js
+++ b/test/plots/autoplot.js
@@ -197,6 +197,11 @@ export async function autoBarMeanZero() {
   return Plot.auto(weather, {x: "date", y: {value: "temp_max", reduce: "mean", zero: true}}).plot();
 }
 
+export async function autoBarMode() {
+  const penguins = await d3.csv("data/penguins.csv", d3.autoType);
+  return Plot.auto(penguins, {x: "island", y: {value: "species", reduce: "mode"}, mark: "bar"}).plot();
+}
+
 export async function autoLineMean() {
   const weather = await d3.csv("data/seattle-weather.csv", d3.autoType);
   return Plot.auto(weather, {x: "date", y: {value: "temp_max", reduce: "mean"}}).plot();


### PR DESCRIPTION
Fixes another bug where we assumed that reducers produce quantitative values. In some cases, _e.g._ with the _mode_ reducer, reducing preserves the input value type. For example:

```js
Plot.auto(penguins, {x: "island", y: {value: "species", reduce: "mode"}, mark: "bar"}).plot()
```

Before, barY is wrongly chosen, resulting in a degenerate plot:

<img width="640" alt="Screenshot 2023-02-15 at 1 07 58 PM" src="https://user-images.githubusercontent.com/230541/219162469-b2059c42-2c6e-4fd5-aad7-252d2910f43e.png">

After, cell is correctly chosen, since both _x_ and _y_ are ordinal:

<img width="640" alt="Screenshot 2023-02-15 at 1 08 53 PM" src="https://user-images.githubusercontent.com/230541/219163134-d9321111-807d-40a9-b8c1-748f97b70551.png">
