### PR TITLE
include scale name in error

### DIFF
--- a/src/scales/ordinal.js
+++ b/src/scales/ordinal.js
@@ -52,7 +52,9 @@ export function ScaleOrdinal(key, channels, {type, interval, domain, range, sche
       }
     }
   }
-  if (unknown === scaleImplicit) throw new Error("implicit unknown is not supported");
+  if (unknown === scaleImplicit) {
+    throw new Error(`implicit unknown on ${key} scale is not supported`);
+  }
   return ScaleO(key, scaleOrdinal().unknown(unknown), channels, {...options, type, domain, range, hint});
 }
 
@@ -98,8 +100,9 @@ function inferDomain(channels, interval, key) {
     const [min, max] = extent(values).map(interval.floor, interval);
     return interval.range(min, interval.offset(max));
   }
-  if (values.size > 10e3 && registry.get(key) === position)
-    throw new Error("implicit ordinal position domain has more than 10,000 values");
+  if (values.size > 10e3 && registry.get(key) === position) {
+    throw new Error(`implicit ordinal domain of ${key} scale has more than 10,000 values`);
+  }
   return sort(values, ascendingDefined);
 }
 

--- a/src/scales/quantitative.js
+++ b/src/scales/quantitative.js
@@ -13,7 +13,6 @@ import {
   quantile,
   quantize,
   reverse as reverseof,
-  pairs,
   scaleLinear,
   scaleLog,
   scalePow,
@@ -225,9 +224,9 @@ export function ScaleThreshold(
     reverse
   }
 ) {
-  const sign = orderof(arrayify(domain)); // preserve descending domain
-  if (!pairs(domain).every(([a, b]) => isOrdered(a, b, sign)))
-    throw new Error(`the ${key} scale has a non-monotonic domain`);
+  domain = arrayify(domain);
+  const sign = orderof(domain); // preserve descending domain
+  if (!isOrdered(domain, sign)) throw new Error(`the ${key} scale has a non-monotonic domain`);
   if (reverse) range = reverseof(range); // domain ascending, so reverse range
   return {
     type: "threshold",
@@ -237,9 +236,12 @@ export function ScaleThreshold(
   };
 }
 
-function isOrdered(a, b, sign) {
-  const s = descending(a, b);
-  return s === 0 || s === sign;
+function isOrdered(domain, sign) {
+  for (let i = 1, n = domain.length, d = domain[0]; i < n; ++i) {
+    const s = descending(d, (d = domain[i]));
+    if (s !== 0 && s !== sign) return false;
+  }
+  return true;
 }
 
 export function ScaleIdentity() {

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -5,7 +5,14 @@ import it from "../jsdom.js";
 
 it("Plot throws an error if an ordinal position scale has a huge inferred domain", () => {
   assert.ok(Plot.cellX({length: 10000}, {x: d3.randomLcg(42)}).plot());
-  assert.throws(() => Plot.cellX({length: 10001}, {x: d3.randomLcg(42)}).plot());
+  assert.throws(() => Plot.cellX({length: 10001}, {x: d3.randomLcg(42)}).plot(), /implicit ordinal domain of x scale/);
+});
+
+it("Plot throws an error if scale.unknown is set to d3.scaleImplicit", () => {
+  assert.throws(
+    () => Plot.plot({color: {type: "ordinal", unknown: d3.scaleImplicit}}),
+    /implicit unknown on color scale/
+  );
 });
 
 it("Plot does not throw an error if an ordinal color scale has a huge inferred domain", () => {


### PR DESCRIPTION
Includes the scale name in errors for easier debugging.

I also rewrote the `isOrdered` helper to iterate directly, instead of materializing all the pairs using d3.pairs and then testing with _array_.every. I think it’s cleaner this way, and slightly faster, not that it matters.