### PR TITLE
autoSpec

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ export {plot} from "./plot.js";
 export {Mark, marks} from "./mark.js";
 export {Area, area, areaX, areaY} from "./marks/area.js";
 export {Arrow, arrow} from "./marks/arrow.js";
-export {auto} from "./marks/auto.js";
+export {auto, autoSpec} from "./marks/auto.js";
 export {axisX, axisY, axisFx, axisFy, gridX, gridY, gridFx, gridFy} from "./marks/axis.js";
 export {BarX, BarY, barX, barY} from "./marks/bar.js";
 export {boxX, boxY} from "./marks/box.js";

--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -93,7 +93,7 @@ export function autoSpec(data, options) {
     color: {
       value: colorValue ?? null,
       reduce: colorReduce ?? null,
-      ...(colorColor !== undefined && {color: colorColor}) // TODO ?? null
+      ...(colorColor !== undefined && {color: colorColor})
     },
     size: {
       value: sizeValue ?? null,
@@ -184,11 +184,11 @@ export function auto(data, options) {
   let markOptions = {
     fx,
     fy,
-    x: X ?? undefined,
-    y: Y ?? undefined,
+    x: X ?? undefined, // treat null x as undefined for implicit stack
+    y: Y ?? undefined, // treat null y as undefined for implicit stack
     [colorMode]: C ?? colorColor,
     z: Z,
-    r: S ?? undefined
+    r: S ?? undefined // treat null size as undefined for default constant radius
   };
   let transform;
   let transformOptions = {[colorMode]: colorReduce ?? undefined, r: sizeReduce ?? undefined};

--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -12,8 +12,7 @@ import {bin, binX, binY} from "../transforms/bin.js";
 import {group, groupX, groupY} from "../transforms/group.js";
 import {marks} from "../mark.js";
 
-/** @jsdoc auto */
-export function auto(data, {x, y, color, size, fx, fy, mark} = {}) {
+export function autoSpec(data, {x, y, color, size, fx, fy, mark} = {}) {
   // Allow x and y and other dimensions to be specified as shorthand field names
   // (but note that they can also be specified as a {transform} object such as
   // Plot.identity).
@@ -64,8 +63,6 @@ export function auto(data, {x, y, color, size, fx, fy, mark} = {}) {
   if (xReduce != null && !y) throw new Error("reducing x requires y");
   if (yReduce != null && !x) throw new Error("reducing y requires x");
 
-  let z, zReduce;
-
   // Propagate the x and y labels (field names), if any. This is necessary for
   // any column we materialize (and hence, we don’t need to do this for fx and
   // fy, since those columns are not needed for type inference and hence are not
@@ -91,7 +88,7 @@ export function auto(data, {x, y, color, size, fx, fy, mark} = {}) {
   // Determine the default mark type.
   if (mark === undefined) {
     mark =
-      sizeValue != null || sizeReduce != null
+      size != null || sizeReduce != null
         ? "dot"
         : xZero || yZero || colorReduce != null // histogram or heatmap
         ? "bar"
@@ -104,6 +101,31 @@ export function auto(data, {x, y, color, size, fx, fy, mark} = {}) {
         : null;
   }
 
+  // TODO: "?? null" on all of these, so none are undefined? (Currently breaks a lot of tests…)
+  return {
+    x: {value: x, reduce: xReduce, zero: xZero, ...xOptions},
+    y: {value: y, reduce: yReduce, zero: yZero, ...yOptions},
+    color: {value: color, color: colorColor, reduce: colorReduce},
+    size: {value: size, reduce: sizeReduce},
+    fx,
+    fy,
+    mark
+  };
+}
+
+/** @jsdoc auto */
+export function auto(data, initialOptions) {
+  let {
+    x: {value: x, reduce: xReduce, zero: xZero, ...xOptions},
+    y: {value: y, reduce: yReduce, zero: yZero, ...yOptions},
+    color: {value: color, color: colorColor, reduce: colorReduce},
+    size: {value: size, reduce: sizeReduce},
+    fx,
+    fy,
+    mark
+  } = autoSpec(data, initialOptions);
+
+  let z, zReduce;
   let colorMode; // "fill" or "stroke"
 
   // Determine the mark implementation.

--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -107,7 +107,9 @@ export function autoSpec(data, options) {
 export function auto(data, options) {
   options = normalizeOptions(options);
 
-  // Greedily materialize columns for type inference; we’ll need them anyway to plot!
+  // Greedily materialize columns for type inference; we’ll need them anyway to
+  // plot! Note that we don’t apply any type inference to the fx and fy
+  // channels, if present; these are always ordinal (at least for now).
   const {x, y, color, size} = options;
   const X = materializeValue(data, x);
   const Y = materializeValue(data, y);
@@ -248,10 +250,8 @@ function isMonotonic(values) {
 
 // Allow x and y and other dimensions to be specified as shorthand field names
 // (but note that they can also be specified as a {transform} object such as
-// Plot.identity). We don’t apply any type inference to the fx and fy channels,
-// if present, so these are simply passed-through to the underlying mark’s
-// options. We don’t support reducers on the facet channels, but for symmetry
-// with x and y we still allow the channels to be specified as {value} objects.
+// Plot.identity). We don’t support reducers for the faceting, but for symmetry
+// with x and y we allow facets to be specified as {value} objects.
 function normalizeOptions({x, y, color, size, fx, fy, mark} = {}) {
   if (!isOptions(x)) x = makeOptions(x);
   if (!isOptions(y)) y = makeOptions(y);

--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -86,7 +86,7 @@ function spec(data, {x, y, color, size, fx, fy, mark} = {}, {materialize} = {}) 
   // Determine the default mark type.
   if (mark === undefined) {
     mark =
-      size != null || sizeReduce != null
+      sizeValue != null || sizeReduce != null
         ? "dot"
         : xZero || yZero || colorReduce != null // histogram or heatmap
         ? "bar"

--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -81,13 +81,13 @@ export function autoSpec(data, options) {
     x: {
       value: xValue ?? null,
       reduce: xReduce ?? null,
-      ...(xZero !== undefined && {zero: xZero}), // TODO ?? false?
+      ...(xZero !== undefined && {zero: xZero}), // TODO realize default
       ...xOptions
     },
     y: {
       value: yValue ?? null,
       reduce: yReduce ?? null,
-      ...(yZero !== undefined && {zero: yZero}), // TODO ?? false?
+      ...(yZero !== undefined && {zero: yZero}), // TODO realize default
       ...yOptions
     },
     color: {
@@ -216,7 +216,7 @@ export function auto(data, options) {
   }
 
   // If zero-ness is not specified, default based on whether the resolved mark
-  // type will include a zero baseline.
+  // type will include a zero baseline. TODO Move this to autoSpec.
   if (xZero === undefined) xZero = transform !== binX && (mark === barX || mark === areaX || mark === rectX);
   if (yZero === undefined) yZero = transform !== binY && (mark === barY || mark === areaY || mark === rectY);
 

--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -165,7 +165,15 @@ export function auto(data, options) {
   }
 
   // Determine the mark options.
-  let markOptions = {fx, fy, x: X ?? undefined, y: Y ?? undefined, [colorMode]: C ?? colorColor, z: Z, r: S ?? undefined};
+  let markOptions = {
+    fx,
+    fy,
+    x: X ?? undefined,
+    y: Y ?? undefined,
+    [colorMode]: C ?? colorColor,
+    z: Z,
+    r: S ?? undefined
+  };
   let transform;
   let transformOptions = {[colorMode]: colorReduce ?? undefined, z: zReduce ?? undefined, r: sizeReduce ?? undefined};
   if (xReduce != null && yReduce != null) {

--- a/test/marks/auto-test.js
+++ b/test/marks/auto-test.js
@@ -3,16 +3,36 @@ import assert from "assert";
 
 it("Plot.autoSpec makes a histogram from a quantitative dimension", () => {
   const data = [{value: 1}, {value: 1}, {value: 38}];
-  const A = Plot.autoSpec(data, {x: "value"});
-  assert.strictEqual(A.y.reduce, "count");
-  assert.strictEqual(A.mark, "bar");
+  assert.deepStrictEqual(Plot.autoSpec(data, {x: "value"}), {
+    x: {
+      value: Object.assign([1, 1, 38], {label: "value"}),
+      reduce: null,
+      zero: undefined
+    },
+    y: {value: undefined, reduce: "count", zero: true},
+    color: {value: undefined, color: undefined, reduce: undefined},
+    size: {value: undefined, reduce: undefined},
+    fx: undefined,
+    fy: undefined,
+    mark: "bar"
+  });
 });
 
 it("Plot.autoSpec makes a bar chart from an ordinal dimension", () => {
   const data = [{value: "duck"}, {value: "duck"}, {value: "goose"}];
-  const A = Plot.autoSpec(data, {x: "value"});
-  assert.strictEqual(A.y.reduce, "count");
-  assert.strictEqual(A.mark, "bar");
+  assert.deepStrictEqual(Plot.autoSpec(data, {x: "value", color: "blue"}), {
+    x: {
+      value: Object.assign(["duck", "duck", "goose"], {label: "value"}),
+      reduce: null,
+      zero: undefined
+    },
+    y: {value: undefined, reduce: "count", zero: true},
+    color: {value: undefined, color: "blue", reduce: undefined},
+    size: {value: undefined, reduce: undefined},
+    fx: undefined,
+    fy: undefined,
+    mark: "bar"
+  });
 });
 
 it("Plot.autoSpec makes a line from a monotonic dimension", () => {
@@ -21,9 +41,19 @@ it("Plot.autoSpec makes a line from a monotonic dimension", () => {
     {date: 2, value: 1},
     {date: 3, value: 38}
   ];
-  const A = Plot.autoSpec(data, {x: "date", y: "value"});
-  assert.strictEqual(A.y.reduce, null);
-  assert.strictEqual(A.mark, "line");
+  assert.deepStrictEqual(Plot.autoSpec(data, {x: "date", y: "value"}), {
+    x: {value: Object.assign([1, 2, 3], {label: "date"}), reduce: null, zero: undefined},
+    y: {
+      value: Object.assign([1, 1, 38], {label: "value"}),
+      reduce: null,
+      zero: undefined
+    },
+    color: {value: undefined, color: undefined, reduce: undefined},
+    size: {value: undefined, reduce: undefined},
+    fx: undefined,
+    fy: undefined,
+    mark: "line"
+  });
 });
 
 it("Plot.autoSpec makes a dot plot from two quantitative dimensions", () => {
@@ -32,6 +62,41 @@ it("Plot.autoSpec makes a dot plot from two quantitative dimensions", () => {
     {x: 2, y: 3},
     {x: 1, y: 2}
   ];
-  const A = Plot.autoSpec(data, {x: "x", y: "y"});
-  assert.strictEqual(A.mark, "dot");
+  assert.deepStrictEqual(Plot.autoSpec(data, {x: "x", y: "y"}), {
+    x: {value: Object.assign([0, 2, 1], {label: "x"}), reduce: null, zero: undefined},
+    y: {value: Object.assign([0, 3, 2], {label: "y"}), reduce: null, zero: undefined},
+    color: {value: undefined, color: undefined, reduce: undefined},
+    size: {value: undefined, reduce: undefined},
+    fx: undefined,
+    fy: undefined,
+    mark: "dot"
+  });
+});
+
+it("Plot.autoSpec makes a faceted heatmap", () => {
+  const data = [
+    {x: 0, y: 0, f: "one"},
+    {x: 2, y: 3, f: "one"},
+    {x: 1, y: 2, f: "one"},
+    {x: 4, y: 1, f: "two"},
+    {x: 2, y: 6, f: "two"},
+    {x: 4, y: 2, f: "two"}
+  ];
+  assert.deepStrictEqual(Plot.autoSpec(data, {x: "x", y: "y", fy: "f", color: "count"}), {
+    x: {
+      value: Object.assign([0, 2, 1, 4, 2, 4], {label: "x"}),
+      reduce: null,
+      zero: undefined
+    },
+    y: {
+      value: Object.assign([0, 3, 2, 1, 6, 2], {label: "y"}),
+      reduce: null,
+      zero: undefined
+    },
+    color: {value: undefined, color: undefined, reduce: "count"},
+    size: {value: undefined, reduce: undefined},
+    fx: undefined,
+    fy: "f",
+    mark: "bar"
+  });
 });

--- a/test/marks/auto-test.js
+++ b/test/marks/auto-test.js
@@ -4,10 +4,12 @@ import assert from "assert";
 it("Plot.autoSpec makes a histogram from a quantitative dimension", () => {
   const data = [{value: 1}, {value: 1}, {value: 38}];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "value"}), {
+    fx: null,
+    fy: null,
     x: {value: "value", reduce: null},
-    y: {reduce: "count", zero: true},
-    color: {},
-    size: {},
+    y: {value: null, reduce: "count", zero: true},
+    color: {value: null, reduce: null},
+    size: {value: null, reduce: null},
     mark: "bar"
   });
 });
@@ -15,10 +17,12 @@ it("Plot.autoSpec makes a histogram from a quantitative dimension", () => {
 it("Plot.autoSpec makes a bar chart from an ordinal dimension", () => {
   const data = [{value: "duck"}, {value: "duck"}, {value: "goose"}];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "value", color: "blue"}), {
+    fx: null,
+    fy: null,
     x: {value: "value", reduce: null},
-    y: {reduce: "count", zero: true},
-    color: {color: "blue"},
-    size: {},
+    y: {value: null, reduce: "count", zero: true},
+    color: {value: null, reduce: null, color: "blue"},
+    size: {value: null, reduce: null},
     mark: "bar"
   });
 });
@@ -30,10 +34,12 @@ it("Plot.autoSpec makes a line from a monotonic dimension", () => {
     {date: 3, value: 38}
   ];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "date", y: "value"}), {
+    fx: null,
+    fy: null,
     x: {value: "date", reduce: null},
     y: {value: "value", reduce: null},
-    color: {},
-    size: {},
+    color: {value: null, reduce: null},
+    size: {value: null, reduce: null},
     mark: "line"
   });
 });
@@ -45,10 +51,12 @@ it("Plot.autoSpec makes a dot plot from two quantitative dimensions", () => {
     {x: 1, y: 2}
   ];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "x", y: "y"}), {
+    fx: null,
+    fy: null,
     x: {value: "x", reduce: null},
     y: {value: "y", reduce: null},
-    color: {},
-    size: {},
+    color: {value: null, reduce: null},
+    size: {value: null, reduce: null},
     mark: "dot"
   });
 });
@@ -63,11 +71,12 @@ it("Plot.autoSpec makes a faceted heatmap", () => {
     {x: 4, y: 2, f: "two"}
   ];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "x", y: "y", fy: "f", color: "count"}), {
+    fx: null,
+    fy: "f",
     x: {value: "x", reduce: null},
     y: {value: "y", reduce: null},
-    color: {reduce: "count"},
-    size: {},
-    fy: "f",
+    color: {value: null, reduce: "count"},
+    size: {value: null, reduce: null},
     mark: "bar"
   });
 });

--- a/test/marks/auto-test.js
+++ b/test/marks/auto-test.js
@@ -1,0 +1,37 @@
+import * as Plot from "@observablehq/plot";
+import assert from "assert";
+
+it("Plot.autoSpec makes a histogram from a quantitative dimension", () => {
+  const data = [{value: 1}, {value: 1}, {value: 38}];
+  const A = Plot.autoSpec(data, {x: "value"});
+  assert.strictEqual(A.y.reduce, "count");
+  assert.strictEqual(A.mark, "bar");
+});
+
+it("Plot.autoSpec makes a bar chart from an ordinal dimension", () => {
+  const data = [{value: "duck"}, {value: "duck"}, {value: "goose"}];
+  const A = Plot.autoSpec(data, {x: "value"});
+  assert.strictEqual(A.y.reduce, "count");
+  assert.strictEqual(A.mark, "bar");
+});
+
+it("Plot.autoSpec makes a line from a monotonic dimension", () => {
+  const data = [
+    {date: 1, value: 1},
+    {date: 2, value: 1},
+    {date: 3, value: 38}
+  ];
+  const A = Plot.autoSpec(data, {x: "date", y: "value"});
+  assert.strictEqual(A.y.reduce, null);
+  assert.strictEqual(A.mark, "line");
+});
+
+it("Plot.autoSpec makes a dot plot from two quantitative dimensions", () => {
+  const data = [
+    {x: 0, y: 0},
+    {x: 2, y: 3},
+    {x: 1, y: 2}
+  ];
+  const A = Plot.autoSpec(data, {x: "x", y: "y"});
+  assert.strictEqual(A.mark, "dot");
+});

--- a/test/marks/auto-test.js
+++ b/test/marks/auto-test.js
@@ -4,16 +4,10 @@ import assert from "assert";
 it("Plot.autoSpec makes a histogram from a quantitative dimension", () => {
   const data = [{value: 1}, {value: 1}, {value: 38}];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "value"}), {
-    x: {
-      value: Object.assign([1, 1, 38], {label: "value"}),
-      reduce: null,
-      zero: undefined
-    },
-    y: {value: undefined, reduce: "count", zero: true},
-    color: {value: undefined, color: undefined, reduce: undefined},
-    size: {value: undefined, reduce: undefined},
-    fx: undefined,
-    fy: undefined,
+    x: {value: "value", reduce: null},
+    y: {reduce: "count", zero: true},
+    color: {},
+    size: {},
     mark: "bar"
   });
 });
