### PR TITLE
assume high pixel density when headless

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -15,7 +15,7 @@ import {
 } from "./options.js";
 import {warn} from "./warnings.js";
 
-export const offset = typeof window !== "undefined" && window.devicePixelRatio > 1 ? 0 : 0.5;
+export const offset = (typeof window !== "undefined" ? window.devicePixelRatio > 1 : typeof it === "undefined") ? 0 : 0.5; // prettier-ignore
 
 let nextClipId = 0;
 


### PR DESCRIPTION
We currently assume the opposite, but given that high-pixel-density screens are definitely the norm, this seems like the better default. This is desirable for server-side rendering of Plots to avoid a half-pixel shift on the client, assuming the client has a high-pixel-density screen.

Note that to avoid re-generating all the test snapshots, I’ve left the default as-is for Mocha (by testing `typeof it`). In a follow-up commit we can remove this exemption and update the snapshots.