### PR TITLE
upgrade actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,9 +17,8 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
@@ -28,8 +27,7 @@ jobs:
           yarn run eslint src test --format=compact
       - run: yarn run prettier --check src test
       - run: yarn test:mocha
-      - name: Test artifacts
-        uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: test-output-changes


### PR DESCRIPTION
We’re using some old deprecated actions which use Node 12. Found [here](https://github.com/observablehq/plot/actions/runs/4567228301).

<img width="781" alt="Screenshot 2023-03-30 at 12 39 20 PM" src="https://user-images.githubusercontent.com/230541/228946161-9266d35d-e778-4f09-8dbd-5686613fc4e0.png">

Ref. https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/