@@ -21,16 +15,10 @@ it("Plot.autoSpec makes a histogram from a quantitative dimension", () => {
 it("Plot.autoSpec makes a bar chart from an ordinal dimension", () => {
   const data = [{value: "duck"}, {value: "duck"}, {value: "goose"}];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "value", color: "blue"}), {
-    x: {
-      value: Object.assign(["duck", "duck", "goose"], {label: "value"}),
-      reduce: null,
-      zero: undefined
-    },
-    y: {value: undefined, reduce: "count", zero: true},
-    color: {value: undefined, color: "blue", reduce: undefined},
-    size: {value: undefined, reduce: undefined},
-    fx: undefined,
-    fy: undefined,
+    x: {value: "value", reduce: null},
+    y: {reduce: "count", zero: true},
+    color: {color: "blue"},
+    size: {},
     mark: "bar"
   });
 });
@@ -42,16 +30,10 @@ it("Plot.autoSpec makes a line from a monotonic dimension", () => {
     {date: 3, value: 38}
   ];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "date", y: "value"}), {
-    x: {value: Object.assign([1, 2, 3], {label: "date"}), reduce: null, zero: undefined},
-    y: {
-      value: Object.assign([1, 1, 38], {label: "value"}),
-      reduce: null,
-      zero: undefined
-    },
-    color: {value: undefined, color: undefined, reduce: undefined},
-    size: {value: undefined, reduce: undefined},
-    fx: undefined,
-    fy: undefined,
+    x: {value: "date", reduce: null},
+    y: {value: "value", reduce: null},
+    color: {},
+    size: {},
     mark: "line"
   });
 });
