### PR TITLE
minimal support for bigint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "plugins": ["@typescript-eslint"],
   "parser": "@typescript-eslint/parser",
   "env": {
-    "es6": true,
+    "es2020": true,
     "node": true,
     "browser": true
   },

--- a/src/scales.js
+++ b/src/scales.js
@@ -512,7 +512,7 @@ export function coerceNumbers(values) {
 // since the result will be stored in a Float64Array and we don’t want null to
 // be coerced to zero.
 export function coerceNumber(x) {
-  return x == null ? NaN : +x;
+  return x == null ? NaN : Number(x);
 }
 
 // When coercing strings to dates, we only want to allow the ISO 8601 format

--- a/test/output/bigint1.svg
+++ b/test/output/bigint1.svg
@@ -1,0 +1,85 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+    <path transform="translate(40,370)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,339.5652173913044)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,309.1304347826087)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,278.695652173913)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,248.2608695652174)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,217.82608695652175)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,187.3913043478261)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,156.9565217391304)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,126.5217391304348)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,96.08695652173913)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,65.65217391304348)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,35.217391304347814)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+    <text y="0.32em" transform="translate(40,370)">0</text>
+    <text y="0.32em" transform="translate(40,339.5652173913044)">2</text>
+    <text y="0.32em" transform="translate(40,309.1304347826087)">4</text>
+    <text y="0.32em" transform="translate(40,278.695652173913)">6</text>
+    <text y="0.32em" transform="translate(40,248.2608695652174)">8</text>
+    <text y="0.32em" transform="translate(40,217.82608695652175)">10</text>
+    <text y="0.32em" transform="translate(40,187.3913043478261)">12</text>
+    <text y="0.32em" transform="translate(40,156.9565217391304)">14</text>
+    <text y="0.32em" transform="translate(40,126.5217391304348)">16</text>
+    <text y="0.32em" transform="translate(40,96.08695652173913)">18</text>
+    <text y="0.32em" transform="translate(40,65.65217391304348)">20</text>
+    <text y="0.32em" transform="translate(40,35.217391304347814)">22</text>
+  </g>
+  <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-16.5)">
+    <text y="0.71em" transform="translate(40,20)">↑ Frequency</text>
+  </g>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(40,370)" d="M0,0L0,6"></path>
+    <path transform="translate(98,370)" d="M0,0L0,6"></path>
+    <path transform="translate(156,370)" d="M0,0L0,6"></path>
+    <path transform="translate(214,370)" d="M0,0L0,6"></path>
+    <path transform="translate(272,370)" d="M0,0L0,6"></path>
+    <path transform="translate(330,370)" d="M0,0L0,6"></path>
+    <path transform="translate(388,370)" d="M0,0L0,6"></path>
+    <path transform="translate(446,370)" d="M0,0L0,6"></path>
+    <path transform="translate(504,370)" d="M0,0L0,6"></path>
+    <path transform="translate(562,370)" d="M0,0L0,6"></path>
+    <path transform="translate(620,370)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(40,370)">0</text>
+    <text y="0.71em" transform="translate(98,370)">200</text>
+    <text y="0.71em" transform="translate(156,370)">400</text>
+    <text y="0.71em" transform="translate(214,370)">600</text>
+    <text y="0.71em" transform="translate(272,370)">800</text>
+    <text y="0.71em" transform="translate(330,370)">1,000</text>
+    <text y="0.71em" transform="translate(388,370)">1,200</text>
+    <text y="0.71em" transform="translate(446,370)">1,400</text>
+    <text y="0.71em" transform="translate(504,370)">1,600</text>
+    <text y="0.71em" transform="translate(562,370)">1,800</text>
+    <text y="0.71em" transform="translate(620,370)">2,000</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,370)">big2 →</text>
+  </g>
+  <g aria-label="rect">
+    <rect x="41" y="20" width="144" height="350"></rect>
+    <rect x="186" y="233.0434782608696" width="144" height="136.9565217391304"></rect>
+    <rect x="331" y="263.4782608695652" width="144" height="106.52173913043481"></rect>
+    <rect x="476" y="354.7826086956522" width="144" height="15.217391304347814"></rect>
+  </g>
+  <g aria-label="rule" stroke="currentColor" transform="translate(0,0.5)">
+    <line x1="40" x2="620" y1="370" y2="370"></line>
+  </g>
+</svg>

