### PR TITLE
Auto mark: zero baseline default for rules

### DIFF
--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -216,8 +216,8 @@ export function auto(data, options) {
 
   // If zero-ness is not specified, default based on whether the resolved mark
   // type will include a zero baseline. TODO Move this to autoSpec.
-  if (xZero === undefined) xZero = transform !== binX && (mark === barX || mark === areaX || mark === rectX);
-  if (yZero === undefined) yZero = transform !== binY && (mark === barY || mark === areaY || mark === rectY);
+  if (xZero === undefined) xZero = transform !== binX && (mark === barX || mark === areaX || mark === rectX || mark === ruleY);
+  if (yZero === undefined) yZero = transform !== binY && (mark === barY || mark === areaY || mark === rectY || mark === ruleX);
 
   // In the case of filled marks (particularly bars and areas) the frame and
   // rules should come after the mark; in the case of stroked marks

--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -216,8 +216,10 @@ export function auto(data, options) {
 
   // If zero-ness is not specified, default based on whether the resolved mark
   // type will include a zero baseline. TODO Move this to autoSpec.
-  if (xZero === undefined) xZero = transform !== binX && (mark === barX || mark === areaX || mark === rectX || mark === ruleY);
-  if (yZero === undefined) yZero = transform !== binY && (mark === barY || mark === areaY || mark === rectY || mark === ruleX);
+  if (xZero === undefined)
+    xZero = X && transform !== binX && (mark === barX || mark === areaX || mark === rectX || mark === ruleY);
+  if (yZero === undefined)
+    yZero = Y && transform !== binY && (mark === barY || mark === areaY || mark === rectY || mark === ruleX);
 
   // In the case of filled marks (particularly bars and areas) the frame and
   // rules should come after the mark; in the case of stroked marks

--- a/test/output/autoRuleZero.svg
+++ b/test/output/autoRuleZero.svg
@@ -1,0 +1,124 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+    <path transform="translate(40,370)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,333.15789473684214)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,296.3157894736842)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,259.4736842105263)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,222.63157894736844)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,185.78947368421052)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,148.94736842105263)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,112.10526315789474)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,75.26315789473682)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,38.42105263157893)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+    <text y="0.32em" transform="translate(40,370)">0.0</text>
+    <text y="0.32em" transform="translate(40,333.15789473684214)">0.2</text>
+    <text y="0.32em" transform="translate(40,296.3157894736842)">0.4</text>
+    <text y="0.32em" transform="translate(40,259.4736842105263)">0.6</text>
+    <text y="0.32em" transform="translate(40,222.63157894736844)">0.8</text>
+    <text y="0.32em" transform="translate(40,185.78947368421052)">1.0</text>
+    <text y="0.32em" transform="translate(40,148.94736842105263)">1.2</text>
+    <text y="0.32em" transform="translate(40,112.10526315789474)">1.4</text>
+    <text y="0.32em" transform="translate(40,75.26315789473682)">1.6</text>
+    <text y="0.32em" transform="translate(40,38.42105263157893)">1.8</text>
+  </g>
+  <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-16.5)">
+    <text y="0.71em" transform="translate(40,20)">↑ height</text>
+  </g>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(46.03753137120694,370)" d="M0,0L0,6"></path>
+    <path transform="translate(106.44592744695414,370)" d="M0,0L0,6"></path>
+    <path transform="translate(166.88740588637918,370)" d="M0,0L0,6"></path>
+    <path transform="translate(227.2958019621264,370)" d="M0,0L0,6"></path>
+    <path transform="translate(287.7041980378736,370)" d="M0,0L0,6"></path>
+    <path transform="translate(348.11259411362084,370)" d="M0,0L0,6"></path>
+    <path transform="translate(408.55407255304584,370)" d="M0,0L0,6"></path>
+    <path transform="translate(468.9624686287931,370)" d="M0,0L0,6"></path>
+    <path transform="translate(529.3708647045403,370)" d="M0,0L0,6"></path>
+    <path transform="translate(589.7792607802875,370)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(46.03753137120694,370)">1955</text>
+    <text y="0.71em" transform="translate(106.44592744695414,370)">1960</text>
+    <text y="0.71em" transform="translate(166.88740588637918,370)">1965</text>
+    <text y="0.71em" transform="translate(227.2958019621264,370)">1970</text>
+    <text y="0.71em" transform="translate(287.7041980378736,370)">1975</text>
+    <text y="0.71em" transform="translate(348.11259411362084,370)">1980</text>
+    <text y="0.71em" transform="translate(408.55407255304584,370)">1985</text>
+    <text y="0.71em" transform="translate(468.9624686287931,370)">1990</text>
+    <text y="0.71em" transform="translate(529.3708647045403,370)">1995</text>
+    <text y="0.71em" transform="translate(589.7792607802875,370)">2000</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,370)">date_of_birth →</text>
+  </g>
+  <g aria-label="rule" stroke="currentColor" transform="translate(0,0.5)">
+    <line x1="40" x2="620" y1="370" y2="370"></line>
+  </g>
+  <g aria-label="rule" stroke="currentColor" transform="translate(0.5,0)">
+    <line x1="40" x2="40" y1="370" y2="66.05263157894736"></line>
+    <line x1="52.07506274241388" x2="52.07506274241388" y1="370" y2="73.42105263157892"></line>
+    <line x1="64.16666666666667" x2="64.16666666666667" y1="370" y2="20"></line>
+    <line x1="76.25827059091947" x2="76.25827059091947" y1="370" y2="47.63157894736839"></line>
+    <line x1="88.33333333333333" x2="88.33333333333333" y1="370" y2="78.94736842105262"></line>
+    <line x1="100.4083960757472" x2="100.4083960757472" y1="370" y2="54.07894736842104"></line>
+    <line x1="112.5" x2="112.5" y1="370" y2="29.210526315789423"></line>
+    <line x1="124.59160392425281" x2="124.59160392425281" y1="370" y2="31.052631578947327"></line>
+    <line x1="136.66666666666666" x2="136.66666666666666" y1="370" y2="53.771929824561354"></line>
+    <line x1="148.74172940908053" x2="148.74172940908053" y1="370" y2="50.57894736842104"></line>
+    <line x1="160.83333333333334" x2="160.83333333333334" y1="370" y2="50.02631578947364"></line>
+    <line x1="172.92493725758612" x2="172.92493725758612" y1="370" y2="49.47368421052633"></line>
+    <line x1="185" x2="185" y1="370" y2="48.552631578947384"></line>
+    <line x1="197.07506274241388" x2="197.07506274241388" y1="370" y2="37.63157894736835"></line>
+    <line x1="209.16666666666669" x2="209.16666666666669" y1="370" y2="46.57894736842107"></line>
+    <line x1="221.25827059091944" x2="221.25827059091944" y1="370" y2="50.08771929824563"></line>
+    <line x1="233.33333333333331" x2="233.33333333333331" y1="370" y2="50.39473684210528"></line>
+    <line x1="245.4083960757472" x2="245.4083960757472" y1="370" y2="48.30143540669856"></line>
+    <line x1="257.5" x2="257.5" y1="370" y2="47.63157894736831"></line>
+    <line x1="269.5916039242528" x2="269.5916039242528" y1="370" y2="45.869565217391425"></line>
+    <line x1="281.6666666666667" x2="281.6666666666667" y1="370" y2="54.14979757085025"></line>
+    <line x1="293.74172940908056" x2="293.74172940908056" y1="370" y2="44.05572755417951"></line>
+    <line x1="305.8333333333333" x2="305.8333333333333" y1="370" y2="45.482456140350806"></line>
+    <line x1="317.9249372575861" x2="317.9249372575861" y1="370" y2="44.309210526315766"></line>
+    <line x1="330" x2="330" y1="370" y2="46.048925129725866"></line>
+    <line x1="342.0750627424139" x2="342.0750627424139" y1="370" y2="43.624525230602245"></line>
+    <line x1="354.16666666666663" x2="354.16666666666663" y1="370" y2="42.88205453392497"></line>
+    <line x1="366.25827059091944" x2="366.25827059091944" y1="370" y2="43.14082503556206"></line>
+    <line x1="378.33333333333337" x2="378.33333333333337" y1="370" y2="42.66447368421035"></line>
+    <line x1="390.4083960757472" x2="390.4083960757472" y1="370" y2="42.61557610241823"></line>
+    <line x1="402.5" x2="402.5" y1="370" y2="40.56941360846277"></line>
+    <line x1="414.5916039242528" x2="414.5916039242528" y1="370" y2="43.92887338829004"></line>
+    <line x1="426.66666666666663" x2="426.66666666666663" y1="370" y2="43.256208153233445"></line>
+    <line x1="438.74172940908056" x2="438.74172940908056" y1="370" y2="42.358208955224256"></line>
+    <line x1="450.83333333333337" x2="450.83333333333337" y1="370" y2="42.99792329158285"></line>
+    <line x1="462.9249372575861" x2="462.9249372575861" y1="370" y2="43.441364478164324"></line>
+    <line x1="475" x2="475" y1="370" y2="43.17880794701999"></line>
+    <line x1="487.0750627424139" x2="487.0750627424139" y1="370" y2="44.049821439025465"></line>
+    <line x1="499.16666666666663" x2="499.16666666666663" y1="370" y2="44.73042362002515"></line>
+    <line x1="511.25827059091944" x2="511.25827059091944" y1="370" y2="45.46608187134485"></line>
+    <line x1="523.3333333333334" x2="523.3333333333334" y1="370" y2="45.945431062318136"></line>
+    <line x1="535.4083960757472" x2="535.4083960757472" y1="370" y2="45.662550230324825"></line>
+    <line x1="547.5" x2="547.5" y1="370" y2="47.22888616891049"></line>
+    <line x1="559.5916039242528" x2="559.5916039242528" y1="370" y2="51.23515860357951"></line>
+    <line x1="571.6666666666666" x2="571.6666666666666" y1="370" y2="54.39404432132953"></line>
+    <line x1="583.7417294090806" x2="583.7417294090806" y1="370" y2="62.60458839406199"></line>
+    <line x1="595.8333333333334" x2="595.8333333333334" y1="370" y2="66.2368421052632"></line>
+    <line x1="607.9249372575862" x2="607.9249372575862" y1="370" y2="65.74561403508771"></line>
+    <line x1="620" x2="620" y1="370" y2="60.26315789473687"></line>
+  </g>
+</svg>

