### PR TITLE
auto-label functions

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -21,7 +21,7 @@ export function valueof(data, value, type) {
 }
 
 export const field = (name) => (d) => d[name];
-export const indexOf = (d, i) => i;
+export const indexOf = anonymous((d, i) => i);
 /** @jsdoc identity */
 export const identity = {transform: (d) => d};
 export const zero = () => 0;
@@ -30,9 +30,9 @@ export const yes = () => true;
 export const string = (x) => (x == null ? x : `${x}`);
 export const number = (x) => (x == null ? x : +x);
 export const boolean = (x) => (x == null ? x : !!x);
-export const first = (x) => (x ? x[0] : undefined);
-export const second = (x) => (x ? x[1] : undefined);
-export const third = (x) => (x ? x[2] : undefined);
+export const first = anonymous((x) => (x ? x[0] : undefined));
+export const second = anonymous((x) => (x ? x[1] : undefined));
+export const third = anonymous((x) => (x ? x[2] : undefined));
 export const constant = (x) => () => x;
 
 // Converts a string like “p25” into a function that takes an index I and an
@@ -217,7 +217,17 @@ export function maybeColumn(source) {
 }
 
 export function labelof(value, defaultValue) {
-  return typeof value === "string" ? value : value && value.label !== undefined ? value.label : defaultValue;
+  return typeof value === "string"
+    ? value
+    : typeof value === "function" && value.name && !/^f?[xy]\d*$/.test(value.name)
+    ? value.name
+    : value && value.label !== undefined
+    ? value.label
+    : defaultValue;
+}
+
+export function anonymous(f) {
+  return f;
 }
 
 // Assuming that both x1 and x2 and lazy columns (per above), this derives a new

--- a/src/transforms/bin.js
+++ b/src/transforms/bin.js
@@ -20,7 +20,8 @@ import {
   labelof,
   isTemporal,
   isIterable,
-  map
+  map,
+  anonymous
 } from "../options.js";
 import {coerceDate, coerceNumber} from "../scales.js";
 import {basic} from "./basic.js";
@@ -226,7 +227,7 @@ function maybeBinValueTuple(options) {
 function maybeBin(options) {
   if (options == null) return;
   const {value, cumulative, domain = extent, thresholds} = options;
-  const bin = (data) => {
+  const bin = anonymous((data) => {
     let V = valueof(data, value);
     let T; // bin thresholds
     if (isTemporal(V) || isTimeThresholds(thresholds)) {
@@ -293,7 +294,7 @@ function maybeBin(options) {
     else for (let i = 1; i < T.length; ++i) E.push([T[i - 1], T[i]]);
     E.bin = (cumulative < 0 ? bin1cn : cumulative > 0 ? bin1cp : bin1)(E, T, V);
     return E;
-  };
+  });
   bin.label = labelof(value);
   return bin;
 }

--- a/test/output/athletesBirthdays.svg
+++ b/test/output/athletesBirthdays.svg
@@ -41,6 +41,9 @@
     <text y="0.32em" transform="translate(40,226)">Nov</text>
     <text y="0.32em" transform="translate(40,246)">Dec</text>
   </g>
+  <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
+    <text y="0.71em" transform="translate(40,145) rotate(-90)">month</text>
+  </g>
   <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
     <path transform="translate(40,270)" d="M0,0L0,6"></path>
     <path transform="translate(142.00364298724955,270)" d="M0,0L0,6"></path>

--- a/test/output/moviesProfitByGenre.svg
+++ b/test/output/moviesProfitByGenre.svg
@@ -43,6 +43,9 @@
     <text y="0.32em" transform="translate(120,246)">Western</text>
     <text y="0.32em" transform="translate(120,266)">Other</text>
   </g>
+  <g aria-label="y-axis label" transform="translate(-116.5,0.5)">
+    <text y="0.71em" transform="translate(120,155) rotate(-90)">Genre</text>
+  </g>
   <g aria-label="x-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0)">
     <line x1="182.141592920354" x2="182.141592920354" y1="20" y2="290"></line>
     <line x1="268.5132743362832" x2="268.5132743362832" y1="20" y2="290"></line>

--- a/test/output/seattleTemperatureAmplitude.html
+++ b/test/output/seattleTemperatureAmplitude.html
@@ -40,6 +40,7 @@
         <text fill="currentColor" y="9" dy="0.71em">Nov</text>
       </g>
     </g>
+    <text x="0" y="12" fill="currentColor" font-weight="bold">fill</text>
   </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="441.5" viewBox="0 0 640 441.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-2 {

--- a/test/plots/athletes-birthdays.js
+++ b/test/plots/athletes-birthdays.js
@@ -3,17 +3,15 @@ import * as d3 from "d3";
 
 export default async function () {
   const athletes = await d3.csv("data/athletes.csv", d3.autoType);
+  const month = (d) => d.date_of_birth.getUTCMonth();
   return Plot.plot({
     marginRight: 40,
     y: {
       tickFormat: Plot.formatMonth()
     },
     marks: [
-      Plot.barX(athletes, Plot.groupY({x: "count"}, {y: (d) => d.date_of_birth.getUTCMonth()})),
-      Plot.textX(
-        athletes,
-        Plot.groupY({x: "count", text: "count"}, {y: (d) => d.date_of_birth.getUTCMonth(), dx: 4, frameAnchor: "left"})
-      ),
+      Plot.barX(athletes, Plot.groupY({x: "count"}, {y: month})),
+      Plot.textX(athletes, Plot.groupY({x: "count", text: "count"}, {y: month, dx: 4, frameAnchor: "left"})),
       Plot.ruleX([0])
     ]
   });


### PR DESCRIPTION
This an idea that I think we should not pursue, but was somewhat interesting. What if we inferred a channel label from the name of the associated value function? Then in cases like this, we can get a nice automatic label (“decade” for _fy_):

```js
{
  const athletes = await d3.csv("data/athletes.csv", d3.autoType);
  const decade = (d) => `${Math.floor(d.date_of_birth.getUTCFullYear() / 10) * 10}`;
  return Plot.plot({
    grid: true,
    marks: [
      Plot.dot(athletes, {x: "weight", y: "height", fx: "sex", fy: decade}),
      Plot.tooltip(athletes, {x: "weight", y: "height", fx: "sex", fy: decade})
    ]
  });
}
```

(Note that ECMAScript formalizes how arrow functions are named; see https://stackoverflow.com/a/37488652.)

Unfortunately, there are a few cases where we get undesirable names this way:

1. Internal functions such as `bin` need to be anonymized.
2. Channel declarations such as `fy: (d) => …` inherit the name of the channel.
3. Code minimization might introduce nonsense names.

As such, I don’t think we should pursue this. But it was an interesting experiment.