--- a/test/output/bigint2.svg
+++ b/test/output/bigint2.svg
@@ -1,0 +1,68 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+    <path transform="translate(40,370)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,323.97764628533855)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,277.9552925706772)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,231.93293885601577)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,185.91058514135437)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,139.88823142669298)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,93.86587771203155)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,47.843523997370156)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+    <text y="0.32em" transform="translate(40,370)">0</text>
+    <text y="0.32em" transform="translate(40,323.97764628533855)">200</text>
+    <text y="0.32em" transform="translate(40,277.9552925706772)">400</text>
+    <text y="0.32em" transform="translate(40,231.93293885601577)">600</text>
+    <text y="0.32em" transform="translate(40,185.91058514135437)">800</text>
+    <text y="0.32em" transform="translate(40,139.88823142669298)">1,000</text>
+    <text y="0.32em" transform="translate(40,93.86587771203155)">1,200</text>
+    <text y="0.32em" transform="translate(40,47.843523997370156)">1,400</text>
+  </g>
+  <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-16.5)">
+    <text y="0.71em" transform="translate(40,20)">↑ big2</text>
+  </g>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(40,370)" d="M0,0L0,6"></path>
+    <path transform="translate(114.35897435897435,370)" d="M0,0L0,6"></path>
+    <path transform="translate(188.7179487179487,370)" d="M0,0L0,6"></path>
+    <path transform="translate(263.0769230769231,370)" d="M0,0L0,6"></path>
+    <path transform="translate(337.4358974358974,370)" d="M0,0L0,6"></path>
+    <path transform="translate(411.7948717948718,370)" d="M0,0L0,6"></path>
+    <path transform="translate(486.1538461538462,370)" d="M0,0L0,6"></path>
+    <path transform="translate(560.5128205128206,370)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(40,370)">0</text>
+    <text y="0.71em" transform="translate(114.35897435897435,370)">5</text>
+    <text y="0.71em" transform="translate(188.7179487179487,370)">10</text>
+    <text y="0.71em" transform="translate(263.0769230769231,370)">15</text>
+    <text y="0.71em" transform="translate(337.4358974358974,370)">20</text>
+    <text y="0.71em" transform="translate(411.7948717948718,370)">25</text>
+    <text y="0.71em" transform="translate(486.1538461538462,370)">30</text>
+    <text y="0.71em" transform="translate(560.5128205128206,370)">35</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,370)">big1 →</text>
+  </g>
+  <g aria-label="line" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round" transform="translate(0.5,0.5)">
+    <marker viewBox="-5 -5 10 10" markerWidth="6.67" markerHeight="6.67" fill="currentColor" stroke="white" stroke-width="1.5" id="plot-marker-1">
+      <circle r="3"></circle>
+    </marker>
+    <path marker-start="url(#plot-marker-1)" marker-mid="url(#plot-marker-1)" marker-end="url(#plot-marker-1)" d="M40,370L54.872,369.77L69.744,369.08L84.615,367.929L99.487,366.318L114.359,364.247L129.231,361.716L144.103,358.725L158.974,355.273L173.846,351.361L188.718,346.989L203.59,342.156L218.462,336.864L233.333,331.111L248.205,324.898L263.077,318.225L277.949,311.091L292.821,303.498L307.692,295.444L322.564,286.93L337.436,277.955L352.308,268.521L367.179,258.626L382.051,248.271L396.923,237.456L411.795,226.18L426.667,214.444L441.538,202.249L456.41,189.592L471.282,176.476L486.154,162.899L501.026,148.863L515.897,134.366L530.769,119.408L545.641,103.991L560.513,88.113L575.385,71.775L590.256,54.977L605.128,37.719L620,20"></path>
+  </g>
+</svg>