--- a/test/plots/autoplot.ts
+++ b/test/plots/autoplot.ts
@@ -162,6 +162,11 @@ export async function autoRectColorReducer() {
   return Plot.auto(penguins, {x: "culmen_length_mm", color: {value: "island", reduce: "mode"}}).plot();
 }
 
+export async function autoRuleZero() {
+  const athletes = await d3.csv<any>("data/athletes.csv", d3.autoType);
+  return Plot.auto(athletes, {x: "date_of_birth", y: {value: "height", reduce: "mean"}, mark: "rule"}).plot();
+}
+
 export async function autoLineColor() {
   const aapl = await d3.csv<any>("data/aapl.csv", d3.autoType);
   return Plot.auto(aapl, {x: "Date", y: "Close", color: "Close"}).plot();


### PR DESCRIPTION
[Mike writes:](https://github.com/observablehq/plot/issues/1340#issuecomment-1469302368)

>The mark-based zero check is also forgetting about rule. This should have a y = 0 rule like rect does.  

Now it does! 

|Before|After|
|-|-|
|![autoRuleZero-changed](https://user-images.githubusercontent.com/841829/225350516-f83ec6ad-7a03-4110-a527-27699f7d2269.svg)|![autoRuleZero](https://user-images.githubusercontent.com/841829/225350369-4280f509-09ab-4a17-b96f-5e67f3793cd8.svg)|

```js
Plot.auto(olympians, {x: "date_of_birth", y: {value: "height", reduce: "mean"}, mark: "rule"}).plot()
```

A couple notes:

barY or areaY or rectY or… ruleX? Yes; ruleY would be the one parallel to the y baseline, and can make sense without any zero baseline; ruleX is the one orthogonal to the baseline, which has to “stand on it” (like barY).

Merely adding `|| mark === ruleY` and `|| mark === ruleX` to the conditional breaks autoNullReduceContinuous and autoNullReduceDate, so I also added the `X &&` and `Y &&` checks, which seem like a good idea anyway.

|Broken|Fixed|
|--|--|
|![autoNullReduceContinuous-changed](https://user-images.githubusercontent.com/841829/225348268-8ae99952-718b-4268-a0b1-ca3c7e89bf4a.svg)|![autoNullReduceContinuous](https://user-images.githubusercontent.com/841829/225348852-23460129-b57a-4d75-b842-bb3a2b244780.svg)|

The new test case demonstrates the existing issue that a rule can overhang its baseline… but that sounds like a whole can of worms and I wouldn't worry about it lol:

<img width="240" alt="image" src="https://user-images.githubusercontent.com/841829/225346436-b5264fd5-9ec1-44d8-8c4c-0e64b0b8ec9f.png">