### PR TITLE
fix for 1429

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -437,7 +437,7 @@ function maybeMarkFacet(mark, topFacetState, options) {
   // top-level facet option.
   if (
     (groups.size > 1 || (groups.size === 1 && channels.fx && channels.fy && [...groups][0][1].size > 1)) &&
-    (arrayify(mark.data)?.length ?? NaN) === (data.length ?? NaN)
+    (data.length > 0 && arrayify(mark.data)?.length === data.length)
   ) {
     warn(
       `Warning: the ${mark.ariaLabel} mark appears to use faceted data, but isn’t faceted. The mark data has the same length as the facet data and the mark facet option is "auto", but the mark data and facet data are distinct. If this mark should be faceted, set the mark facet option to true; otherwise, suppress this warning by setting the mark facet option to false.`

--- a/src/plot.js
+++ b/src/plot.js
@@ -437,7 +437,7 @@ function maybeMarkFacet(mark, topFacetState, options) {
   // top-level facet option.
   if (
     (groups.size > 1 || (groups.size === 1 && channels.fx && channels.fy && [...groups][0][1].size > 1)) &&
-    arrayify(mark.data)?.length === data.length
+    (arrayify(mark.data)?.length ?? NaN) === (data.length ?? NaN)
   ) {
     warn(
       `Warning: the ${mark.ariaLabel} mark appears to use faceted data, but isn’t faceted. The mark data has the same length as the facet data and the mark facet option is "auto", but the mark data and facet data are distinct. If this mark should be faceted, set the mark facet option to true; otherwise, suppress this warning by setting the mark facet option to false.`

--- a/src/plot.js
+++ b/src/plot.js
@@ -436,8 +436,9 @@ function maybeMarkFacet(mark, topFacetState, options) {
   // Warn for the common pitfall of wanting to facet mapped data with the
   // top-level facet option.
   if (
+    data.length > 0 &&
     (groups.size > 1 || (groups.size === 1 && channels.fx && channels.fy && [...groups][0][1].size > 1)) &&
-    (data.length > 0 && arrayify(mark.data)?.length === data.length)
+    arrayify(mark.data)?.length === data.length
   ) {
     warn(
       `Warning: the ${mark.ariaLabel} mark appears to use faceted data, but isn’t faceted. The mark data has the same length as the facet data and the mark facet option is "auto", but the mark data and facet data are distinct. If this mark should be faceted, set the mark facet option to true; otherwise, suppress this warning by setting the mark facet option to false.`


### PR DESCRIPTION
when ~~both the~~ (EDIT:) **any of** data length and facet data length are undefined, suppress the warning

fixes #1429


Note: I initially added arquero as a devDependency and @juba’s penguins test, but removed it as I felt it adds too much cruft. The test was:

```ts
import * as Plot from "@observablehq/plot";
import * as d3 from "d3";
import * as aq from "arquero";

export async function penguinArqueroFacet() {
  const data = await d3.csv<any>("data/penguins.csv", d3.autoType);
  const penguins = aq.from(data).toArrow();
  return Plot.plot({
    facet: {data: penguins, x: "island"},
    marks: [Plot.dot(penguins, {x: "culmen_depth_mm", y: "body_mass_g"}), Plot.frame()]
  });
}

```