--- a/test/output/bigintLog.svg
+++ b/test/output/bigintLog.svg
@@ -1,0 +1,120 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(20,30)" d="M0,0L0,6"></path>
+    <path transform="translate(76.76010785506101,30)" d="M0,0L0,6"></path>
+    <path transform="translate(109.96264248716004,30)" d="M0,0L0,6"></path>
+    <path transform="translate(133.52021571012202,30)" d="M0,0L0,6"></path>
+    <path transform="translate(151.792889097503,30)" d="M0,0L0,6"></path>
+    <path transform="translate(166.72275034222105,30)" d="M0,0L0,6"></path>
+    <path transform="translate(179.345768163426,30)" d="M0,0L0,6"></path>
+    <path transform="translate(190.280323565183,30)" d="M0,0L0,6"></path>
+    <path transform="translate(199.9252849743201,30)" d="M0,0L0,6"></path>
+    <path transform="translate(208.5529969525641,30)" d="M0,0L0,6"></path>
+    <path transform="translate(265.31310480762505,30)" d="M0,0L0,6"></path>
+    <path transform="translate(298.5156394397241,30)" d="M0,0L0,6"></path>
+    <path transform="translate(322.07321266268605,30)" d="M0,0L0,6"></path>
+    <path transform="translate(340.345886050067,30)" d="M0,0L0,6"></path>
+    <path transform="translate(355.27574729478505,30)" d="M0,0L0,6"></path>
+    <path transform="translate(367.89876511599005,30)" d="M0,0L0,6"></path>
+    <path transform="translate(378.83332051774704,30)" d="M0,0L0,6"></path>
+    <path transform="translate(388.47828192688416,30)" d="M0,0L0,6"></path>
+    <path transform="translate(397.1059939051282,30)" d="M0,0L0,6"></path>
+    <path transform="translate(453.8661017601891,30)" d="M0,0L0,6"></path>
+    <path transform="translate(487.0686363922881,30)" d="M0,0L0,6"></path>
+    <path transform="translate(510.6262096152501,30)" d="M0,0L0,6"></path>
+    <path transform="translate(528.898883002631,30)" d="M0,0L0,6"></path>
+    <path transform="translate(543.8287442473492,30)" d="M0,0L0,6"></path>
+    <path transform="translate(556.4517620685541,30)" d="M0,0L0,6"></path>
+    <path transform="translate(567.3863174703112,30)" d="M0,0L0,6"></path>
+    <path transform="translate(577.0312788794482,30)" d="M0,0L0,6"></path>
+    <path transform="translate(585.6589908576922,30)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(20,30)">1</text>
+    <text y="0.71em" transform="translate(76.76010785506101,30)">2</text>
+    <text y="0.71em" transform="translate(109.96264248716004,30)"></text>
+    <text y="0.71em" transform="translate(133.52021571012202,30)"></text>
+    <text y="0.71em" transform="translate(151.792889097503,30)"></text>
+    <text y="0.71em" transform="translate(166.72275034222105,30)"></text>
+    <text y="0.71em" transform="translate(179.345768163426,30)"></text>
+    <text y="0.71em" transform="translate(190.280323565183,30)"></text>
+    <text y="0.71em" transform="translate(199.9252849743201,30)"></text>
+    <text y="0.71em" transform="translate(208.5529969525641,30)">10</text>
+    <text y="0.71em" transform="translate(265.31310480762505,30)">20</text>
+    <text y="0.71em" transform="translate(298.5156394397241,30)"></text>
+    <text y="0.71em" transform="translate(322.07321266268605,30)"></text>
+    <text y="0.71em" transform="translate(340.345886050067,30)"></text>
+    <text y="0.71em" transform="translate(355.27574729478505,30)"></text>
+    <text y="0.71em" transform="translate(367.89876511599005,30)"></text>
+    <text y="0.71em" transform="translate(378.83332051774704,30)"></text>
+    <text y="0.71em" transform="translate(388.47828192688416,30)"></text>
+    <text y="0.71em" transform="translate(397.1059939051282,30)">100</text>
+    <text y="0.71em" transform="translate(453.8661017601891,30)">200</text>
+    <text y="0.71em" transform="translate(487.0686363922881,30)"></text>
+    <text y="0.71em" transform="translate(510.6262096152501,30)"></text>
+    <text y="0.71em" transform="translate(528.898883002631,30)"></text>
+    <text y="0.71em" transform="translate(543.8287442473492,30)"></text>
+    <text y="0.71em" transform="translate(556.4517620685541,30)"></text>
+    <text y="0.71em" transform="translate(567.3863174703112,30)"></text>
+    <text y="0.71em" transform="translate(577.0312788794482,30)"></text>
+    <text y="0.71em" transform="translate(585.6589908576922,30)">1k</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,30)">big2 →</text>
+  </g>
+  <g aria-label="tick" transform="translate(0.5,0)">
+    <line x1="20" x2="20" y1="0" y2="30" stroke="rgb(58, 38, 100)"></line>
+    <line x1="133.52021571012202" x2="133.52021571012202" y1="0" y2="30" stroke="rgb(71, 55, 155)"></line>
+    <line x1="199.9252849743201" x2="199.9252849743201" y1="0" y2="30" stroke="rgb(75, 72, 195)"></line>
+    <line x1="247.04043142024403" x2="247.04043142024403" y1="0" y2="30" stroke="rgb(73, 90, 223)"></line>
+    <line x1="283.585778195006" x2="283.585778195006" y1="0" y2="30" stroke="rgb(68, 108, 240)"></line>
+    <line x1="313.4455006844421" x2="313.4455006844421" y1="0" y2="30" stroke="rgb(61, 126, 248)"></line>
+    <line x1="338.691536326852" x2="338.691536326852" y1="0" y2="30" stroke="rgb(53, 143, 248)"></line>
+    <line x1="360.560647130366" x2="360.560647130366" y1="0" y2="30" stroke="rgb(46, 160, 244)"></line>
+    <line x1="379.8505699486402" x2="379.8505699486402" y1="0" y2="30" stroke="rgb(40, 177, 234)"></line>
+    <line x1="397.1059939051282" x2="397.1059939051282" y1="0" y2="30" stroke="rgb(37, 192, 222)"></line>
+    <line x1="412.7154235821226" x2="412.7154235821226" y1="0" y2="30" stroke="rgb(37, 206, 207)"></line>
+    <line x1="426.96571639456414" x2="426.96571639456414" y1="0" y2="30" stroke="rgb(40, 218, 191)"></line>
+    <line x1="440.07471502567995" x2="440.07471502567995" y1="0" y2="30" stroke="rgb(46, 229, 174)"></line>
+    <line x1="452.2117520369741" x2="452.2117520369741" y1="0" y2="30" stroke="rgb(56, 238, 157)"></line>
+    <line x1="463.5110631693262" x2="463.5110631693262" y1="0" y2="30" stroke="rgb(68, 245, 141)"></line>
+    <line x1="474.08086284048807" x2="474.08086284048807" y1="0" y2="30" stroke="rgb(83, 250, 125)"></line>
+    <line x1="484.00966344584674" x2="484.00966344584674" y1="0" y2="30" stroke="rgb(100, 253, 111)"></line>
+    <line x1="493.37078565876226" x2="493.37078565876226" y1="0" y2="30" stroke="rgb(119, 254, 98)"></line>
+    <line x1="502.22564764707806" x2="502.22564764707806" y1="0" y2="30" stroke="rgb(138, 252, 86)"></line>
+    <line x1="510.6262096152501" x2="510.6262096152501" y1="0" y2="30" stroke="rgb(159, 249, 76)"></line>
+    <line x1="518.6168213011721" x2="518.6168213011721" y1="0" y2="30" stroke="rgb(179, 243, 67)"></line>
+    <line x1="526.2356392922446" x2="526.2356392922446" y1="0" y2="30" stroke="rgb(198, 235, 59)"></line>
+    <line x1="533.5157290296936" x2="533.5157290296936" y1="0" y2="30" stroke="rgb(216, 225, 53)"></line>
+    <line x1="540.4859321046862" x2="540.4859321046862" y1="0" y2="30" stroke="rgb(231, 214, 47)"></line>
+    <line x1="547.171556390012" x2="547.171556390012" y1="0" y2="30" stroke="rgb(244, 200, 43)"></line>
+    <line x1="553.594930735802" x2="553.594930735802" y1="0" y2="30" stroke="rgb(254, 185, 39)"></line>
+    <line x1="559.7758549229603" x2="559.7758549229603" y1="0" y2="30" stroke="rgb(255, 169, 36)"></line>
+    <line x1="565.7319677470961" x2="565.7319677470961" y1="0" y2="30" stroke="rgb(255, 152, 33)"></line>
+    <line x1="571.4790504825553" x2="571.4790504825553" y1="0" y2="30" stroke="rgb(255, 135, 30)"></line>
+    <line x1="577.0312788794482" x2="577.0312788794482" y1="0" y2="30" stroke="rgb(255, 116, 27)"></line>
+    <line x1="582.4014338254087" x2="582.4014338254087" y1="0" y2="30" stroke="rgb(248, 98, 24)"></line>
+    <line x1="587.60107855061" x2="587.60107855061" y1="0" y2="30" stroke="rgb(236, 81, 21)"></line>
+    <line x1="592.6407085564427" x2="592.6407085564427" y1="0" y2="30" stroke="rgb(221, 64, 17)"></line>
+    <line x1="597.5298791559687" x2="597.5298791559687" y1="0" y2="30" stroke="rgb(205, 48, 13)"></line>
+    <line x1="602.2773145218581" x2="602.2773145218581" y1="0" y2="30" stroke="rgb(188, 35, 9)"></line>
+    <line x1="606.8910013688842" x2="606.8910013688842" y1="0" y2="30" stroke="rgb(171, 24, 5)"></line>
+    <line x1="611.3782697980196" x2="611.3782697980196" y1="0" y2="30" stroke="rgb(157, 16, 0)"></line>
+    <line x1="615.7458633572002" x2="615.7458633572002" y1="0" y2="30" stroke="rgb(147, 12, 0)"></line>
+    <line x1="620" x2="620" y1="0" y2="30" stroke="rgb(144, 12, 0)"></line>
+  </g>
+</svg>