@@ -63,12 +45,10 @@ it("Plot.autoSpec makes a dot plot from two quantitative dimensions", () => {
     {x: 1, y: 2}
   ];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "x", y: "y"}), {
-    x: {value: Object.assign([0, 2, 1], {label: "x"}), reduce: null, zero: undefined},
-    y: {value: Object.assign([0, 3, 2], {label: "y"}), reduce: null, zero: undefined},
-    color: {value: undefined, color: undefined, reduce: undefined},
-    size: {value: undefined, reduce: undefined},
-    fx: undefined,
-    fy: undefined,
+    x: {value: "x", reduce: null},
+    y: {value: "y", reduce: null},
+    color: {},
+    size: {},
     mark: "dot"
   });
 });
@@ -83,19 +63,10 @@ it("Plot.autoSpec makes a faceted heatmap", () => {
     {x: 4, y: 2, f: "two"}
   ];
   assert.deepStrictEqual(Plot.autoSpec(data, {x: "x", y: "y", fy: "f", color: "count"}), {
-    x: {
-      value: Object.assign([0, 2, 1, 4, 2, 4], {label: "x"}),
-      reduce: null,
-      zero: undefined
-    },
-    y: {
-      value: Object.assign([0, 3, 2, 1, 6, 2], {label: "y"}),
-      reduce: null,
-      zero: undefined
-    },
-    color: {value: undefined, color: undefined, reduce: "count"},
-    size: {value: undefined, reduce: undefined},
-    fx: undefined,
+    x: {value: "x", reduce: null},
+    y: {value: "y", reduce: null},
+    color: {reduce: "count"},
+    size: {},
     fy: "f",
     mark: "bar"
   });


### PR DESCRIPTION
Factors out the parts of the auto mark that fill in its options. Produces an object that you can pass as a fully-specified Plot.auto options object.

As an optimization, there are two versions:
- the internal _spec_ function optionally returns the materialized columns, so that Plot.auto doesn't have to re-materialize them in order to determine the implementation of the marks
- the exported _autoSpec_ function, which calls _spec_ but doesn't return the materialized columns

So, calling Plot.auto will still only materialize columns once; calling Plot.auto(data, Plot.autoSpec(data, options)) will materialize them twice.

Optional to-dos, I'm not sure they're necessary for now:
- [ ] Investigate making all undefineds into nulls
- [ ] More tests. I have a couple just for autoSpec but am still mostly relying on the usual mark snapshots
- [ ] Bring zero and z assignments up from auto to autoSpec?