### PR TITLE
document window

### DIFF
--- a/README.md
+++ b/README.md
@@ -2457,7 +2457,7 @@ Like [Plot.mapY](#plotmapymap-options), but applies the normalize map method wit
 Plot.map({y: Plot.window(24)}, {x: "Date", y: "Close", stroke: "Symbol"})
 ```
 
-Returns a window map method for the given window size *k*, suitable for use with Plot.map. For additional options to the window transform, replace the number *k* with an object with properties *k*, *anchor*, or *reduce*.
+Returns a window map method for the given window size *k*, suitable for use with Plot.map. For additional options to the window transform, replace the number *k* with an object with properties *k*, *anchor*, *reduce*, or *strict*.
 
 #### Plot.windowX(*k*, *options*)
 

--- a/src/transforms/window.d.ts
+++ b/src/transforms/window.d.ts
@@ -65,8 +65,8 @@ export interface WindowOptions {
    */
   anchor?: "start" | "middle" | "end";
 
-  /** The shift option is deprecated. See **anchor**. */
-  shift?: never; // was "leading" | "centered" | "trailing";
+  /** @deprecated See **anchor**. */
+  shift?: "leading" | "centered" | "trailing";
 
   /** If the **strict** option is true, the output start values or end values or
    * both (depending on the **anchor**) of each series may be undefined since

--- a/src/transforms/window.d.ts
+++ b/src/transforms/window.d.ts
@@ -22,19 +22,135 @@ export type WindowReducerFunction = (values: any[]) => any;
 export type WindowReducer = WindowReducerName | WindowReducerFunction;
 
 export interface WindowOptions {
-  k?: number;
+  /**
+   * The size —number of consecutive values— in the window; includes the current
+   * value.
+   */
+  k: number;
+
+  /**
+   * The reducer returns a summary statistic from the **k** values in the
+   * current window, say to compute rolling averages, rolling minimums, or
+   * rolling maximums. The following window reducers are supported:
+   *
+   * * *min* - the minimum
+   * * *max* - the maximum
+   * * *mean* - the mean (average)
+   * * *median* - the median
+   * * *mode* - the mode (most common occurrence)
+   * * *pXX* - the percentile value, where XX is a number in [00,99]
+   * * *sum* - the sum of values
+   * * *deviation* - the standard deviation
+   * * *variance* - the variance per [Welford’s
+   *   algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm)
+   * * *difference* - the difference between the last and first window value
+   * * *ratio* - the ratio of the last and first window value
+   * * *first* - the first value
+   * * *last* - the last value
+   * * a function to be passed an array of *k* values
+   *
+   * Defaults to mean.
+   */
   reduce?: WindowReducer;
+
+  /**
+   * How to align the window:
+   *
+   * * *start* - the current value is the first element in the window
+   * * *middle* - the current value is in the middle of the window (rounded to
+   *   the left if the size **k** is even)
+   * * *end* - the current value is the last element in the window.
+   *
+   * Defaults to middle.
+   */
   anchor?: "start" | "middle" | "end";
-  shift?: "leading" | "centered" | "trailing"; // deprecated!
+
+  /** The shift option is deprecated. See **anchor**. */
+  shift?: never; // was "leading" | "centered" | "trailing";
+
+  /** If the **strict** option is true, the output start values or end values or
+   * both (depending on the **anchor**) of each series may be undefined since
+   * there are not enough elements to create a window of size **k**; output
+   * values may also be undefined if some of the input values in the
+   * corresponding window are undefined. If the **strict** option is false (the
+   * default), the window will be automatically truncated as needed, and
+   * undefined input values are ignored. For example, if **k** is 24 and
+   * **anchor** is *middle*, then the initial 11 values have effective window
+   * sizes of 13, 14, 15, … 23, and likewise the last 12 values have effective
+   * window sizes of 23, 22, 21, … 12. Values computed with a truncated window
+   * may be noisy; if you would prefer to not show this data, set the **strict**
+   * option to true.
+   */
   strict?: boolean;
 }
 
+/**
+ * Computes a moving window of the *x* channel around each data point and then
+ * derives a summary statistic from values in the current window, say to compute
+ * rolling averages, rolling minimums, or rolling maximums. The window options
+ * can be specified as the first argument, or grouped with the *options*. For
+ * example, the following are equivalent:
+ *
+ * ```js
+ * Plot.windowX(24, {x: "Anomaly", y: "Date"});
+ * Plot.windowX({k: 24, reduce: "mean", x: "Anomaly", y: "Date"});
+ * Plot.windowX({k: 24, reduce: "mean"}, {x: "Anomaly", y: "Date"});
+ * ```
+ */
 export function windowX<T>(options?: T & WindowOptions): Transformed<T>;
 
+/**
+ * Computes a moving window of the *x* channel around each data point and then
+ * derives a summary statistic from values in the current window, say to compute
+ * rolling averages, rolling minimums, or rolling maximums. The window options
+ * can be specified as the first argument, or grouped with the *options*. For
+ * example, the following are equivalent:
+ *
+ * ```js
+ * Plot.windowX(24, {x: "Anomaly", y: "Date"});
+ * Plot.windowX({k: 24, reduce: "mean", x: "Anomaly", y: "Date"});
+ * Plot.windowX({k: 24, reduce: "mean"}, {x: "Anomaly", y: "Date"});
+ * ```
+ */
 export function windowX<T>(windowOptions?: WindowOptions | number, options?: T): Transformed<T>;
 
+/**
+ * Computes a moving window of the *y* channel around each data point and then
+ * derives a summary statistic from values in the current window, say to compute
+ * rolling averages, rolling minimums, or rolling maximums. The window options
+ * can be specified as the first argument, or grouped with the *options*. For
+ * example, the following are equivalent:
+ *
+ * ```js
+ * Plot.windowY(24, {x: "Date", y: "Anomaly"});
+ * Plot.windowY({k: 24, reduce: "mean", x: "Date", y: "Anomaly"});
+ * Plot.windowY({k: 24, reduce: "mean"}, {x: "Date", y: "Anomaly"});
+ * ```
+ */
 export function windowY<T>(options?: T & WindowOptions): Transformed<T>;
 
+/**
+ * Computes a moving window of the *y* channel around each data point and then
+ * derives a summary statistic from values in the current window, say to compute
+ * rolling averages, rolling minimums, or rolling maximums. The window options
+ * can be specified as the first argument, or grouped with the *options*. For
+ * example, the following are equivalent:
+ *
+ * ```js
+ * Plot.windowY(24, {x: "Date", y: "Anomaly"});
+ * Plot.windowY({k: 24, reduce: "mean", x: "Date", y: "Anomaly"});
+ * Plot.windowY({k: 24, reduce: "mean"}, {x: "Date", y: "Anomaly"});
+ * ```
+ */
 export function windowY<T>(windowOptions?: WindowOptions | number, options?: T): Transformed<T>;
 
+/**
+ * Returns a window map method suitable for use with Plot.map. The options are
+ * the window size *k*, or an object with properties *k*, *anchor*, *reduce*, or
+ * *strict*.
+ *
+ * ```js
+ * Plot.map({y: Plot.window(24)}, {x: "Date", y: "Close", stroke: "Symbol"})
+ * ```
+ */
 export function window(options?: WindowOptions | number): Map;

--- a/src/transforms/window.d.ts
+++ b/src/transforms/window.d.ts
@@ -29,39 +29,32 @@ export interface WindowOptions {
   k: number;
 
   /**
-   * The reducer returns a summary statistic from the **k** values in the
-   * current window, say to compute rolling averages, rolling minimums, or
-   * rolling maximums. The following window reducers are supported:
+   * How to produce a summary statistic from the **k** values in the current
+   * window. The reducer may be specified as:
    *
    * * *min* - the minimum
    * * *max* - the maximum
-   * * *mean* - the mean (average)
+   * * *mean* (default) - the mean (average)
    * * *median* - the median
    * * *mode* - the mode (most common occurrence)
    * * *pXX* - the percentile value, where XX is a number in [00,99]
    * * *sum* - the sum of values
    * * *deviation* - the standard deviation
-   * * *variance* - the variance per [Welford’s
-   *   algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm)
+   * * *variance* - the variance per [Welford’s algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm)
    * * *difference* - the difference between the last and first window value
    * * *ratio* - the ratio of the last and first window value
    * * *first* - the first value
    * * *last* - the last value
-   * * a function to be passed an array of *k* values
-   *
-   * Defaults to mean.
+   * * a function to be passed an array of **k** values
    */
   reduce?: WindowReducer;
 
   /**
-   * How to align the window:
+   * How to align the rolling window, placing the current value:
    *
-   * * *start* - the current value is the first element in the window
-   * * *middle* - the current value is in the middle of the window (rounded to
-   *   the left if the size **k** is even)
-   * * *end* - the current value is the last element in the window.
-   *
-   * Defaults to middle.
+   * * *start* - as the first element in the window
+   * * *middle* (default) - in the middle of the window, rounding down if **k** is even
+   * * *end* - as the last element in the window
    */
   anchor?: "start" | "middle" | "end";
 
@@ -69,28 +62,28 @@ export interface WindowOptions {
   shift?: "leading" | "centered" | "trailing";
 
   /**
-   * If the **strict** option is true, the output start values or end values or
-   * both (depending on the **anchor**) of each series may be undefined since
-   * there are not enough elements to create a window of size **k**; output
-   * values may also be undefined if some of the input values in the
-   * corresponding window are undefined. If the **strict** option is false (the
-   * default), the window will be automatically truncated as needed, and
-   * undefined input values are ignored. For example, if **k** is 24 and
-   * **anchor** is *middle*, then the initial 11 values have effective window
-   * sizes of 13, 14, 15, … 23, and likewise the last 12 values have effective
-   * window sizes of 23, 22, 21, … 12. Values computed with a truncated window
-   * may be noisy; if you would prefer to not show this data, set the **strict**
-   * option to true.
+   * If true, the output start values or end values or both (depending on the
+   * **anchor**) of each series may be undefined since there are not enough
+   * elements to create a window of size **k**; output values may also be
+   * undefined if some of the input values in the corresponding window are
+   * undefined.
+   *
+   * If false (the default), the window will be automatically truncated as
+   * needed, and undefined input values are ignored. For example, if **k** is 24
+   * and **anchor** is *middle*, then the initial 11 values have effective
+   * window sizes of 13, 14, 15, … 23, and likewise the last 12 values have
+   * effective window sizes of 23, 22, 21, … 12. Values computed with a
+   * truncated window may be noisy; if you would prefer to not show this data,
+   * set the **strict** option to true.
    */
   strict?: boolean;
 }
 
 /**
- * Computes a moving window of the *x* channel around each data point and then
+ * Computes a moving window of *x*, *x1*, and *x2* channel values and then
  * derives a summary statistic from values in the current window, say to compute
- * rolling averages, rolling minimums, or rolling maximums. The window options
- * can be specified as the first argument, or grouped with the *options*. For
- * example, the following are equivalent:
+ * a rolling average. The window options can be specified as the first argument,
+ * or grouped with the *options*. For example, the following are equivalent:
  *
  * ```js
  * Plot.windowX(24, {x: "Anomaly", y: "Date"});
@@ -102,11 +95,11 @@ export function windowX<T>(options?: T & WindowOptions): Transformed<T>;
 export function windowX<T>(windowOptions?: WindowOptions | number, options?: T): Transformed<T>;
 
 /**
- * Computes a moving window of the *y* channel around each data point and then
- * derives a summary statistic from values in the current window, say to compute
- * rolling averages, rolling minimums, or rolling maximums. The window options
- * can be specified as the first argument, or grouped with the *options*. For
- * example, the following are equivalent:
+ * Computes a moving window of *y*, *y1*, and *y2* channel values around and
+ * then derives a summary statistic from values in the current window, say to
+ * compute a rolling average. The window options can be specified as the first
+ * argument, or grouped with the *options*. For example, the following are
+ * equivalent:
  *
  * ```js
  * Plot.windowY(24, {x: "Date", y: "Anomaly"});

--- a/src/transforms/window.d.ts
+++ b/src/transforms/window.d.ts
@@ -23,7 +23,7 @@ export type WindowReducer = WindowReducerName | WindowReducerFunction;
 
 export interface WindowOptions {
   /**
-   * The size —number of consecutive values— in the window; includes the current
+   * The size (number of consecutive values) in the window; includes the current
    * value.
    */
   k: number;

--- a/src/transforms/window.d.ts
+++ b/src/transforms/window.d.ts
@@ -68,7 +68,8 @@ export interface WindowOptions {
   /** @deprecated See **anchor**. */
   shift?: "leading" | "centered" | "trailing";
 
-  /** If the **strict** option is true, the output start values or end values or
+  /**
+   * If the **strict** option is true, the output start values or end values or
    * both (depending on the **anchor**) of each series may be undefined since
    * there are not enough elements to create a window of size **k**; output
    * values may also be undefined if some of the input values in the

--- a/src/transforms/window.d.ts
+++ b/src/transforms/window.d.ts
@@ -98,20 +98,6 @@ export interface WindowOptions {
  * ```
  */
 export function windowX<T>(options?: T & WindowOptions): Transformed<T>;
-
-/**
- * Computes a moving window of the *x* channel around each data point and then
- * derives a summary statistic from values in the current window, say to compute
- * rolling averages, rolling minimums, or rolling maximums. The window options
- * can be specified as the first argument, or grouped with the *options*. For
- * example, the following are equivalent:
- *
- * ```js
- * Plot.windowX(24, {x: "Anomaly", y: "Date"});
- * Plot.windowX({k: 24, reduce: "mean", x: "Anomaly", y: "Date"});
- * Plot.windowX({k: 24, reduce: "mean"}, {x: "Anomaly", y: "Date"});
- * ```
- */
 export function windowX<T>(windowOptions?: WindowOptions | number, options?: T): Transformed<T>;
 
 /**

--- a/src/transforms/window.d.ts
+++ b/src/transforms/window.d.ts
@@ -114,20 +114,6 @@ export function windowX<T>(windowOptions?: WindowOptions | number, options?: T):
  * ```
  */
 export function windowY<T>(options?: T & WindowOptions): Transformed<T>;
-
-/**
- * Computes a moving window of the *y* channel around each data point and then
- * derives a summary statistic from values in the current window, say to compute
- * rolling averages, rolling minimums, or rolling maximums. The window options
- * can be specified as the first argument, or grouped with the *options*. For
- * example, the following are equivalent:
- *
- * ```js
- * Plot.windowY(24, {x: "Date", y: "Anomaly"});
- * Plot.windowY({k: 24, reduce: "mean", x: "Date", y: "Anomaly"});
- * Plot.windowY({k: 24, reduce: "mean"}, {x: "Date", y: "Anomaly"});
- * ```
- */
 export function windowY<T>(windowOptions?: WindowOptions | number, options?: T): Transformed<T>;
 
 /**


### PR DESCRIPTION
remarks:
* *k* is not optional
* *shift* is deprecated
* added the *strict* option to README

for #1343 