### PR TITLE
support for fillOpacity in swatch and ramp color legends

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@ Categorical and ordinal color legends are rendered as swatches, unless *options*
 * *options*.**columns** - the number of swatches per row
 * *options*.**marginLeft** - the legend’s left margin
 * *options*.**className** - a class name, that defaults to a randomly generated string scoping the styles
+* *options*.**fillOpacity** - the swatch fill opacity; defaults to 1
 * *options*.**width** - the legend’s width (in pixels)
 
 Symbol legends are rendered as swatches and support the options above in addition to the following options:
@@ -679,6 +680,7 @@ Continuous color legends are rendered as a ramp, and can be configured with the 
 * *options*.**marginRight** - the legend’s right margin
 * *options*.**marginBottom** - the legend’s bottom margin
 * *options*.**marginLeft** - the legend’s left margin
+* *options*.**fillOpacity** - the ramp’s fill opacity; defaults to 1
 
 The **style** legend option allows custom styles to override Plot’s defaults; it has the same behavior as in Plot’s top-level [layout options](#layout-options).
 

--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ Categorical and ordinal color legends are rendered as swatches, unless *options*
 * *options*.**columns** - the number of swatches per row
 * *options*.**marginLeft** - the legend’s left margin
 * *options*.**className** - a class name, that defaults to a randomly generated string scoping the styles
-* *options*.**fillOpacity** - the swatch fill opacity; defaults to 1
+* *options*.**opacity** - the swatch opacity
 * *options*.**width** - the legend’s width (in pixels)
 
 Symbol legends are rendered as swatches and support the options above in addition to the following options:
@@ -680,7 +680,7 @@ Continuous color legends are rendered as a ramp, and can be configured with the 
 * *options*.**marginRight** - the legend’s right margin
 * *options*.**marginBottom** - the legend’s bottom margin
 * *options*.**marginLeft** - the legend’s left margin
-* *options*.**fillOpacity** - the ramp’s fill opacity; defaults to 1
+* *options*.**opacity** - the ramp’s opacity
 
 The **style** legend option allows custom styles to override Plot’s defaults; it has the same behavior as in Plot’s top-level [layout options](#layout-options).
 

--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ Categorical and ordinal color legends are rendered as swatches, unless *options*
 * *options*.**columns** - the number of swatches per row
 * *options*.**marginLeft** - the legend’s left margin
 * *options*.**className** - a class name, that defaults to a randomly generated string scoping the styles
-* *options*.**opacity** - the swatch opacity
+* *options*.**opacity** - the swatch fill opacity
 * *options*.**width** - the legend’s width (in pixels)
 
 Symbol legends are rendered as swatches and support the options above in addition to the following options:
@@ -680,7 +680,7 @@ Continuous color legends are rendered as a ramp, and can be configured with the 
 * *options*.**marginRight** - the legend’s right margin
 * *options*.**marginBottom** - the legend’s bottom margin
 * *options*.**marginLeft** - the legend’s left margin
-* *options*.**opacity** - the ramp’s opacity
+* *options*.**opacity** - the ramp’s fill opacity
 
 The **style** legend option allows custom styles to override Plot’s defaults; it has the same behavior as in Plot’s top-level [layout options](#layout-options).
 

--- a/src/legends.d.ts
+++ b/src/legends.d.ts
@@ -45,14 +45,33 @@ export interface LegendOptions {
    */
   className?: string | null;
 
-  /** The constant color the ramp; defaults to black. For *ramp* *opacity* legends only. */
+  /**
+   * The constant color the ramp; defaults to black. For *ramp* *opacity*
+   * legends only.
+   */
   color?: string;
-  /** The desired fill color of symbols; use *color* for a redundant encoding. For *symbol* legends only. */
+
+  /**
+   * The desired fill color of symbols; use *color* for a redundant encoding.
+   * For *symbol* legends only.
+   */
   fill?: string;
-  /** The desired fill opacity of symbols. For *symbol* and *color* legends. */
+
+  /** The desired fill opacity of symbols. For *symbol* legends only. */
   fillOpacity?: number;
-  /** The desired stroke color of symbols; use *color* for a redundant encoding. For *symbol* legends only. */
+
+  /**
+   * The desired opacity of the color swatches or ramp. For *color* legends
+   * only.
+   */
+  opacity?: number;
+
+  /**
+   * The desired stroke color of symbols; use *color* for a redundant encoding.
+   * For *symbol* legends only.
+   */
   stroke?: string;
+
   /** The desired stroke opacity of symbols. For *symbol* legends only. */
   strokeOpacity?: number;
   /** The desired stroke width of symbols. For *symbol* legends only. */

--- a/src/legends.d.ts
+++ b/src/legends.d.ts
@@ -45,33 +45,16 @@ export interface LegendOptions {
    */
   className?: string | null;
 
-  /**
-   * The constant color the ramp; defaults to black. For *ramp* *opacity*
-   * legends only.
-   */
+  /** The constant color the ramp; defaults to black. For *ramp* *opacity* legends only. */
   color?: string;
-
-  /**
-   * The desired fill color of symbols; use *color* for a redundant encoding.
-   * For *symbol* legends only.
-   */
+  /** The desired fill color of symbols; use *color* for a redundant encoding. For *symbol* legends only. */
   fill?: string;
-
   /** The desired fill opacity of symbols. For *symbol* legends only. */
   fillOpacity?: number;
-
-  /**
-   * The desired opacity of the color swatches or ramp. For *color* legends
-   * only.
-   */
+  /** The desired opacity of the color swatches or ramp. For *color* legends only. */
   opacity?: number;
-
-  /**
-   * The desired stroke color of symbols; use *color* for a redundant encoding.
-   * For *symbol* legends only.
-   */
+  /** The desired stroke color of symbols; use *color* for a redundant encoding. For *symbol* legends only. */
   stroke?: string;
-
   /** The desired stroke opacity of symbols. For *symbol* legends only. */
   strokeOpacity?: number;
   /** The desired stroke width of symbols. For *symbol* legends only. */

--- a/src/legends.d.ts
+++ b/src/legends.d.ts
@@ -49,7 +49,7 @@ export interface LegendOptions {
   color?: string;
   /** The desired fill color of symbols; use *color* for a redundant encoding. For *symbol* legends only. */
   fill?: string;
-  /** The desired fill opacity of symbols. For *symbol* legends only. */
+  /** The desired fill opacity of symbols. For *symbol* and *color* legends. */
   fillOpacity?: number;
   /** The desired stroke color of symbols; use *color* for a redundant encoding. For *symbol* legends only. */
   stroke?: string;

--- a/src/legends/ramp.js
+++ b/src/legends/ramp.js
@@ -1,7 +1,7 @@
 import {quantize, interpolateNumber, piecewise, format, scaleBand, scaleLinear, axisBottom} from "d3";
 import {inferFontVariant} from "../axes.js";
 import {createContext, create} from "../context.js";
-import {map} from "../options.js";
+import {map, maybeNumberChannel} from "../options.js";
 import {interpolatePiecewise} from "../scales/quantitative.js";
 import {applyInlineStyles, impliedString, maybeClassName} from "../style.js";
 
@@ -20,6 +20,7 @@ export function legendRamp(color, options) {
     tickFormat,
     fontVariant = inferFontVariant(color),
     round = true,
+    fillOpacity,
     className
   } = options;
   const context = createContext(options);
@@ -96,6 +97,7 @@ export function legendRamp(color, options) {
 
     svg
       .append("image")
+      .attr("opacity", maybeNumberChannel(fillOpacity)[1])
       .attr("x", marginLeft)
       .attr("y", marginTop)
       .attr("width", width - marginLeft - marginRight)

--- a/src/legends/ramp.js
+++ b/src/legends/ramp.js
@@ -26,7 +26,6 @@ export function legendRamp(color, options) {
   const context = createContext(options);
   className = maybeClassName(className);
   opacity = maybeNumberChannel(opacity)[1];
-
   if (tickFormat === null) tickFormat = () => null;
 
   const svg = create("svg", context)

--- a/src/legends/ramp.js
+++ b/src/legends/ramp.js
@@ -121,7 +121,7 @@ export function legendRamp(color, options) {
 
     svg
       .append("g")
-      .attr("opacity", opacity)
+      .attr("fill-opacity", opacity)
       .selectAll()
       .data(range)
       .enter()
@@ -142,7 +142,7 @@ export function legendRamp(color, options) {
 
     svg
       .append("g")
-      .attr("opacity", opacity)
+      .attr("fill-opacity", opacity)
       .selectAll()
       .data(domain)
       .enter()

--- a/src/legends/ramp.js
+++ b/src/legends/ramp.js
@@ -20,11 +20,13 @@ export function legendRamp(color, options) {
     tickFormat,
     fontVariant = inferFontVariant(color),
     round = true,
-    fillOpacity,
+    opacity,
     className
   } = options;
   const context = createContext(options);
   className = maybeClassName(className);
+  opacity = maybeNumberChannel(opacity)[1];
+
   if (tickFormat === null) tickFormat = () => null;
 
   const svg = create("svg", context)
@@ -97,7 +99,7 @@ export function legendRamp(color, options) {
 
     svg
       .append("image")
-      .attr("opacity", maybeNumberChannel(fillOpacity)[1])
+      .attr("opacity", opacity)
       .attr("x", marginLeft)
       .attr("y", marginTop)
       .attr("width", width - marginLeft - marginRight)
@@ -119,6 +121,7 @@ export function legendRamp(color, options) {
 
     svg
       .append("g")
+      .attr("opacity", opacity)
       .selectAll()
       .data(range)
       .enter()
@@ -139,6 +142,7 @@ export function legendRamp(color, options) {
 
     svg
       .append("g")
+      .attr("opacity", opacity)
       .selectAll()
       .data(domain)
       .enter()

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -22,10 +22,10 @@ export function legendSwatches(color, {opacity, ...options}) {
       selection
         .append("svg")
         .attr("fill", scale.scale)
+        .attr("fill-opacity", maybeNumberChannel(opacity)[1])
         .append("rect")
         .attr("width", "100%")
-        .attr("height", "100%")
-        .attr("opacity", maybeNumberChannel(opacity)[1]),
+        .attr("height", "100%"),
     (className) => `.${className}-swatch svg {
         width: var(--swatchWidth);
         height: var(--swatchHeight);

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -12,7 +12,7 @@ function maybeScale(scale, key) {
   return s;
 }
 
-export function legendSwatches(color, {opacity, ...options}) {
+export function legendSwatches(color, {opacity, ...options} = {}) {
   if (!isOrdinalScale(color) && !isThresholdScale(color))
     throw new Error(`swatches legend requires ordinal or threshold color scale (not ${color.type})`);
   return legendItems(

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -12,7 +12,7 @@ function maybeScale(scale, key) {
   return s;
 }
 
-export function legendSwatches(color, {fillOpacity, ...options}) {
+export function legendSwatches(color, {opacity, ...options}) {
   if (!isOrdinalScale(color) && !isThresholdScale(color))
     throw new Error(`swatches legend requires ordinal or threshold color scale (not ${color.type})`);
   return legendItems(
@@ -25,7 +25,7 @@ export function legendSwatches(color, {fillOpacity, ...options}) {
         .append("rect")
         .attr("width", "100%")
         .attr("height", "100%")
-        .attr("opacity", maybeNumberChannel(fillOpacity)[1]),
+        .attr("opacity", maybeNumberChannel(opacity)[1]),
     (className) => `.${className}-swatch svg {
         width: var(--swatchWidth);
         height: var(--swatchHeight);

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -12,14 +12,20 @@ function maybeScale(scale, key) {
   return s;
 }
 
-export function legendSwatches(color, options) {
+export function legendSwatches(color, {fillOpacity, ...options}) {
   if (!isOrdinalScale(color) && !isThresholdScale(color))
     throw new Error(`swatches legend requires ordinal or threshold color scale (not ${color.type})`);
   return legendItems(
     color,
     options,
     (selection, scale) =>
-      selection.append("svg").attr("fill", scale.scale).append("rect").attr("width", "100%").attr("height", "100%"),
+      selection
+        .append("svg")
+        .attr("fill", scale.scale)
+        .append("rect")
+        .attr("width", "100%")
+        .attr("height", "100%")
+        .attr("opacity", maybeNumberChannel(fillOpacity)[1]),
     (className) => `.${className}-swatch svg {
         width: var(--swatchWidth);
         height: var(--swatchHeight);

--- a/test/output/colorLegendOpacity.html
+++ b/test/output/colorLegendOpacity.html
@@ -1,0 +1,38 @@
+<div class="plot" style="
+        --swatchWidth: 15px;
+        --swatchHeight: 15px;
+      ">
+  <style>
+    .plot {
+      font-family: system-ui, sans-serif;
+      font-size: 10px;
+      margin-bottom: 0.5em;
+      margin-left: 0px;
+    }
+
+    .plot-swatch svg {
+      width: var(--swatchWidth);
+      height: var(--swatchHeight);
+      margin-right: 0.5em;
+    }
+
+    .plot {
+      display: flex;
+      align-items: center;
+      min-height: 33px;
+      flex-wrap: wrap;
+    }
+
+    .plot-swatch {
+      display: inline-flex;
+      align-items: center;
+      margin-right: 1em;
+    }
+  </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <rect width="100%" height="100%" opacity="0.5"></rect>
+    </svg>Dream</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <rect width="100%" height="100%" opacity="0.5"></rect>
+    </svg>Torgersen</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <rect width="100%" height="100%" opacity="0.5"></rect>
+    </svg>Biscoe</span>
+</div>

--- a/test/output/colorLegendOpacity.html
+++ b/test/output/colorLegendOpacity.html
@@ -28,11 +28,11 @@
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <rect width="100%" height="100%" opacity="0.5"></rect>
-    </svg>Dream</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <rect width="100%" height="100%" opacity="0.5"></rect>
-    </svg>Torgersen</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <rect width="100%" height="100%" opacity="0.5"></rect>
+  </style><span class="plot-swatch"><svg fill="#4e79a7" fill-opacity="0.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <rect width="100%" height="100%"></rect>
+    </svg>Dream</span><span class="plot-swatch"><svg fill="#f28e2c" fill-opacity="0.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <rect width="100%" height="100%"></rect>
+    </svg>Torgersen</span><span class="plot-swatch"><svg fill="#e15759" fill-opacity="0.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <rect width="100%" height="100%"></rect>
     </svg>Biscoe</span>
 </div>

--- a/test/output/colorLegendOpacityOrdinalRamp.svg
+++ b/test/output/colorLegendOpacityOrdinalRamp.svg
@@ -13,7 +13,7 @@
       white-space: pre;
     }
   </style>
-  <g opacity="0.5">
+  <g fill-opacity="0.5">
     <rect x="0" y="18" width="23" height="10" fill="rgb(35, 23, 27)"></rect>
     <rect x="24" y="18" width="23" height="10" fill="rgb(72, 96, 230)"></rect>
     <rect x="48" y="18" width="23" height="10" fill="rgb(42, 171, 238)"></rect>

--- a/test/output/colorLegendOpacityOrdinalRamp.svg
+++ b/test/output/colorLegendOpacityOrdinalRamp.svg
@@ -1,0 +1,70 @@
+<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+      overflow: visible;
+    }
+
+    .plot text {
+      white-space: pre;
+    }
+  </style>
+  <g opacity="0.5">
+    <rect x="0" y="18" width="23" height="10" fill="rgb(35, 23, 27)"></rect>
+    <rect x="24" y="18" width="23" height="10" fill="rgb(72, 96, 230)"></rect>
+    <rect x="48" y="18" width="23" height="10" fill="rgb(42, 171, 238)"></rect>
+    <rect x="72" y="18" width="23" height="10" fill="rgb(46, 229, 174)"></rect>
+    <rect x="96" y="18" width="23" height="10" fill="rgb(106, 253, 106)"></rect>
+    <rect x="120" y="18" width="23" height="10" fill="rgb(192, 238, 61)"></rect>
+    <rect x="144" y="18" width="23" height="10" fill="rgb(254, 185, 39)"></rect>
+    <rect x="168" y="18" width="23" height="10" fill="rgb(254, 110, 26)"></rect>
+    <rect x="192" y="18" width="23" height="10" fill="rgb(194, 39, 10)"></rect>
+    <rect x="216" y="18" width="23" height="10" fill="rgb(144, 12, 0)"></rect>
+  </g>
+  <g transform="translate(0,28)" fill="none" text-anchor="middle">
+    <g class="tick" opacity="1" transform="translate(12.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">A</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(36.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">B</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(60.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">C</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(84.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">D</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(108.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">E</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(132.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">F</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(156.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">G</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(180.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">H</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(204.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">I</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(228.5,0)">
+      <line stroke="currentColor" y2="6"></line>
+      <text fill="currentColor" y="9" dy="0.71em">J</text>
+    </g>
+  </g>
+</svg>

--- a/test/output/colorLegendOpacityRamp.svg
+++ b/test/output/colorLegendOpacityRamp.svg
@@ -1,0 +1,43 @@
+<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+      overflow: visible;
+    }
+
+    .plot text {
+      white-space: pre;
+    }
+  </style>
+  <image opacity="0.5" x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAABH0lEQVQ4jX2QQW4bUQxDn6hJ6sTtuosse/8jSuzi64/HblADAvlIDjDj+PP7y0f+4tCdQz9J3Tnyk9Qd6YPMT6QPlDekG5E3QjeUP4h8B43mO6E3yDm9QR44D9CBM4cTS0tTOAUpWsIZkwVW4ARn0BlYDDPedILlyT1+a5+MevKG7KWzQeusWv7M6uziGx9RxOxCRUQ/qU4uNHtFo9lo83dKk5csWT53TpPDYvW7S17OTeJ/2Zv90OkOb57s9Bduo531o1c/WBddf+32Rn7mKM6d2kQbFUsbokw00Ib6j5ahrzr+dfPEL88Nd4F79GTo8rrTQ8/umtepq6teXZXpnr5N1cW316uM757nPBt7vfZk7Z0t7/mM7c3lDMTy+/cXwM9vrI9SuXIAAAAASUVORK5CYII="></image>
+  <g transform="translate(0,28)" fill="none" text-anchor="middle" font-variant="tabular-nums">
+    <g class="tick" opacity="1" transform="translate(0.5,0)">
+      <line stroke="currentColor" y2="6" y1="-10"></line>
+      <text fill="currentColor" y="9" dy="0.71em">0</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(48.5,0)">
+      <line stroke="currentColor" y2="6" y1="-10"></line>
+      <text fill="currentColor" y="9" dy="0.71em">200</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(96.5,0)">
+      <line stroke="currentColor" y2="6" y1="-10"></line>
+      <text fill="currentColor" y="9" dy="0.71em">400</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(144.5,0)">
+      <line stroke="currentColor" y2="6" y1="-10"></line>
+      <text fill="currentColor" y="9" dy="0.71em">600</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(192.5,0)">
+      <line stroke="currentColor" y2="6" y1="-10"></line>
+      <text fill="currentColor" y="9" dy="0.71em">800</text>
+    </g>
+    <g class="tick" opacity="1" transform="translate(240.5,0)">
+      <line stroke="currentColor" y2="6" y1="-10"></line>
+      <text fill="currentColor" y="9" dy="0.71em">1,000</text>
+    </g>
+  </g>
+</svg>

--- a/test/output/symbolLegendOpacityColor.html
+++ b/test/output/symbolLegendOpacityColor.html
@@ -1,0 +1,50 @@
+<div class="plot" style="
+        --swatchWidth: 15px;
+        --swatchHeight: 15px;
+      ">
+  <style>
+    .plot {
+      font-family: system-ui, sans-serif;
+      font-size: 10px;
+      margin-bottom: 0.5em;
+      margin-left: 0px;
+    }
+
+    .plot-swatch>svg {
+      width: var(--swatchWidth);
+      height: var(--swatchHeight);
+      margin-right: 0.5em;
+      overflow: visible;
+      fill: none;
+      fill-opacity: 1;
+      stroke: undefined;
+      stroke-width: 1.5px;
+      stroke-opacity: 0.5;
+    }
+
+    .plot {
+      display: flex;
+      align-items: center;
+      min-height: 33px;
+      flex-wrap: wrap;
+    }
+
+    .plot-swatch {
+      display: inline-flex;
+      align-items: center;
+      margin-right: 1em;
+    }
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M0,-5.443L4.714,2.721L-4.714,2.721Z"></path>
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M0,4.769L0,-4.769M-4.13,-2.384L4.13,2.384M-4.13,2.384L4.13,-2.384"></path>
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M3.534,3.534L3.534,-3.534L-3.534,-3.534L-3.534,3.534Z"></path>
+    </svg>F</span>
+</div>

--- a/test/output/symbolLegendOpacityFill.html
+++ b/test/output/symbolLegendOpacityFill.html
@@ -1,0 +1,44 @@
+<div class="plot" style="
+        --swatchWidth: 15px;
+        --swatchHeight: 15px;
+      ">
+  <style>
+    .plot {
+      font-family: system-ui, sans-serif;
+      font-size: 10px;
+      margin-bottom: 0.5em;
+      margin-left: 0px;
+    }
+
+    .plot-swatch>svg {
+      width: var(--swatchWidth);
+      height: var(--swatchHeight);
+      margin-right: 0.5em;
+      overflow: visible;
+      fill: red;
+      fill-opacity: 0.5;
+      stroke: none;
+      stroke-width: 1.5px;
+      stroke-opacity: 1;
+    }
+
+    .plot {
+      display: flex;
+      align-items: center;
+      min-height: 33px;
+      flex-wrap: wrap;
+    }
+
+    .plot-swatch {
+      display: inline-flex;
+      align-items: center;
+      margin-right: 1em;
+    }
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
+    </svg>Dream</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M-5.35,-1.783L-1.783,-1.783L-1.783,-5.35L1.783,-5.35L1.783,-1.783L5.35,-1.783L5.35,1.783L1.783,1.783L1.783,5.35L-1.783,5.35L-1.783,1.783L-5.35,1.783Z"></path>
+    </svg>Torgersen</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M0,-7.423L4.285,0L0,7.423L-4.285,0Z"></path>
+    </svg>Biscoe</span>
+</div>

--- a/test/output/symbolLegendOpacityStroke.html
+++ b/test/output/symbolLegendOpacityStroke.html
@@ -1,0 +1,44 @@
+<div class="plot" style="
+        --swatchWidth: 15px;
+        --swatchHeight: 15px;
+      ">
+  <style>
+    .plot {
+      font-family: system-ui, sans-serif;
+      font-size: 10px;
+      margin-bottom: 0.5em;
+      margin-left: 0px;
+    }
+
+    .plot-swatch>svg {
+      width: var(--swatchWidth);
+      height: var(--swatchHeight);
+      margin-right: 0.5em;
+      overflow: visible;
+      fill: none;
+      fill-opacity: 1;
+      stroke: red;
+      stroke-width: 1.5px;
+      stroke-opacity: 0.5;
+    }
+
+    .plot {
+      display: flex;
+      align-items: center;
+      min-height: 33px;
+      flex-wrap: wrap;
+    }
+
+    .plot-swatch {
+      display: inline-flex;
+      align-items: center;
+      margin-right: 1em;
+    }
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
+    </svg>Dream</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
+    </svg>Torgersen</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
+    </svg>Biscoe</span>
+</div>

--- a/test/plots/legend-color.ts
+++ b/test/plots/legend-color.ts
@@ -435,3 +435,11 @@ export function colorSchemesQuantitative() {
   }
   return div;
 }
+
+export async function colorLegendOpacity() {
+  return Plot.legend({color: {domain: ["Dream", "Torgersen", "Biscoe"]}, fillOpacity: 0.5});
+}
+
+export async function colorLegendOpacityRamp() {
+  return Plot.legend({color: {domain: [0, 1000]}, fillOpacity: 0.5});
+}

--- a/test/plots/legend-color.ts
+++ b/test/plots/legend-color.ts
@@ -437,9 +437,13 @@ export function colorSchemesQuantitative() {
 }
 
 export async function colorLegendOpacity() {
-  return Plot.legend({color: {domain: ["Dream", "Torgersen", "Biscoe"]}, fillOpacity: 0.5});
+  return Plot.legend({color: {domain: ["Dream", "Torgersen", "Biscoe"]}, opacity: 0.5});
 }
 
 export async function colorLegendOpacityRamp() {
-  return Plot.legend({color: {domain: [0, 1000]}, fillOpacity: 0.5});
+  return Plot.legend({color: {domain: [0, 1000]}, opacity: 0.5});
+}
+
+export function colorLegendOpacityOrdinalRamp() {
+  return Plot.legend({color: {type: "ordinal", domain: "ABCDEFGHIJ"}, legend: "ramp", opacity: 0.5});
 }

--- a/test/plots/legend-symbol.ts
+++ b/test/plots/legend-symbol.ts
@@ -45,3 +45,11 @@ export function symbolLegendImplicitRange() {
 export function symbolLegendStroke() {
   return Plot.legend({symbol: {domain: "ABCDEF"}, stroke: "red"});
 }
+
+export async function symbolLegendOpacityFill() {
+  return Plot.legend({symbol: {domain: ["Dream", "Torgersen", "Biscoe"]}, fill: "red", fillOpacity: 0.5});
+}
+
+export async function symbolLegendOpacityStroke() {
+  return Plot.legend({symbol: {domain: ["Dream", "Torgersen", "Biscoe"]}, stroke: "red", strokeOpacity: 0.5});
+}

--- a/test/plots/legend-symbol.ts
+++ b/test/plots/legend-symbol.ts
@@ -50,6 +50,10 @@ export async function symbolLegendOpacityFill() {
   return Plot.legend({symbol: {domain: ["Dream", "Torgersen", "Biscoe"]}, fill: "red", fillOpacity: 0.5});
 }
 
+export async function symbolLegendOpacityColor() {
+  return Plot.legend({color: {domain: "ABCDEF"}, symbol: {domain: "ABCDEF"}, strokeOpacity: 0.5});
+}
+
 export async function symbolLegendOpacityStroke() {
   return Plot.legend({symbol: {domain: ["Dream", "Torgersen", "Biscoe"]}, stroke: "red", strokeOpacity: 0.5});
 }


### PR DESCRIPTION
Note: I used **fillOpacity** and not **opacity**, for consistency with the *symbol* legends.


closes #1356