--- a/test/output/bigintOrdinal.html
+++ b/test/output/bigintOrdinal.html
@@ -1,0 +1,114 @@
+<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+      .plot {
+        display: block;
+        background: white;
+        height: auto;
+        height: intrinsic;
+        max-width: 100%;
+        overflow: visible;
+      }
+
+      .plot text {
+        white-space: pre;
+      }
+    </style>
+    <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAABH0lEQVQ4jX2QQW4bUQxDn6hJ6sTtuosse/8jSuzi64/HblADAvlIDjDj+PP7y0f+4tCdQz9J3Tnyk9Qd6YPMT6QPlDekG5E3QjeUP4h8B43mO6E3yDm9QR44D9CBM4cTS0tTOAUpWsIZkwVW4ARn0BlYDDPedILlyT1+a5+MevKG7KWzQeusWv7M6uziGx9RxOxCRUQ/qU4uNHtFo9lo83dKk5csWT53TpPDYvW7S17OTeJ/2Zv90OkOb57s9Bduo531o1c/WBddf+32Rn7mKM6d2kQbFUsbokw00Ib6j5ahrzr+dfPEL88Nd4F79GTo8rrTQ8/umtepq6teXZXpnr5N1cW316uM757nPBt7vfZk7Z0t7/mM7c3lDMTy+/cXwM9vrI9SuXIAAAAASUVORK5CYII="></image>
+    <g transform="translate(0,28)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+      <g class="tick" opacity="1" transform="translate(0.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em">1</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(72.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em">2</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(115.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em">3</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(144.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em"></text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(168.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em"></text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(187.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em"></text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(203.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em"></text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(217.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em"></text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(229.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em"></text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(240.5,0)">
+        <line stroke="currentColor" y2="6" y1="-10"></line>
+        <text fill="currentColor" y="9" dy="0.71em">10</text>
+      </g>
+    </g>
+    <text x="0" y="12" fill="currentColor" font-weight="bold">big1</text>
+  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+      .plot-2 {
+        display: block;
+        background: white;
+        height: auto;
+        height: intrinsic;
+        max-width: 100%;
+      }
+
+      .plot-2 text,
+      .plot-2 tspan {
+        white-space: pre;
+      }
+    </style>
+    <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(27,0)">
+      <path transform="translate(28,30)" d="M0,0L0,6"></path>
+      <path transform="translate(87,30)" d="M0,0L0,6"></path>
+      <path transform="translate(146,30)" d="M0,0L0,6"></path>
+      <path transform="translate(205,30)" d="M0,0L0,6"></path>
+      <path transform="translate(264,30)" d="M0,0L0,6"></path>
+      <path transform="translate(323,30)" d="M0,0L0,6"></path>
+      <path transform="translate(382,30)" d="M0,0L0,6"></path>
+      <path transform="translate(441,30)" d="M0,0L0,6"></path>
+      <path transform="translate(500,30)" d="M0,0L0,6"></path>
+      <path transform="translate(559,30)" d="M0,0L0,6"></path>
+    </g>
+    <g aria-label="x-axis tick label" transform="translate(27,9.5)">
+      <text y="0.71em" transform="translate(28,30)">1</text>
+      <text y="0.71em" transform="translate(87,30)">2</text>
+      <text y="0.71em" transform="translate(146,30)">3</text>
+      <text y="0.71em" transform="translate(205,30)">4</text>
+      <text y="0.71em" transform="translate(264,30)">5</text>
+      <text y="0.71em" transform="translate(323,30)">6</text>
+      <text y="0.71em" transform="translate(382,30)">7</text>
+      <text y="0.71em" transform="translate(441,30)">8</text>
+      <text y="0.71em" transform="translate(500,30)">9</text>
+      <text y="0.71em" transform="translate(559,30)">10</text>
+    </g>
+    <g aria-label="x-axis label" transform="translate(0.5,27.5)">
+      <text transform="translate(320,30)">big1</text>
+    </g>
+    <g aria-label="cell">
+      <rect x="28" width="53" y="0" height="30" fill="rgb(35, 23, 27)"></rect>
+      <rect x="87" width="53" y="0" height="30" fill="rgb(39, 215, 195)"></rect>
+      <rect x="146" width="53" y="0" height="30" fill="rgb(131, 253, 90)"></rect>
+      <rect x="205" width="53" y="0" height="30" fill="rgb(223, 220, 50)"></rect>
+      <rect x="264" width="53" y="0" height="30" fill="rgb(255, 165, 35)"></rect>
+      <rect x="323" width="53" y="0" height="30" fill="rgb(254, 110, 26)"></rect>
+      <rect x="382" width="53" y="0" height="30" fill="rgb(222, 64, 17)"></rect>
+      <rect x="441" width="53" y="0" height="30" fill="rgb(184, 32, 8)"></rect>
+      <rect x="500" width="53" y="0" height="30" fill="rgb(155, 15, 0)"></rect>
+      <rect x="559" width="53" y="0" height="30" fill="rgb(144, 12, 0)"></rect>
+    </g>
+  </svg></figure>

--- a/test/plots/bigint.js
+++ b/test/plots/bigint.js
@@ -2,7 +2,6 @@ import * as Plot from "@observablehq/plot";
 import * as d3 from "d3";
 
 const integers = d3.range(40).map((int) => ({
-  /* eslint-disable no-undef */
   big1: BigInt(int),
   big2: BigInt(int * int)
 }));

--- a/test/plots/bigint.js
+++ b/test/plots/bigint.js
@@ -1,0 +1,24 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+const integers = d3.range(40).map((int) => ({
+  /* eslint-disable no-undef */
+  big1: BigInt(int),
+  big2: BigInt(int * int)
+}));
+
+export async function bigint1() {
+  return Plot.auto(integers, {x: "big2"}).plot();
+}
+
+export async function bigint2() {
+  return Plot.line(integers, {x: "big1", y: "big2", marker: "circle"}).plot();
+}
+
+export async function bigintLog() {
+  return Plot.tickX(integers, {x: "big2", stroke: "big1"}).plot({x: {type: "log"}});
+}
+
+export async function bigintOrdinal() {
+  return Plot.cellX(integers.slice(1, 11), {x: "big1", fill: "big1"}).plot({color: {type: "log", legend: true}});
+}

--- a/test/plots/index.js
+++ b/test/plots/index.js
@@ -283,6 +283,7 @@ export * from "./aspectRatio.js";
 export * from "./athletes-sample.js";
 export * from "./autoplot.js";
 export * from "./axis-labels.js";
+export * from "./bigint.js";
 export * from "./bin-1m.js";
 export * from "./electricity-demand.js";
 export * from "./federal-funds.js";


### PR DESCRIPTION
closes #1278

@llimllib see if you can break this branch by passing bigints to unsuspected places (a build is available at https://observablehq.com/@observablehq/plot-bigint-1278 )… note that we're supporting bigints only as channel values, not as options (_e.g._ we don't try to support `inset: 1n` or `margin: 10n`).

As I was researching all the places where we coerce values to a number, I realized that this line is probably redundant, as we enter inferLogDomain only with already-coerced channels:
https://github.com/observablehq/plot/blob/d8378f088fa39d611f3219992ad5e452418765b6/src/scales/quantitative.js#L293
