### PR TITLE
facetAnchor: empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ The <a name="facetanchor">*mark*.**facetAnchor**</a> option controls the placeme
 * null - display the mark on each non-empty facet (default for all marks, with the exception of axis marks)
 * *top*, *right*, *bottom*, or *left* - display the mark on facets on the specified side
 * *top-empty*, *right-empty*, *bottom-empty*, or *left-empty* - display the mark on facets that have an empty space on the specified side (the empty space being either the margin, or an empty facet); this is the default for axis marks
+* *empty* - display the mark on empty facets only
 
 ## Legends
 

--- a/src/facet.js
+++ b/src/facet.js
@@ -91,7 +91,8 @@ const facetAnchors = new Map([
   ["top-empty", facetAnchorTopEmpty],
   ["right-empty", facetAnchorRightEmpty],
   ["bottom-empty", facetAnchorBottomEmpty],
-  ["left-empty", facetAnchorLeftEmpty]
+  ["left-empty", facetAnchorLeftEmpty],
+  ["empty", facetAnchorEmpty]
 ]);
 
 export function maybeFacetAnchor(facetAnchor) {
@@ -151,6 +152,10 @@ function facetAnchorRightEmpty(facets, {x: X}, {x, y, empty}) {
     const x = X[i + 1];
     return facets.find((f) => f.x === x && f.y === y)?.empty;
   }
+}
+
+function facetAnchorEmpty(facets, channels, {empty}) {
+  return empty;
 }
 
 function and(a, b) {

--- a/test/output/futureSplom.svg
+++ b/test/output/futureSplom.svg
@@ -1,0 +1,232 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="400" height="400" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="facet" transform="translate(0,0)">
+    <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+      <path transform="translate(40,117.5)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,82.5)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,47.5)" d="M0,0L-6,0"></path>
+    </g>
+    <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+      <text y="0.32em" transform="translate(40,117.5)">−1</text>
+      <text y="0.32em" transform="translate(40,82.5)">0</text>
+      <text y="0.32em" transform="translate(40,47.5)">1</text>
+    </g>
+    <g aria-label="fx-axis tick label" transform="translate(0.5,1.5)">
+      <text transform="translate(92.5,82.5)">A</text>
+    </g>
+    <rect aria-label="frame" fill="none" stroke="currentColor" transform="translate(0.5,0.5)" x="40" y="30" width="105" height="105"></rect>
+  </g>
+  <g aria-label="facet" transform="translate(0,117)">
+    <g aria-label="x-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0)">
+      <line x1="40" x2="40" y1="30" y2="135"></line>
+      <line x1="57.5" x2="57.5" y1="30" y2="135"></line>
+      <line x1="75" x2="75" y1="30" y2="135"></line>
+      <line x1="92.5" x2="92.5" y1="30" y2="135"></line>
+      <line x1="110" x2="110" y1="30" y2="135"></line>
+      <line x1="127.50000000000001" x2="127.50000000000001" y1="30" y2="135"></line>
+      <line x1="145" x2="145" y1="30" y2="135"></line>
+    </g>
+    <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
+      <line x1="40" x2="145" y1="135" y2="135"></line>
+      <line x1="40" x2="145" y1="117.5" y2="117.5"></line>
+      <line x1="40" x2="145" y1="100.00000000000001" y2="100.00000000000001"></line>
+      <line x1="40" x2="145" y1="82.5" y2="82.5"></line>
+      <line x1="40" x2="145" y1="65" y2="65"></line>
+      <line x1="40" x2="145" y1="47.5" y2="47.5"></line>
+      <line x1="40" x2="145" y1="30" y2="30"></line>
+    </g>
+    <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+      <path transform="translate(40,117.5)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,82.5)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,47.5)" d="M0,0L-6,0"></path>
+    </g>
+    <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+      <text y="0.32em" transform="translate(40,117.5)">−1</text>
+      <text y="0.32em" transform="translate(40,82.5)">0</text>
+      <text y="0.32em" transform="translate(40,47.5)">1</text>
+    </g>
+    <g aria-label="text" transform="translate(0.5,0.5)">
+      <text y="0.32em" transform="translate(92.5,82.5)">*</text>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(0,234)">
+    <g aria-label="x-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0)">
+      <line x1="40" x2="40" y1="30" y2="135"></line>
+      <line x1="57.5" x2="57.5" y1="30" y2="135"></line>
+      <line x1="75" x2="75" y1="30" y2="135"></line>
+      <line x1="92.5" x2="92.5" y1="30" y2="135"></line>
+      <line x1="110" x2="110" y1="30" y2="135"></line>
+      <line x1="127.50000000000001" x2="127.50000000000001" y1="30" y2="135"></line>
+      <line x1="145" x2="145" y1="30" y2="135"></line>
+    </g>
+    <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
+      <line x1="40" x2="145" y1="135" y2="135"></line>
+      <line x1="40" x2="145" y1="117.5" y2="117.5"></line>
+      <line x1="40" x2="145" y1="100.00000000000001" y2="100.00000000000001"></line>
+      <line x1="40" x2="145" y1="82.5" y2="82.5"></line>
+      <line x1="40" x2="145" y1="65" y2="65"></line>
+      <line x1="40" x2="145" y1="47.5" y2="47.5"></line>
+      <line x1="40" x2="145" y1="30" y2="30"></line>
+    </g>
+    <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+      <path transform="translate(57.5,135)" d="M0,0L0,6"></path>
+      <path transform="translate(92.5,135)" d="M0,0L0,6"></path>
+      <path transform="translate(127.50000000000001,135)" d="M0,0L0,6"></path>
+    </g>
+    <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+      <text y="0.71em" transform="translate(57.5,135)">−1</text>
+      <text y="0.71em" transform="translate(92.5,135)">0</text>
+      <text y="0.71em" transform="translate(127.50000000000001,135)">1</text>
+    </g>
+    <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+      <path transform="translate(40,117.5)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,82.5)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,47.5)" d="M0,0L-6,0"></path>
+    </g>
+    <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+      <text y="0.32em" transform="translate(40,117.5)">−1</text>
+      <text y="0.32em" transform="translate(40,82.5)">0</text>
+      <text y="0.32em" transform="translate(40,47.5)">1</text>
+    </g>
+    <g aria-label="text" transform="translate(0.5,0.5)">
+      <text y="0.32em" transform="translate(92.5,82.5)">*</text>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(117,0)">
+    <g aria-label="x-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0)">
+      <line x1="40" x2="40" y1="30" y2="135"></line>
+      <line x1="57.5" x2="57.5" y1="30" y2="135"></line>
+      <line x1="75" x2="75" y1="30" y2="135"></line>
+      <line x1="92.5" x2="92.5" y1="30" y2="135"></line>
+      <line x1="110" x2="110" y1="30" y2="135"></line>
+      <line x1="127.50000000000001" x2="127.50000000000001" y1="30" y2="135"></line>
+      <line x1="145" x2="145" y1="30" y2="135"></line>
+    </g>
+    <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
+      <line x1="40" x2="145" y1="135" y2="135"></line>
+      <line x1="40" x2="145" y1="117.5" y2="117.5"></line>
+      <line x1="40" x2="145" y1="100.00000000000001" y2="100.00000000000001"></line>
+      <line x1="40" x2="145" y1="82.5" y2="82.5"></line>
+      <line x1="40" x2="145" y1="65" y2="65"></line>
+      <line x1="40" x2="145" y1="47.5" y2="47.5"></line>
+      <line x1="40" x2="145" y1="30" y2="30"></line>
+    </g>
+    <g aria-label="text" transform="translate(0.5,0.5)">
+      <text y="0.32em" transform="translate(92.5,82.5)">*</text>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(117,117)">
+    <g aria-label="fx-axis tick label" transform="translate(0.5,1.5)">
+      <text transform="translate(92.5,82.5)">B</text>
+    </g>
+    <rect aria-label="frame" fill="none" stroke="currentColor" transform="translate(0.5,0.5)" x="40" y="30" width="105" height="105"></rect>
+  </g>
+  <g aria-label="facet" transform="translate(117,234)">
+    <g aria-label="x-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0)">
+      <line x1="40" x2="40" y1="30" y2="135"></line>
+      <line x1="57.5" x2="57.5" y1="30" y2="135"></line>
+      <line x1="75" x2="75" y1="30" y2="135"></line>
+      <line x1="92.5" x2="92.5" y1="30" y2="135"></line>
+      <line x1="110" x2="110" y1="30" y2="135"></line>
+      <line x1="127.50000000000001" x2="127.50000000000001" y1="30" y2="135"></line>
+      <line x1="145" x2="145" y1="30" y2="135"></line>
+    </g>
+    <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
+      <line x1="40" x2="145" y1="135" y2="135"></line>
+      <line x1="40" x2="145" y1="117.5" y2="117.5"></line>
+      <line x1="40" x2="145" y1="100.00000000000001" y2="100.00000000000001"></line>
+      <line x1="40" x2="145" y1="82.5" y2="82.5"></line>
+      <line x1="40" x2="145" y1="65" y2="65"></line>
+      <line x1="40" x2="145" y1="47.5" y2="47.5"></line>
+      <line x1="40" x2="145" y1="30" y2="30"></line>
+    </g>
+    <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+      <path transform="translate(57.5,135)" d="M0,0L0,6"></path>
+      <path transform="translate(92.5,135)" d="M0,0L0,6"></path>
+      <path transform="translate(127.50000000000001,135)" d="M0,0L0,6"></path>
+    </g>
+    <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+      <text y="0.71em" transform="translate(57.5,135)">−1</text>
+      <text y="0.71em" transform="translate(92.5,135)">0</text>
+      <text y="0.71em" transform="translate(127.50000000000001,135)">1</text>
+    </g>
+    <g aria-label="text" transform="translate(0.5,0.5)">
+      <text y="0.32em" transform="translate(92.5,82.5)">*</text>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(234,0)">
+    <g aria-label="x-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0)">
+      <line x1="40" x2="40" y1="30" y2="135"></line>
+      <line x1="57.5" x2="57.5" y1="30" y2="135"></line>
+      <line x1="75" x2="75" y1="30" y2="135"></line>
+      <line x1="92.5" x2="92.5" y1="30" y2="135"></line>
+      <line x1="110" x2="110" y1="30" y2="135"></line>
+      <line x1="127.50000000000001" x2="127.50000000000001" y1="30" y2="135"></line>
+      <line x1="145" x2="145" y1="30" y2="135"></line>
+    </g>
+    <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
+      <line x1="40" x2="145" y1="135" y2="135"></line>
+      <line x1="40" x2="145" y1="117.5" y2="117.5"></line>
+      <line x1="40" x2="145" y1="100.00000000000001" y2="100.00000000000001"></line>
+      <line x1="40" x2="145" y1="82.5" y2="82.5"></line>
+      <line x1="40" x2="145" y1="65" y2="65"></line>
+      <line x1="40" x2="145" y1="47.5" y2="47.5"></line>
+      <line x1="40" x2="145" y1="30" y2="30"></line>
+    </g>
+    <g aria-label="text" transform="translate(0.5,0.5)">
+      <text y="0.32em" transform="translate(92.5,82.5)">*</text>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(234,117)">
+    <g aria-label="x-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0)">
+      <line x1="40" x2="40" y1="30" y2="135"></line>
+      <line x1="57.5" x2="57.5" y1="30" y2="135"></line>
+      <line x1="75" x2="75" y1="30" y2="135"></line>
+      <line x1="92.5" x2="92.5" y1="30" y2="135"></line>
+      <line x1="110" x2="110" y1="30" y2="135"></line>
+      <line x1="127.50000000000001" x2="127.50000000000001" y1="30" y2="135"></line>
+      <line x1="145" x2="145" y1="30" y2="135"></line>
+    </g>
+    <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
+      <line x1="40" x2="145" y1="135" y2="135"></line>
+      <line x1="40" x2="145" y1="117.5" y2="117.5"></line>
+      <line x1="40" x2="145" y1="100.00000000000001" y2="100.00000000000001"></line>
+      <line x1="40" x2="145" y1="82.5" y2="82.5"></line>
+      <line x1="40" x2="145" y1="65" y2="65"></line>
+      <line x1="40" x2="145" y1="47.5" y2="47.5"></line>
+      <line x1="40" x2="145" y1="30" y2="30"></line>
+    </g>
+    <g aria-label="text" transform="translate(0.5,0.5)">
+      <text y="0.32em" transform="translate(92.5,82.5)">*</text>
+    </g>
+  </g>
+  <g aria-label="facet" transform="translate(234,234)">
+    <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+      <path transform="translate(57.5,135)" d="M0,0L0,6"></path>
+      <path transform="translate(92.5,135)" d="M0,0L0,6"></path>
+      <path transform="translate(127.50000000000001,135)" d="M0,0L0,6"></path>
+    </g>
+    <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+      <text y="0.71em" transform="translate(57.5,135)">−1</text>
+      <text y="0.71em" transform="translate(92.5,135)">0</text>
+      <text y="0.71em" transform="translate(127.50000000000001,135)">1</text>
+    </g>
+    <g aria-label="fx-axis tick label" transform="translate(0.5,1.5)">
+      <text transform="translate(92.5,82.5)">C</text>
+    </g>
+    <rect aria-label="frame" fill="none" stroke="currentColor" transform="translate(0.5,0.5)" x="40" y="30" width="105" height="105"></rect>
+  </g>
+</svg>

--- a/test/plots/frame.js
+++ b/test/plots/frame.js
@@ -1,4 +1,5 @@
 import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
 
 export async function frameCorners() {
   return Plot.frame({rx: 16, ry: 10}).plot();
@@ -25,4 +26,28 @@ export async function frameSidesX() {
 
 export async function frameSidesY() {
   return Plot.plot({width: 350, height: 250, y: {domain: [0, 1]}, marks});
+}
+
+export async function futureSplom() {
+  const data = {columns: ["A", "B", "C"]};
+  return Plot.plot({
+    width: 400,
+    height: 400,
+    fx: {domain: data.columns, axis: null},
+    fy: {domain: data.columns, axis: null},
+    x: {type: "linear", domain: [-1.5, 1.5]},
+    y: {type: "linear", domain: [-1.5, 1.5]},
+    marks: [
+      Plot.gridX({ticks: 7}),
+      Plot.gridY({ticks: 7}),
+      Plot.axisX({facetAnchor: "bottom", ticks: 3}),
+      Plot.axisY({facetAnchor: "left", ticks: 3}),
+      Plot.text(
+        d3.cross(data.columns, data.columns).filter(([key1, key2]) => key2 !== key1),
+        {fx: "0", fy: "1", text: () => "*", frameAnchor: "middle"}
+      ),
+      Plot.axisFx({label: null, frameAnchor: "middle", dy: 10, facetAnchor: "empty"}),
+      Plot.frame({facetAnchor: "empty"})
+    ]
+  });
 }


### PR DESCRIPTION
This can be useful, for example with a SPLOM (not ready yet); see also https://observablehq.com/@heman/brush

<img src=https://user-images.githubusercontent.com/7001/220133592-3cf72d46-aac5-416a-b411-5a0320deba3e.png width=400>


Otherwise I have to do a weird trick:
>     Plot.axisFx({ label: null, y: (d, i) => -3.35 * (i + 0.05) }),
https://observablehq.com/@observablehq/positioning-facet-names-1287


TODO:
- [ ]  This PR (or another one) should close that loophole.
