### PR TITLE
Auto: error on reducer without input; warn on ordinal size; expose warnings

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -301,11 +301,8 @@ export function plot(options = {}) {
     }
   }
 
-  figure.scale = exposeScales(scaleDescriptors);
-  figure.legend = exposeLegends(scaleDescriptors, context, options);
-
-  const w = consumeWarnings();
-  if (w > 0) {
+  const warnings = consumeWarnings();
+  if (warnings.length > 0) {
     select(svg)
       .append("text")
       .attr("x", width)
@@ -315,8 +312,16 @@ export function plot(options = {}) {
       .attr("font-family", "initial") // fix emoji rendering in Chrome
       .text("\u26a0\ufe0f") // emoji variation selector
       .append("title")
-      .text(`${w.toLocaleString("en-US")} warning${w === 1 ? "" : "s"}. Please check the console.`);
+      .text(
+        `${warnings.length.toLocaleString("en-US")} warning${
+          warnings.length === 1 ? "" : "s"
+        }. Please check the console.`
+      );
   }
+
+  figure.scale = exposeScales(scaleDescriptors);
+  figure.legend = exposeLegends(scaleDescriptors, context, options);
+  figure.warnings = warnings;
 
   return figure;
 }

--- a/src/warnings.js
+++ b/src/warnings.js
@@ -1,12 +1,12 @@
-let warnings = 0;
+let warnings = [];
 
 export function consumeWarnings() {
   const w = warnings;
-  warnings = 0;
+  warnings = [];
   return w;
 }
 
 export function warn(message) {
   console.warn(message);
-  ++warnings;
+  warnings.push(message);
 }


### PR DESCRIPTION
[Demo](https://observablehq.com/d/35391f601fb9181d). Sketching some additional errors / warnings based on what I've seen leading people astray.

**Error on reducer without input** — Setting a non-count reducer without an input field _error_, not warns, because it's a static error in the config, regardless of what data gets passed in. TODO: do any other reducers not need an input field?

**Warn on ordinal size** — Since this is dynamic, it’s just a warning, not an error. One issue is there’s no way to suppress it if for some reason you want this. It should probably be subsumed by https://github.com/observablehq/plot/issues/493, but I was just itching to try something.

**Expose warnings** (https://github.com/observablehq/plot/issues/1192) — In this PR, my approach is to set an array of warnings on the returned figure. Mike has mentioned he might prefer passing in an onWarn callback. I guess the advantage there is that these warnings could be triggered by interaction in the future? Right now, the chart cell almost never runs into warnings, but there are situations where it seems like it should (like ordinal size), so I feel the itch to be able to expose the warnings in its UI.