### PR TITLE
a details channel

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -81,6 +81,20 @@ export class Mark {
     if (this.transform != null) ({facets, data} = this.transform(data, facets)), (data = arrayify(data));
     const channels = Channels(this.channels, data);
     if (this.sort != null) channelDomain(channels, facetChannels, data, this.sort); // mutates facetChannels!
+
+    // TODO design the default details channel
+    channels.details ??= {
+      value: channels.x
+        ? Array.from(channels.x.value, (x, i) => ({
+            x,
+            y: channels.y?.value[i],
+            fill: channels.fill?.value[i],
+            stroke: channels.stroke?.value[i],
+            text: channels.text?.value[i]
+          }))
+        : null,
+      filter: null
+    };
     return {data, facets, channels};
   }
   filter(index, channels, values) {

--- a/src/style.js
+++ b/src/style.js
@@ -1,4 +1,4 @@
-import {geoPath, group, namespaces} from "d3";
+import {geoPath, group, local, namespaces} from "d3";
 import {create} from "./context.js";
 import {defined, nonempty} from "./defined.js";
 import {formatDefault} from "./format.js";
@@ -46,7 +46,8 @@ export function styles(
     mixBlendMode,
     paintOrder,
     pointerEvents,
-    shapeRendering
+    shapeRendering,
+    details
   },
   {
     ariaLabel: cariaLabel,
@@ -148,7 +149,8 @@ export function styles(
     stroke: {value: vstroke, scale: "auto", optional: true},
     strokeOpacity: {value: vstrokeOpacity, scale: "opacity", optional: true},
     strokeWidth: {value: vstrokeWidth, optional: true},
-    opacity: {value: vopacity, scale: "opacity", optional: true}
+    opacity: {value: vopacity, scale: "opacity", optional: true},
+    details: {value: details, optional: true}
   };
 }
 
@@ -190,7 +192,10 @@ export function applyChannelStyles(
     strokeOpacity: SO,
     strokeWidth: SW,
     opacity: O,
-    href: H
+    href: H,
+    details: D,
+    x: X,
+    y: Y
   }
 ) {
   if (AL) applyAttr(selection, "aria-label", (i) => AL[i]);
@@ -201,7 +206,18 @@ export function applyChannelStyles(
   if (SW) applyAttr(selection, "stroke-width", (i) => SW[i]);
   if (O) applyAttr(selection, "opacity", (i) => O[i]);
   if (H) applyHref(selection, (i) => H[i], target);
+  if (D) applyDetails(selection, D, X, Y);
   applyTitle(selection, T);
+}
+
+const details = local(); // TODO: this should belong to the plot context
+const geometry = local();
+function applyDetails(selection, D, X, Y) {
+  for (const node of selection) {
+    const i = node.__data__;
+    details.set(node, D[i]);
+    geometry.set(node, {x: X[i], y: Y[i]});
+  }
 }
 
 export function applyGroupedChannelStyles(

--- a/test/plots/penguin-culmen.js
+++ b/test/plots/penguin-culmen.js
@@ -1,5 +1,7 @@
 import * as Plot from "@observablehq/plot";
 import * as d3 from "d3";
+import {pointers, quadtree} from "d3";
+import {create} from "d3";
 
 export default async function () {
   const penguins = await d3.csv("data/penguins.csv", d3.autoType);
@@ -14,8 +16,57 @@ export default async function () {
     },
     marks: [
       Plot.frame(),
-      Plot.dot(penguins, {facet: "exclude", x: "culmen_depth_mm", y: "culmen_length_mm", r: 2, fill: "#ddd"}),
-      Plot.dot(penguins, {x: "culmen_depth_mm", y: "culmen_length_mm"})
+      Plot.dot(penguins, {
+        facet: "exclude",
+        x: "culmen_depth_mm",
+        y: "culmen_length_mm",
+        r: 2,
+        fill: "#ddd",
+        details: false // TODO null
+      }),
+      Plot.dot(penguins, {x: "culmen_depth_mm", y: "culmen_length_mm", details: Plot.identity}),
+      new Tooltip()
     ]
   });
+}
+
+class Tooltip extends Plot.Mark {
+  render(I, S, C, {width, height, marginLeft, marginTop, marginRight, marginBottom}) {
+    const g = create("svg:g");
+    const popup = g
+      .append("svg:foreignObject")
+      .attr("width", 150)
+      .attr("height", 200)
+      .attr("x", marginLeft)
+      .attr("y", marginTop);
+    const div = popup.append("xhtml:div");
+    g.append("svg:rect")
+      .attr("x", marginLeft)
+      .attr("width", width - marginLeft - marginRight)
+      .attr("y", marginTop)
+      .attr("height", height - marginTop - marginBottom)
+      .attr("fill", "none")
+      .attr("pointer-events", "all")
+      .on("pointermove", function (event) {
+        if (!this.__quadtree) {
+          this.__quadtree = quadtree();
+          for (const node of g.node().parentNode.querySelectorAll("*")) {
+            // @1: details;
+            // @2: geometry;
+            if (node["@1"]) {
+              console.warn("adding", node["@1"], node["@2"]);
+              this.__quadtree.add([node["@2"].x, node["@2"].y, node["@1"]]);
+            }
+          }
+        }
+        const [[x, y]] = pointers(event);
+        const [, , closest] = this.__quadtree.find(x, y);
+        div.html(
+          Object.entries(closest)
+            .map(([k, v]) => [k, v].join(": "))
+            .join("<br>")
+        );
+      });
+    return g.node();
+  }
 }


### PR DESCRIPTION
A details channel is created on all marks. By default it is populated with the existing channels (x, y, fill, text…), but it's possible to define it with Plot.identity instead.

When the details on a mark are non-null, we store them details _and_ the scaled geometry (x, y) as local variables.

A mark (such as Tooltip) can retrieve those across all marks, and use the geometries to infer the closest mark and display the details.

This generic approach might allow to:
* have details by default (extracted from the variable channels)
* set details to be the data (Plot.identity) or anything else
  * perf. issue: special-case when it's the data to avoid creating a derived object?
* have tooltips by default on all marks
* remove default tooltips from marks which don't need them (axes, etc.)
* remove all tooltips by setting a top-level tooltip: false option (could also be opt-in)
* the tooltips (or other interaction mechanism) could be a mark, like axes, that could be set to a different mode than the default

This PR is just a way to organize some of the questions:
* where and how do we store the details
* where and how do we store the geometries (or position information)
* how would transform handle these
  * in particular, do we also need to pass the "original point index" when a transform groups values? so that brushing on a bin or group could change the *selected* value of the original points.


Just to give a hint of what could be done, the penguinCulmen test has a custom tooltip mark which just puts some html in a foreignObject. But this should be designed in a separate PR.

<img width="678" alt="Capture d’écran 2023-02-24 à 13 05 06" src="https://user-images.githubusercontent.com/7001/221175022-aa559849-f6a3-44cd-a35a-c5a4513df95d.png">
