### PR TITLE
remove coercion in inferLogDomain

### DIFF
--- a/src/scales/quantitative.js
+++ b/src/scales/quantitative.js
@@ -290,7 +290,6 @@ function inferLogDomain(channels) {
   for (const {value} of channels) {
     if (value !== undefined) {
       for (let v of value) {
-        v = +v;
         if (v > 0) return inferDomain(channels, positive);
         if (v < 0) return inferDomain(channels, negative);
       }


### PR DESCRIPTION
It is redundant since in the case of a log scale, the values have already been coerced to a Float64Array by https://github.com/observablehq/plot/blob/d8378f088fa39d611f3219992ad5e452418765b6/src/scales.js#L306

(It's not a huge deal since we call it maybe just once or twice… anyway. Researched with #1279.)