### PR TITLE
deterministic class name

### DIFF
--- a/src/legends.js
+++ b/src/legends.js
@@ -40,7 +40,7 @@ export function exposeLegends(scales, context, defaults = {}) {
 }
 
 function legendOptions({className, ...context}, {label, ticks, tickFormat} = {}, options) {
-  return inherit(options, {className: `${className}-legend`, ...context}, {label, ticks, tickFormat});
+  return inherit(options, {className, ...context}, {label, ticks, tickFormat});
 }
 
 function legendColor(color, {legend = true, ...options}) {

--- a/src/legends/ramp.js
+++ b/src/legends/ramp.js
@@ -23,8 +23,8 @@ export function legendRamp(color, options) {
     opacity,
     className
   } = options;
-  className = maybeClassName(className);
   const context = createContext(options);
+  className = maybeClassName(className);
   opacity = maybeNumberChannel(opacity)[1];
   if (tickFormat === null) tickFormat = () => null;
 

--- a/src/legends/ramp.js
+++ b/src/legends/ramp.js
@@ -23,32 +23,33 @@ export function legendRamp(color, options) {
     opacity,
     className
   } = options;
-  const context = createContext(options);
   className = maybeClassName(className);
+  const context = createContext(options);
   opacity = maybeNumberChannel(opacity)[1];
   if (tickFormat === null) tickFormat = () => null;
 
   const svg = create("svg", context)
-    .attr("class", className)
+    .attr("class", `${className}-ramp`)
     .attr("font-family", "system-ui, sans-serif")
     .attr("font-size", 10)
     .attr("width", width)
     .attr("height", height)
     .attr("viewBox", `0 0 ${width} ${height}`)
     .call((svg) =>
-      svg.append("style").text(`
-        .${className} {
-          display: block;
-          background: white;
-          height: auto;
-          height: intrinsic;
-          max-width: 100%;
-          overflow: visible;
-        }
-        .${className} text {
-          white-space: pre;
-        }
-      `)
+      // Warning: if you edit this, change defaultClassName.
+      svg.append("style").text(
+        `.${className}-ramp {
+  display: block;
+  background: white;
+  height: auto;
+  height: intrinsic;
+  max-width: 100%;
+  overflow: visible;
+}
+.${className}-ramp text {
+  white-space: pre;
+}`
+      )
     )
     .call(applyInlineStyles, style);
 

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -15,22 +15,16 @@ function maybeScale(scale, key) {
 export function legendSwatches(color, {opacity, ...options} = {}) {
   if (!isOrdinalScale(color) && !isThresholdScale(color))
     throw new Error(`swatches legend requires ordinal or threshold color scale (not ${color.type})`);
-  return legendItems(
-    color,
-    options,
-    (selection, scale) =>
-      selection
-        .append("svg")
-        .attr("fill", scale.scale)
-        .attr("fill-opacity", maybeNumberChannel(opacity)[1])
-        .append("rect")
-        .attr("width", "100%")
-        .attr("height", "100%"),
-    (className) => `.${className}-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
-        margin-right: 0.5em;
-      }`
+  return legendItems(color, options, (selection, scale, width, height) =>
+    selection
+      .append("svg")
+      .attr("width", width)
+      .attr("height", height)
+      .attr("fill", scale.scale)
+      .attr("fill-opacity", maybeNumberChannel(opacity)[1])
+      .append("rect")
+      .attr("width", "100%")
+      .attr("height", "100%")
   );
 }
 
@@ -55,36 +49,27 @@ export function legendSymbols(
   fillOpacity = maybeNumberChannel(fillOpacity)[1];
   strokeOpacity = maybeNumberChannel(strokeOpacity)[1];
   strokeWidth = maybeNumberChannel(strokeWidth)[1];
-  return legendItems(
-    symbol,
-    options,
-    (selection) =>
-      selection
-        .append("svg")
-        .attr("viewBox", "-8 -8 16 16")
-        .attr("fill", vf === "color" ? (d) => sf.scale(d) : null)
-        .attr("stroke", vs === "color" ? (d) => ss.scale(d) : null)
-        .append("path")
-        .attr("d", (d) => {
-          const p = path();
-          symbol.scale(d).draw(p, size);
-          return p;
-        }),
-    (className) => `.${className}-swatch > svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
-        margin-right: 0.5em;
-        overflow: visible;
-        fill: ${cf};
-        fill-opacity: ${fillOpacity};
-        stroke: ${cs};
-        stroke-width: ${strokeWidth}px;
-        stroke-opacity: ${strokeOpacity};
-      }`
+  return legendItems(symbol, options, (selection, scale, width, height) =>
+    selection
+      .append("svg")
+      .attr("viewBox", "-8 -8 16 16")
+      .attr("width", width)
+      .attr("height", height)
+      .attr("fill", vf === "color" ? (d) => sf.scale(d) : cf)
+      .attr("fill-opacity", fillOpacity)
+      .attr("stroke", vs === "color" ? (d) => ss.scale(d) : cs)
+      .attr("stroke-opacity", strokeOpacity)
+      .attr("stroke-width", strokeWidth)
+      .append("path")
+      .attr("d", (d) => {
+        const p = path();
+        symbol.scale(d).draw(p, size);
+        return p;
+      })
   );
 }
 
-function legendItems(scale, options = {}, swatch, swatchStyle) {
+function legendItems(scale, options = {}, swatch) {
   let {
     columns,
     tickFormat,
@@ -102,35 +87,28 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
   className = maybeClassName(className);
   tickFormat = maybeAutoTickFormat(tickFormat, scale.domain);
 
-  const swatches = create("div", context)
-    .attr("class", className)
-    .attr(
-      "style",
-      `
-        --swatchWidth: ${+swatchWidth}px;
-        --swatchHeight: ${+swatchHeight}px;
-      `
-    );
+  const swatches = create("div", context).attr(
+    "class",
+    `${className}-swatches ${className}-swatches-${columns != null ? "columns" : "wrap"}`
+  );
 
   let extraStyle;
 
   if (columns != null) {
-    extraStyle = `
-      .${className}-swatch {
-        display: flex;
-        align-items: center;
-        break-inside: avoid;
-        padding-bottom: 1px;
-      }
-      .${className}-swatch::before {
-        flex-shrink: 0;
-      }
-      .${className}-label {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-    `;
+    extraStyle = `.${className}-swatches-columns .${className}-swatch {
+  display: flex;
+  align-items: center;
+  break-inside: avoid;
+  padding-bottom: 1px;
+}
+.${className}-swatches-columns .${className}-swatch::before {
+  flex-shrink: 0;
+}
+.${className}-swatches-columns .${className}-swatch-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}`;
 
     swatches
       .style("columns", columns)
@@ -139,24 +117,22 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
       .enter()
       .append("div")
       .attr("class", `${className}-swatch`)
-      .call(swatch, scale)
+      .call(swatch, scale, swatchWidth, swatchHeight)
       .call((item) =>
-        item.append("div").attr("class", `${className}-label`).attr("title", tickFormat).text(tickFormat)
+        item.append("div").attr("class", `${className}-swatch-label`).attr("title", tickFormat).text(tickFormat)
       );
   } else {
-    extraStyle = `
-      .${className} {
-        display: flex;
-        align-items: center;
-        min-height: 33px;
-        flex-wrap: wrap;
-      }
-      .${className}-swatch {
-        display: inline-flex;
-        align-items: center;
-        margin-right: 1em;
-      }
-    `;
+    extraStyle = `.${className}-swatches-wrap {
+  display: flex;
+  align-items: center;
+  min-height: 33px;
+  flex-wrap: wrap;
+}
+.${className}-swatches-wrap .${className}-swatch {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 1em;
+}`;
 
     swatches
       .selectAll()
@@ -164,7 +140,7 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
       .enter()
       .append("span")
       .attr("class", `${className}-swatch`)
-      .call(swatch, scale)
+      .call(swatch, scale, swatchWidth, swatchHeight)
       .append(function () {
         return this.ownerDocument.createTextNode(tickFormat.apply(this, arguments));
       });
@@ -172,26 +148,21 @@ function legendItems(scale, options = {}, swatch, swatchStyle) {
 
   return swatches
     .call((div) =>
-      div.insert("style", "*").text(`
-        .${className} {
-          font-family: system-ui, sans-serif;
-          font-size: 10px;
-          margin-bottom: 0.5em;${
-            marginLeft === undefined
-              ? ""
-              : `
-          margin-left: ${+marginLeft}px;`
-          }${
-        width === undefined
-          ? ""
-          : `
-          width: ${width}px;`
-      }
-        }
-        ${swatchStyle(className)}
-        ${extraStyle}
-      `)
+      div.insert("style", "*").text(
+        `.${className}-swatches {
+  font-family: system-ui, sans-serif;
+  font-size: 10px;
+  margin-bottom: 0.5em;
+}
+.${className}-swatch > svg {
+  margin-right: 0.5em;
+  overflow: visible;
+}
+${extraStyle}`
+      )
     )
+    .style("margin-left", marginLeft === undefined ? null : `${+marginLeft}px;`)
+    .style("width", width === undefined ? null : `${width}px`)
     .style("font-variant", impliedString(fontVariant, "normal"))
     .call(applyInlineStyles, style)
     .node();

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -161,8 +161,8 @@ function legendItems(scale, options = {}, swatch) {
 ${extraStyle}`
       )
     )
-    .style("margin-left", marginLeft === undefined ? null : `${+marginLeft}px;`)
-    .style("width", width === undefined ? null : `${width}px`)
+    .style("margin-left", marginLeft ? `${+marginLeft}px` : null)
+    .style("width", width === undefined ? null : `${+width}px`)
     .style("font-variant", impliedString(fontVariant, "normal"))
     .call(applyInlineStyles, style)
     .node();

--- a/src/plot.js
+++ b/src/plot.js
@@ -216,19 +216,20 @@ export function plot(options = {}) {
     .attr("aria-label", ariaLabel)
     .attr("aria-description", ariaDescription)
     .call((svg) =>
-      svg.append("style").text(`
-        .${className} {
-          display: block;
-          background: white;
-          height: auto;
-          height: intrinsic;
-          max-width: 100%;
-        }
-        .${className} text,
-        .${className} tspan {
-          white-space: pre;
-        }
-      `)
+      // Warning: if you edit this, change defaultClassName.
+      svg.append("style").text(
+        `.${className} {
+  display: block;
+  background: white;
+  height: auto;
+  height: intrinsic;
+  max-width: 100%;
+}
+.${className} text,
+.${className} tspan {
+  white-space: pre;
+}`
+      )
     )
     .call(applyInlineStyles, style)
     .node();

--- a/src/style.js
+++ b/src/style.js
@@ -419,7 +419,9 @@ const validClassName =
   /^-?([_a-z]|[\240-\377]|\\[0-9a-f]{1,6}(\r\n|[ \t\r\n\f])?|\\[^\r\n\f0-9a-f])([_a-z0-9-]|[\240-\377]|\\[0-9a-f]{1,6}(\r\n|[ \t\r\n\f])?|\\[^\r\n\f0-9a-f])*$/i;
 
 export function maybeClassName(name) {
-  if (name === undefined) return `plot-${Math.random().toString(16).slice(2)}`;
+  // The default should be changed whenever the default styles are changed, so
+  // as to avoid conflict when multiple versions of Plot are on the page.
+  if (name === undefined) return "plot-d6a7b5";
   name = `${name}`;
   if (!validClassName.test(name)) throw new Error(`invalid class name: ${name}`);
   return name;

--- a/test/output/athletesSortNationality.html
+++ b/test/output/athletesSortNationality.html
@@ -1,58 +1,53 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ESP</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ESP</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>KOR</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>KOR</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>CAN</span><span class="plot-swatch"><svg fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>CAN</span><span class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>MDA</span><span class="plot-swatch"><svg fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>MDA</span><span class="plot-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>NZL</span><span class="plot-swatch"><svg fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>NZL</span><span class="plot-swatch"><svg width="15" height="15" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>AUS</span><span class="plot-swatch"><svg fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>AUS</span><span class="plot-swatch"><svg width="15" height="15" fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>USA</span><span class="plot-swatch"><svg fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>USA</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ETH</span><span class="plot-swatch"><svg fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ETH</span><span class="plot-swatch"><svg width="15" height="15" fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>BRN</span><span class="plot-swatch"><svg fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>BRN</span><span class="plot-swatch"><svg width="15" height="15" fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>IOA</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -60,8 +55,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/athletesSortNullLimit.html
+++ b/test/output/athletesSortNullLimit.html
@@ -1,58 +1,53 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ESP</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ESP</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>KOR</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>KOR</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>CAN</span><span class="plot-swatch"><svg fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>CAN</span><span class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>MDA</span><span class="plot-swatch"><svg fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>MDA</span><span class="plot-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>NZL</span><span class="plot-swatch"><svg fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>NZL</span><span class="plot-swatch"><svg width="15" height="15" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>AUS</span><span class="plot-swatch"><svg fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>AUS</span><span class="plot-swatch"><svg width="15" height="15" fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>USA</span><span class="plot-swatch"><svg fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>USA</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ETH</span><span class="plot-swatch"><svg fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ETH</span><span class="plot-swatch"><svg width="15" height="15" fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>BRN</span><span class="plot-swatch"><svg fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>BRN</span><span class="plot-swatch"><svg width="15" height="15" fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>IOA</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -60,8 +55,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/bigintOrdinal.html
+++ b/test/output/bigintOrdinal.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -57,9 +57,9 @@
       </g>
     </g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">big1</text>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -67,8 +67,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/caltrain.html
+++ b/test/output/caltrain.html
@@ -1,44 +1,39 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="currentColor" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>N</span><span class="plot-swatch"><svg fill="peru" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>N</span><span class="plot-swatch"><svg width="15" height="15" fill="peru" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>L</span><span class="plot-swatch"><svg fill="brown" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>L</span><span class="plot-swatch"><svg width="15" height="15" fill="brown" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>B</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="240" height="520" viewBox="0 0 240 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="240" height="520" viewBox="0 0 240 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -46,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/carsHexbin.html
+++ b/test/output/carsHexbin.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -33,9 +33,9 @@
       </g>
     </g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">weight (lb)</text>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -43,8 +43,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/carsJitter.html
+++ b/test/output/carsJitter.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -33,9 +33,9 @@
       </g>
     </g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">power (hp)</text>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="350" viewBox="0 0 640 350" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="350" viewBox="0 0 640 350" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -43,8 +43,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/colorLegendCategorical.html
+++ b/test/output/colorLegendCategorical.html
@@ -1,52 +1,47 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>A</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>B</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>C</span><span class="plot-swatch"><svg fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>D</span><span class="plot-swatch"><svg fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>E</span><span class="plot-swatch"><svg fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg width="15" height="15" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>F</span><span class="plot-swatch"><svg fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>F</span><span class="plot-swatch"><svg width="15" height="15" fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>G</span><span class="plot-swatch"><svg fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>G</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>H</span><span class="plot-swatch"><svg fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>H</span><span class="plot-swatch"><svg width="15" height="15" fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>I</span><span class="plot-swatch"><svg fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>I</span><span class="plot-swatch"><svg width="15" height="15" fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>J</span>
 </div>

--- a/test/output/colorLegendCategoricalColumns.html
+++ b/test/output/colorLegendCategoricalColumns.html
@@ -1,83 +1,81 @@
-<div class="plot" style="--swatchWidth: 15px; --swatchHeight: 15px; columns: 180px;">
+<div class="plot-swatches plot-swatches-columns" style="columns: 180px;">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot-swatch {
+    .plot-swatches-columns .plot-swatch {
       display: flex;
       align-items: center;
       break-inside: avoid;
       padding-bottom: 1px;
     }
 
-    .plot-swatch::before {
+    .plot-swatches-columns .plot-swatch::before {
       flex-shrink: 0;
     }
 
-    .plot-label {
+    .plot-swatches-columns .plot-swatch-label {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
   </style>
-  <div class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Wholesale and Retail Trade">Wholesale and Retail Trade</div>
+    <div class="plot-swatch-label" title="Wholesale and Retail Trade">Wholesale and Retail Trade</div>
   </div>
-  <div class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Manufacturing">Manufacturing</div>
+    <div class="plot-swatch-label" title="Manufacturing">Manufacturing</div>
   </div>
-  <div class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Leisure and hospitality">Leisure and hospitality</div>
+    <div class="plot-swatch-label" title="Leisure and hospitality">Leisure and hospitality</div>
   </div>
-  <div class="plot-swatch"><svg fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Business services">Business services</div>
+    <div class="plot-swatch-label" title="Business services">Business services</div>
   </div>
-  <div class="plot-swatch"><svg fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Construction">Construction</div>
+    <div class="plot-swatch-label" title="Construction">Construction</div>
   </div>
-  <div class="plot-swatch"><svg fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Education and Health">Education and Health</div>
+    <div class="plot-swatch-label" title="Education and Health">Education and Health</div>
   </div>
-  <div class="plot-swatch"><svg fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Government">Government</div>
+    <div class="plot-swatch-label" title="Government">Government</div>
   </div>
-  <div class="plot-swatch"><svg fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Finance">Finance</div>
+    <div class="plot-swatch-label" title="Finance">Finance</div>
   </div>
-  <div class="plot-swatch"><svg fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Self-employed">Self-employed</div>
+    <div class="plot-swatch-label" title="Self-employed">Self-employed</div>
   </div>
-  <div class="plot-swatch"><svg fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-swatch"><svg width="15" height="15" fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>
-    <div class="plot-label" title="Other">Other</div>
+    <div class="plot-swatch-label" title="Other">Other</div>
   </div>
 </div>

--- a/test/output/colorLegendCategoricalReverse.html
+++ b/test/output/colorLegendCategoricalReverse.html
@@ -1,52 +1,47 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>J</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>J</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>I</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>I</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>H</span><span class="plot-swatch"><svg fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>H</span><span class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>G</span><span class="plot-swatch"><svg fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>G</span><span class="plot-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>F</span><span class="plot-swatch"><svg fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>F</span><span class="plot-swatch"><svg width="15" height="15" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>E</span><span class="plot-swatch"><svg fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg width="15" height="15" fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>D</span><span class="plot-swatch"><svg fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>C</span><span class="plot-swatch"><svg fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>B</span><span class="plot-swatch"><svg fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>A</span>
 </div>

--- a/test/output/colorLegendCategoricalScheme.html
+++ b/test/output/colorLegendCategoricalScheme.html
@@ -1,52 +1,47 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg width="15" height="15" fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>A</span><span class="plot-swatch"><svg fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>B</span><span class="plot-swatch"><svg fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>C</span><span class="plot-swatch"><svg fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>D</span><span class="plot-swatch"><svg fill="#9467bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg width="15" height="15" fill="#9467bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>E</span><span class="plot-swatch"><svg fill="#8c564b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg width="15" height="15" fill="#8c564b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>F</span><span class="plot-swatch"><svg fill="#e377c2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>F</span><span class="plot-swatch"><svg width="15" height="15" fill="#e377c2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>G</span><span class="plot-swatch"><svg fill="#7f7f7f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>G</span><span class="plot-swatch"><svg width="15" height="15" fill="#7f7f7f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>H</span><span class="plot-swatch"><svg fill="#bcbd22" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>H</span><span class="plot-swatch"><svg width="15" height="15" fill="#bcbd22" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>I</span><span class="plot-swatch"><svg fill="#17becf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>I</span><span class="plot-swatch"><svg width="15" height="15" fill="#17becf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>J</span>
 </div>

--- a/test/output/colorLegendDiverging.svg
+++ b/test/output/colorLegendDiverging.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendDivergingPivot.svg
+++ b/test/output/colorLegendDivergingPivot.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendDivergingPivotAsymmetric.svg
+++ b/test/output/colorLegendDivergingPivotAsymmetric.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendDivergingSqrt.svg
+++ b/test/output/colorLegendDivergingSqrt.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendImplicitLabel.svg
+++ b/test/output/colorLegendImplicitLabel.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendInterpolate.svg
+++ b/test/output/colorLegendInterpolate.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendInterpolateSqrt.svg
+++ b/test/output/colorLegendInterpolateSqrt.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLabelBoth.svg
+++ b/test/output/colorLegendLabelBoth.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLabelLegend.svg
+++ b/test/output/colorLegendLabelLegend.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLabelScale.svg
+++ b/test/output/colorLegendLabelScale.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLinear.svg
+++ b/test/output/colorLegendLinear.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLinearNoTicks.svg
+++ b/test/output/colorLegendLinearNoTicks.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLinearTruncatedScheme.svg
+++ b/test/output/colorLegendLinearTruncatedScheme.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLog.svg
+++ b/test/output/colorLegendLog.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLogTicks.svg
+++ b/test/output/colorLegendLogTicks.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendMargins.svg
+++ b/test/output/colorLegendMargins.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="400" height="50" viewBox="0 0 400 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="400" height="50" viewBox="0 0 400 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOpacity.html
+++ b/test/output/colorLegendOpacity.html
@@ -1,38 +1,33 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="#4e79a7" fill-opacity="0.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" fill-opacity="0.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>Dream</span><span class="plot-swatch"><svg fill="#f28e2c" fill-opacity="0.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>Dream</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" fill-opacity="0.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>Torgersen</span><span class="plot-swatch"><svg fill="#e15759" fill-opacity="0.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>Torgersen</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" fill-opacity="0.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>Biscoe</span>
 </div>

--- a/test/output/colorLegendOpacityOrdinalRamp.svg
+++ b/test/output/colorLegendOpacityOrdinalRamp.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOpacityRamp.svg
+++ b/test/output/colorLegendOpacityRamp.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinal.html
+++ b/test/output/colorLegendOrdinal.html
@@ -1,52 +1,47 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>A</span><span class="plot-swatch"><svg fill="rgb(72, 96, 230)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(72, 96, 230)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>B</span><span class="plot-swatch"><svg fill="rgb(42, 171, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(42, 171, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>C</span><span class="plot-swatch"><svg fill="rgb(46, 229, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(46, 229, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>D</span><span class="plot-swatch"><svg fill="rgb(106, 253, 106)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(106, 253, 106)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>E</span><span class="plot-swatch"><svg fill="rgb(192, 238, 61)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(192, 238, 61)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>F</span><span class="plot-swatch"><svg fill="rgb(254, 185, 39)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>F</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 185, 39)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>G</span><span class="plot-swatch"><svg fill="rgb(254, 110, 26)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>G</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 110, 26)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>H</span><span class="plot-swatch"><svg fill="rgb(194, 39, 10)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>H</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(194, 39, 10)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>I</span><span class="plot-swatch"><svg fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>I</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>J</span>
 </div>

--- a/test/output/colorLegendOrdinalRamp.svg
+++ b/test/output/colorLegendOrdinalRamp.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinalRampTickSize.svg
+++ b/test/output/colorLegendOrdinalRampTickSize.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinalReverseRamp.svg
+++ b/test/output/colorLegendOrdinalReverseRamp.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinalScheme.html
+++ b/test/output/colorLegendOrdinalScheme.html
@@ -1,52 +1,47 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>A</span><span class="plot-swatch"><svg fill="rgb(191, 60, 175)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(191, 60, 175)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>B</span><span class="plot-swatch"><svg fill="rgb(254, 75, 131)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 75, 131)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>C</span><span class="plot-swatch"><svg fill="rgb(255, 120, 71)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 120, 71)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>D</span><span class="plot-swatch"><svg fill="rgb(226, 183, 47)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(226, 183, 47)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>E</span><span class="plot-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>F</span><span class="plot-swatch"><svg fill="rgb(82, 246, 103)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>F</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(82, 246, 103)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>G</span><span class="plot-swatch"><svg fill="rgb(29, 223, 163)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>G</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(29, 223, 163)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>H</span><span class="plot-swatch"><svg fill="rgb(35, 171, 216)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>H</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 171, 216)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>I</span><span class="plot-swatch"><svg fill="rgb(76, 110, 219)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>I</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(76, 110, 219)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>J</span>
 </div>

--- a/test/output/colorLegendOrdinalSchemeRamp.svg
+++ b/test/output/colorLegendOrdinalSchemeRamp.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinalTickFormat.html
+++ b/test/output/colorLegendOrdinalTickFormat.html
@@ -1,42 +1,37 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>1.0</span><span class="plot-swatch"><svg fill="rgb(38, 188, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>1.0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(38, 188, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>2.0</span><span class="plot-swatch"><svg fill="rgb(149, 251, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>2.0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(149, 251, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>3.0</span><span class="plot-swatch"><svg fill="rgb(255, 130, 29)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>3.0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 130, 29)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>4.0</span><span class="plot-swatch"><svg fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>4.0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>5.0</span>
 </div>

--- a/test/output/colorLegendOrdinalTickFormatFunction.html
+++ b/test/output/colorLegendOrdinalTickFormatFunction.html
@@ -1,42 +1,37 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>1.0</span><span class="plot-swatch"><svg fill="rgb(38, 188, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>1.0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(38, 188, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>2.0</span><span class="plot-swatch"><svg fill="rgb(149, 251, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>2.0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(149, 251, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>3.0</span><span class="plot-swatch"><svg fill="rgb(255, 130, 29)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>3.0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 130, 29)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>4.0</span><span class="plot-swatch"><svg fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>4.0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>5.0</span>
 </div>

--- a/test/output/colorLegendOrdinalTicks.svg
+++ b/test/output/colorLegendOrdinalTicks.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantile.svg
+++ b/test/output/colorLegendQuantile.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantileImplicit.svg
+++ b/test/output/colorLegendQuantileImplicit.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantileSwatches.html
+++ b/test/output/colorLegendQuantileSwatches.html
@@ -1,41 +1,39 @@
-<div class="plot" style="--swatchWidth: 15px; --swatchHeight: 15px; font-variant: tabular-nums;">
+<div class="plot-swatches plot-swatches-wrap" style="font-variant: tabular-nums;">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
-    .plot-swatch svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
+    .plot-swatch>svg {
       margin-right: 0.5em;
+      overflow: visible;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg fill="#320a5e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg width="15" height="15" fill="#320a5e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>200</span><span class="plot-swatch"><svg fill="#781c6d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>200</span><span class="plot-swatch"><svg width="15" height="15" fill="#781c6d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>800</span><span class="plot-swatch"><svg fill="#bc3754" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>800</span><span class="plot-swatch"><svg width="15" height="15" fill="#bc3754" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>1,800</span><span class="plot-swatch"><svg fill="#ed6925" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>1,800</span><span class="plot-swatch"><svg width="15" height="15" fill="#ed6925" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>3,201</span><span class="plot-swatch"><svg fill="#fbb61a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>3,201</span><span class="plot-swatch"><svg width="15" height="15" fill="#fbb61a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
-    </svg>5,001</span><span class="plot-swatch"><svg fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>5,001</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <rect width="100%" height="100%"></rect>
     </svg>7,201</span>
 </div>

--- a/test/output/colorLegendQuantitative.svg
+++ b/test/output/colorLegendQuantitative.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantitativeScheme.svg
+++ b/test/output/colorLegendQuantitativeScheme.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantize.svg
+++ b/test/output/colorLegendQuantize.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantizeDescending.svg
+++ b/test/output/colorLegendQuantizeDescending.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantizeDescendingReversed.svg
+++ b/test/output/colorLegendQuantizeDescendingReversed.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantizeRange.svg
+++ b/test/output/colorLegendQuantizeRange.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantizeReverse.svg
+++ b/test/output/colorLegendQuantizeReverse.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendSqrt.svg
+++ b/test/output/colorLegendSqrt.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendSqrtPiecewise.svg
+++ b/test/output/colorLegendSqrtPiecewise.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendThreshold.svg
+++ b/test/output/colorLegendThreshold.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendThresholdTickSize.svg
+++ b/test/output/colorLegendThresholdTickSize.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/colorSchemesOrdinal.html
+++ b/test/output/colorSchemesOrdinal.html
@@ -1,11101 +1,9851 @@
 <div>
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>accent</span>
   </div>
-  <div class="plot-2" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-2 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-2-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-2 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-2-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-2-swatch"><svg fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>accent</span><span class="plot-2-swatch"><svg fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>accent</span><span class="plot-swatch"><svg width="15" height="15" fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-3" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-3 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-3-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-3 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-3-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-3-swatch"><svg fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>accent</span><span class="plot-3-swatch"><svg fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>accent</span><span class="plot-swatch"><svg width="15" height="15" fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-3-swatch"><svg fill="#fdc086" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdc086" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-3-swatch"><svg fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-4" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-4 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-4-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-4 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-4-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-4-swatch"><svg fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>accent</span><span class="plot-4-swatch"><svg fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>accent</span><span class="plot-swatch"><svg width="15" height="15" fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-4-swatch"><svg fill="#fdc086" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdc086" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-4-swatch"><svg fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-4-swatch"><svg fill="#386cb0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#386cb0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-4-swatch"><svg fill="#f0027f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#f0027f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-4-swatch"><svg fill="#bf5b17" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#bf5b17" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-4-swatch"><svg fill="#666666" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#666666" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-4-swatch"><svg fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-5" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-5 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-5-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-5 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-5-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-5-swatch"><svg fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>accent</span><span class="plot-5-swatch"><svg fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>accent</span><span class="plot-swatch"><svg width="15" height="15" fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-5-swatch"><svg fill="#fdc086" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdc086" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-5-swatch"><svg fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-5-swatch"><svg fill="#386cb0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#386cb0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-5-swatch"><svg fill="#f0027f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#f0027f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-5-swatch"><svg fill="#bf5b17" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#bf5b17" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-5-swatch"><svg fill="#666666" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#666666" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-5-swatch"><svg fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#7fc97f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-5-swatch"><svg fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#beaed4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-5-swatch"><svg fill="#fdc086" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdc086" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-5-swatch"><svg fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-5-swatch"><svg fill="#386cb0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#386cb0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-5-swatch"><svg fill="#f0027f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#f0027f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-5-swatch"><svg fill="#bf5b17" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#bf5b17" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-6" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-6 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-6-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-6 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-6-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-6-swatch"><svg fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>category10</span>
   </div>
-  <div class="plot-7" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-7 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-7-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-7 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-7-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-7-swatch"><svg fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>category10</span><span class="plot-7-swatch"><svg fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>category10</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-8" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-8 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-8-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-8 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-8-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-8-swatch"><svg fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>category10</span><span class="plot-8-swatch"><svg fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>category10</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-8-swatch"><svg fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-8-swatch"><svg fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-9" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-9 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-9-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-9 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-9-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-9-swatch"><svg fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>category10</span><span class="plot-9-swatch"><svg fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>category10</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-9-swatch"><svg fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-9-swatch"><svg fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-9-swatch"><svg fill="#9467bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#9467bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-9-swatch"><svg fill="#8c564b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#8c564b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-9-swatch"><svg fill="#e377c2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#e377c2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-9-swatch"><svg fill="#7f7f7f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#7f7f7f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-9-swatch"><svg fill="#bcbd22" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#bcbd22" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-10" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-10 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-10-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-10 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-10-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-10-swatch"><svg fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>category10</span><span class="plot-10-swatch"><svg fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>category10</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-10-swatch"><svg fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-10-swatch"><svg fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-10-swatch"><svg fill="#9467bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#9467bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-10-swatch"><svg fill="#8c564b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#8c564b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-10-swatch"><svg fill="#e377c2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#e377c2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-10-swatch"><svg fill="#7f7f7f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#7f7f7f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-10-swatch"><svg fill="#bcbd22" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#bcbd22" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-10-swatch"><svg fill="#17becf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#17becf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-10-swatch"><svg fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#1f77b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-10-swatch"><svg fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-10-swatch"><svg fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#2ca02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-10-swatch"><svg fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#d62728" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-10-swatch"><svg fill="#9467bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#9467bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-11" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-11 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-11-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-11 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-11-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-11-swatch"><svg fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>dark2</span>
   </div>
-  <div class="plot-12" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-12 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-12-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-12 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-12-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-12-swatch"><svg fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>dark2</span><span class="plot-12-swatch"><svg fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>dark2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-13" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-13 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-13-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-13 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-13-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-13-swatch"><svg fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>dark2</span><span class="plot-13-swatch"><svg fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>dark2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-13-swatch"><svg fill="#7570b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#7570b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-13-swatch"><svg fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-14" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-14 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-14-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-14 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-14-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-14-swatch"><svg fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>dark2</span><span class="plot-14-swatch"><svg fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>dark2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-14-swatch"><svg fill="#7570b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#7570b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-14-swatch"><svg fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-14-swatch"><svg fill="#66a61e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#66a61e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-14-swatch"><svg fill="#e6ab02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e6ab02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-14-swatch"><svg fill="#a6761d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6761d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-14-swatch"><svg fill="#666666" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#666666" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-14-swatch"><svg fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-15" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-15 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-15-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-15 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-15-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-15-swatch"><svg fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>dark2</span><span class="plot-15-swatch"><svg fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>dark2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-15-swatch"><svg fill="#7570b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#7570b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-15-swatch"><svg fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-15-swatch"><svg fill="#66a61e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#66a61e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-15-swatch"><svg fill="#e6ab02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e6ab02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-15-swatch"><svg fill="#a6761d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6761d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-15-swatch"><svg fill="#666666" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#666666" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-15-swatch"><svg fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#1b9e77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-15-swatch"><svg fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#d95f02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-15-swatch"><svg fill="#7570b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#7570b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-15-swatch"><svg fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-15-swatch"><svg fill="#66a61e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#66a61e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-15-swatch"><svg fill="#e6ab02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#e6ab02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-15-swatch"><svg fill="#a6761d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6761d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-16" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-16 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-16-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-16 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-16-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-16-swatch"><svg fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>paired</span>
   </div>
-  <div class="plot-17" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-17 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-17-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-17 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-17-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-17-swatch"><svg fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>paired</span><span class="plot-17-swatch"><svg fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>paired</span><span class="plot-swatch"><svg width="15" height="15" fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-18" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-18 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-18-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-18 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-18-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-18-swatch"><svg fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>paired</span><span class="plot-18-swatch"><svg fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>paired</span><span class="plot-swatch"><svg width="15" height="15" fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-18-swatch"><svg fill="#b2df8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#b2df8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-18-swatch"><svg fill="#33a02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#33a02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-19" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-19 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-19-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-19 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-19-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-19-swatch"><svg fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>paired</span><span class="plot-19-swatch"><svg fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>paired</span><span class="plot-swatch"><svg width="15" height="15" fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-19-swatch"><svg fill="#b2df8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#b2df8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-19-swatch"><svg fill="#33a02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#33a02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-19-swatch"><svg fill="#fb9a99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#fb9a99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-19-swatch"><svg fill="#e31a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e31a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-19-swatch"><svg fill="#fdbf6f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdbf6f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-19-swatch"><svg fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-19-swatch"><svg fill="#cab2d6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#cab2d6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-20" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-20 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-20-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-20 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-20-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-20-swatch"><svg fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>paired</span><span class="plot-20-swatch"><svg fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>paired</span><span class="plot-swatch"><svg width="15" height="15" fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-20-swatch"><svg fill="#b2df8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#b2df8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-20-swatch"><svg fill="#33a02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#33a02c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-20-swatch"><svg fill="#fb9a99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#fb9a99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-20-swatch"><svg fill="#e31a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e31a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-20-swatch"><svg fill="#fdbf6f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdbf6f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-20-swatch"><svg fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-20-swatch"><svg fill="#cab2d6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#cab2d6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-20-swatch"><svg fill="#6a3d9a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#6a3d9a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-20-swatch"><svg fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffff99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-20-swatch"><svg fill="#b15928" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#b15928" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-20-swatch"><svg fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6cee3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-20-swatch"><svg fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#1f78b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-20-swatch"><svg fill="#b2df8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#b2df8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-21" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-21 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-21-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-21 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-21-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-21-swatch"><svg fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>pastel1</span>
   </div>
-  <div class="plot-22" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-22 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-22-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-22 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-22-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-22-swatch"><svg fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pastel1</span><span class="plot-22-swatch"><svg fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pastel1</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-23" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-23 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-23-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-23 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-23-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-23-swatch"><svg fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pastel1</span><span class="plot-23-swatch"><svg fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pastel1</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-23-swatch"><svg fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-23-swatch"><svg fill="#decbe4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#decbe4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-24" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-24 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-24-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-24 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-24-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-24-swatch"><svg fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pastel1</span><span class="plot-24-swatch"><svg fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pastel1</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-24-swatch"><svg fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-24-swatch"><svg fill="#decbe4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#decbe4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-24-swatch"><svg fill="#fed9a6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#fed9a6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-24-swatch"><svg fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-24-swatch"><svg fill="#e5d8bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#e5d8bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-24-swatch"><svg fill="#fddaec" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#fddaec" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-24-swatch"><svg fill="#f2f2f2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#f2f2f2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-25" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-25 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-25-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-25 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-25-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-25-swatch"><svg fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pastel1</span><span class="plot-25-swatch"><svg fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pastel1</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-25-swatch"><svg fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-25-swatch"><svg fill="#decbe4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#decbe4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-25-swatch"><svg fill="#fed9a6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#fed9a6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-25-swatch"><svg fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-25-swatch"><svg fill="#e5d8bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#e5d8bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-25-swatch"><svg fill="#fddaec" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#fddaec" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-25-swatch"><svg fill="#f2f2f2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#f2f2f2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-25-swatch"><svg fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#fbb4ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-25-swatch"><svg fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-25-swatch"><svg fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-25-swatch"><svg fill="#decbe4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#decbe4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-25-swatch"><svg fill="#fed9a6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#fed9a6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-25-swatch"><svg fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-26" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-26 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-26-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-26 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-26-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-26-swatch"><svg fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>pastel2</span>
   </div>
-  <div class="plot-27" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-27 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-27-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-27 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-27-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-27-swatch"><svg fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pastel2</span><span class="plot-27-swatch"><svg fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pastel2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-28" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-28 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-28-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-28 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-28-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-28-swatch"><svg fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pastel2</span><span class="plot-28-swatch"><svg fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pastel2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-28-swatch"><svg fill="#cbd5e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#cbd5e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-28-swatch"><svg fill="#f4cae4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4cae4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-29" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-29 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-29-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-29 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-29-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-29-swatch"><svg fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pastel2</span><span class="plot-29-swatch"><svg fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pastel2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-29-swatch"><svg fill="#cbd5e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#cbd5e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-29-swatch"><svg fill="#f4cae4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4cae4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-29-swatch"><svg fill="#e6f5c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#e6f5c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-29-swatch"><svg fill="#fff2ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#fff2ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-29-swatch"><svg fill="#f1e2cc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#f1e2cc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-29-swatch"><svg fill="#cccccc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#cccccc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-29-swatch"><svg fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-30" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-30 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-30-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-30 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-30-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-30-swatch"><svg fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pastel2</span><span class="plot-30-swatch"><svg fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pastel2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-30-swatch"><svg fill="#cbd5e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#cbd5e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-30-swatch"><svg fill="#f4cae4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4cae4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-30-swatch"><svg fill="#e6f5c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#e6f5c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-30-swatch"><svg fill="#fff2ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#fff2ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-30-swatch"><svg fill="#f1e2cc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#f1e2cc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-30-swatch"><svg fill="#cccccc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#cccccc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-30-swatch"><svg fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3e2cd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-30-swatch"><svg fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdcdac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-30-swatch"><svg fill="#cbd5e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#cbd5e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-30-swatch"><svg fill="#f4cae4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4cae4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-30-swatch"><svg fill="#e6f5c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#e6f5c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-30-swatch"><svg fill="#fff2ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#fff2ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-30-swatch"><svg fill="#f1e2cc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#f1e2cc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-31" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-31 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-31-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-31 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-31-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-31-swatch"><svg fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>set1</span>
   </div>
-  <div class="plot-32" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-32 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-32-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-32 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-32-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-32-swatch"><svg fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set1</span><span class="plot-32-swatch"><svg fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set1</span><span class="plot-swatch"><svg width="15" height="15" fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-33" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-33 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-33-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-33 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-33-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-33-swatch"><svg fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set1</span><span class="plot-33-swatch"><svg fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set1</span><span class="plot-swatch"><svg width="15" height="15" fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-33-swatch"><svg fill="#4daf4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#4daf4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-33-swatch"><svg fill="#984ea3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#984ea3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-34" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-34 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-34-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-34 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-34-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-34-swatch"><svg fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set1</span><span class="plot-34-swatch"><svg fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set1</span><span class="plot-swatch"><svg width="15" height="15" fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-34-swatch"><svg fill="#4daf4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#4daf4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-34-swatch"><svg fill="#984ea3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#984ea3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-34-swatch"><svg fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-34-swatch"><svg fill="#ffff33" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffff33" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-34-swatch"><svg fill="#a65628" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#a65628" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-34-swatch"><svg fill="#f781bf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#f781bf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-34-swatch"><svg fill="#999999" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#999999" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-35" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-35 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-35-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-35 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-35-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-35-swatch"><svg fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set1</span><span class="plot-35-swatch"><svg fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set1</span><span class="plot-swatch"><svg width="15" height="15" fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-35-swatch"><svg fill="#4daf4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#4daf4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-35-swatch"><svg fill="#984ea3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#984ea3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-35-swatch"><svg fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-35-swatch"><svg fill="#ffff33" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffff33" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-35-swatch"><svg fill="#a65628" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#a65628" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-35-swatch"><svg fill="#f781bf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#f781bf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-35-swatch"><svg fill="#999999" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#999999" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-35-swatch"><svg fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#e41a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-35-swatch"><svg fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#377eb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-35-swatch"><svg fill="#4daf4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#4daf4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-35-swatch"><svg fill="#984ea3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#984ea3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-35-swatch"><svg fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff7f00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-35-swatch"><svg fill="#ffff33" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffff33" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-36" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-36 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-36-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-36 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-36-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-36-swatch"><svg fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>set2</span>
   </div>
-  <div class="plot-37" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-37 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-37-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-37 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-37-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-37-swatch"><svg fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set2</span><span class="plot-37-swatch"><svg fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-38" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-38 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-38-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-38 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-38-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-38-swatch"><svg fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set2</span><span class="plot-38-swatch"><svg fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-38-swatch"><svg fill="#8da0cb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#8da0cb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-38-swatch"><svg fill="#e78ac3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e78ac3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-39" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-39 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-39-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-39 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-39-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-39-swatch"><svg fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set2</span><span class="plot-39-swatch"><svg fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-39-swatch"><svg fill="#8da0cb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#8da0cb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-39-swatch"><svg fill="#e78ac3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e78ac3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-39-swatch"><svg fill="#a6d854" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6d854" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-39-swatch"><svg fill="#ffd92f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffd92f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-39-swatch"><svg fill="#e5c494" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#e5c494" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-39-swatch"><svg fill="#b3b3b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3b3b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-39-swatch"><svg fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-40" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-40 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-40-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-40 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-40-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-40-swatch"><svg fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set2</span><span class="plot-40-swatch"><svg fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-40-swatch"><svg fill="#8da0cb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#8da0cb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-40-swatch"><svg fill="#e78ac3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e78ac3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-40-swatch"><svg fill="#a6d854" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6d854" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-40-swatch"><svg fill="#ffd92f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffd92f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-40-swatch"><svg fill="#e5c494" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#e5c494" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-40-swatch"><svg fill="#b3b3b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3b3b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-40-swatch"><svg fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-40-swatch"><svg fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-40-swatch"><svg fill="#8da0cb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#8da0cb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-40-swatch"><svg fill="#e78ac3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#e78ac3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-40-swatch"><svg fill="#a6d854" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6d854" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-40-swatch"><svg fill="#ffd92f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffd92f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-40-swatch"><svg fill="#e5c494" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#e5c494" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-41" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-41 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-41-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-41 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-41-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-41-swatch"><svg fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>set3</span>
   </div>
-  <div class="plot-42" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-42 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-42-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-42 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-42-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-42-swatch"><svg fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set3</span><span class="plot-42-swatch"><svg fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-43" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-43 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-43-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-43 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-43-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-43-swatch"><svg fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set3</span><span class="plot-43-swatch"><svg fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-43-swatch"><svg fill="#bebada" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#bebada" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-43-swatch"><svg fill="#fb8072" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fb8072" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-44" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-44 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-44-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-44 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-44-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-44-swatch"><svg fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set3</span><span class="plot-44-swatch"><svg fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-44-swatch"><svg fill="#bebada" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#bebada" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-44-swatch"><svg fill="#fb8072" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fb8072" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-44-swatch"><svg fill="#80b1d3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#80b1d3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-44-swatch"><svg fill="#fdb462" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdb462" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-44-swatch"><svg fill="#b3de69" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3de69" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-44-swatch"><svg fill="#fccde5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#fccde5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-44-swatch"><svg fill="#d9d9d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#d9d9d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-45" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-45 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-45-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-45 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-45-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-45-swatch"><svg fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>set3</span><span class="plot-45-swatch"><svg fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>set3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-45-swatch"><svg fill="#bebada" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#bebada" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-45-swatch"><svg fill="#fb8072" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fb8072" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-45-swatch"><svg fill="#80b1d3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#80b1d3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-45-swatch"><svg fill="#fdb462" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdb462" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-45-swatch"><svg fill="#b3de69" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3de69" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-45-swatch"><svg fill="#fccde5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#fccde5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-45-swatch"><svg fill="#d9d9d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#d9d9d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-45-swatch"><svg fill="#bc80bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#bc80bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-45-swatch"><svg fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-45-swatch"><svg fill="#ffed6f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffed6f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-45-swatch"><svg fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#8dd3c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-45-swatch"><svg fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffb3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-45-swatch"><svg fill="#bebada" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#bebada" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-46" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-46 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-46-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-46 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-46-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-46-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>tableau10</span>
   </div>
-  <div class="plot-47" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-47 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-47-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-47 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-47-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-47-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>tableau10</span><span class="plot-47-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>tableau10</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-48" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-48 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-48-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-48 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-48-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-48-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>tableau10</span><span class="plot-48-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>tableau10</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-48-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-48-swatch"><svg fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-49" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-49 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-49-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-49 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-49-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-49-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>tableau10</span><span class="plot-49-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>tableau10</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-49-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-49-swatch"><svg fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-49-swatch"><svg fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-49-swatch"><svg fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-49-swatch"><svg fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-49-swatch"><svg fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-49-swatch"><svg fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-50" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-50 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-50-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-50 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-50-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-50-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>tableau10</span><span class="plot-50-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>tableau10</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-50-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-50-swatch"><svg fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-50-swatch"><svg fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-50-swatch"><svg fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-50-swatch"><svg fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-50-swatch"><svg fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-50-swatch"><svg fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-50-swatch"><svg fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-50-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-50-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-50-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-50-swatch"><svg fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-50-swatch"><svg fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-51" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-51 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-51-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-51 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-51-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-51-swatch"><svg fill="#d8b365" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#d8b365" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>brbg</span>
   </div>
-  <div class="plot-52" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-52 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-52-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-52 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-52-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-52-swatch"><svg fill="#d8b365" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#d8b365" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>brbg</span><span class="plot-52-swatch"><svg fill="#5ab4ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>brbg</span><span class="plot-swatch"><svg width="15" height="15" fill="#5ab4ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-53" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-53 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-53-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-53 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-53-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-53-swatch"><svg fill="#a6611a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6611a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>brbg</span><span class="plot-53-swatch"><svg fill="#dfc27d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>brbg</span><span class="plot-swatch"><svg width="15" height="15" fill="#dfc27d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-53-swatch"><svg fill="#80cdc1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#80cdc1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-53-swatch"><svg fill="#018571" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#018571" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-54" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-54 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-54-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-54 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-54-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-54-swatch"><svg fill="#8c510a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#8c510a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>brbg</span><span class="plot-54-swatch"><svg fill="#bf812d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>brbg</span><span class="plot-swatch"><svg width="15" height="15" fill="#bf812d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-54-swatch"><svg fill="#dfc27d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#dfc27d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-54-swatch"><svg fill="#f6e8c3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#f6e8c3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-54-swatch"><svg fill="#f5f5f5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#f5f5f5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-54-swatch"><svg fill="#c7eae5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#c7eae5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-54-swatch"><svg fill="#80cdc1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#80cdc1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-54-swatch"><svg fill="#35978f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#35978f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-54-swatch"><svg fill="#01665e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#01665e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-55" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-55 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-55-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-55 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-55-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-55-swatch"><svg fill="rgb(84, 48, 5)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(84, 48, 5)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>brbg</span><span class="plot-55-swatch"><svg fill="rgb(124, 72, 10)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>brbg</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(124, 72, 10)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-55-swatch"><svg fill="rgb(161, 102, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(161, 102, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-55-swatch"><svg fill="rgb(194, 140, 61)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(194, 140, 61)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-55-swatch"><svg fill="rgb(217, 182, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(217, 182, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-55-swatch"><svg fill="rgb(235, 215, 164)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(235, 215, 164)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-55-swatch"><svg fill="rgb(244, 234, 208)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(244, 234, 208)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-55-swatch"><svg fill="rgb(238, 241, 234)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(238, 241, 234)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-55-swatch"><svg fill="rgb(210, 236, 232)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(210, 236, 232)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-55-swatch"><svg fill="rgb(168, 221, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(168, 221, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-55-swatch"><svg fill="rgb(117, 195, 184)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(117, 195, 184)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-55-swatch"><svg fill="rgb(66, 159, 150)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(66, 159, 150)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-55-swatch"><svg fill="rgb(25, 123, 115)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(25, 123, 115)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-55-swatch"><svg fill="rgb(4, 90, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(4, 90, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-55-swatch"><svg fill="rgb(0, 60, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 60, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-56" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-56 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-56-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-56 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-56-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-56-swatch"><svg fill="#af8dc3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#af8dc3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>prgn</span>
   </div>
-  <div class="plot-57" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-57 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-57-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-57 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-57-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-57-swatch"><svg fill="#af8dc3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#af8dc3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>prgn</span><span class="plot-57-swatch"><svg fill="#7fbf7b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>prgn</span><span class="plot-swatch"><svg width="15" height="15" fill="#7fbf7b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-58" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-58 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-58-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-58 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-58-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-58-swatch"><svg fill="#7b3294" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#7b3294" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>prgn</span><span class="plot-58-swatch"><svg fill="#c2a5cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>prgn</span><span class="plot-swatch"><svg width="15" height="15" fill="#c2a5cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-58-swatch"><svg fill="#a6dba0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6dba0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-58-swatch"><svg fill="#008837" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#008837" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-59" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-59 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-59-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-59 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-59-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-59-swatch"><svg fill="#762a83" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#762a83" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>prgn</span><span class="plot-59-swatch"><svg fill="#9970ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>prgn</span><span class="plot-swatch"><svg width="15" height="15" fill="#9970ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-59-swatch"><svg fill="#c2a5cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#c2a5cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-59-swatch"><svg fill="#e7d4e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e7d4e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-59-swatch"><svg fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-59-swatch"><svg fill="#d9f0d3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#d9f0d3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-59-swatch"><svg fill="#a6dba0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6dba0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-59-swatch"><svg fill="#5aae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#5aae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-59-swatch"><svg fill="#1b7837" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#1b7837" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-60" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-60 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-60-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-60 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-60-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-60-swatch"><svg fill="rgb(64, 0, 75)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(64, 0, 75)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>prgn</span><span class="plot-60-swatch"><svg fill="rgb(101, 32, 114)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>prgn</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(101, 32, 114)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-60-swatch"><svg fill="rgb(132, 73, 148)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(132, 73, 148)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-60-swatch"><svg fill="rgb(159, 118, 176)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(159, 118, 176)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-60-swatch"><svg fill="rgb(188, 157, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(188, 157, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-60-swatch"><svg fill="rgb(214, 191, 221)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(214, 191, 221)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-60-swatch"><svg fill="rgb(234, 221, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(234, 221, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-60-swatch"><svg fill="rgb(239, 240, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(239, 240, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-60-swatch"><svg fill="rgb(224, 241, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(224, 241, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-60-swatch"><svg fill="rgb(194, 230, 189)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(194, 230, 189)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-60-swatch"><svg fill="rgb(153, 210, 150)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(153, 210, 150)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-60-swatch"><svg fill="rgb(102, 179, 108)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(102, 179, 108)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-60-swatch"><svg fill="rgb(55, 143, 74)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(55, 143, 74)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-60-swatch"><svg fill="rgb(21, 105, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(21, 105, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-60-swatch"><svg fill="rgb(0, 68, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 68, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-61" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-61 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-61-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-61 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-61-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-61-swatch"><svg fill="#e9a3c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#e9a3c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>piyg</span>
   </div>
-  <div class="plot-62" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-62 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-62-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-62 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-62-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-62-swatch"><svg fill="#e9a3c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#e9a3c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>piyg</span><span class="plot-62-swatch"><svg fill="#a1d76a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>piyg</span><span class="plot-swatch"><svg width="15" height="15" fill="#a1d76a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-63" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-63 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-63-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-63 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-63-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-63-swatch"><svg fill="#d01c8b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#d01c8b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>piyg</span><span class="plot-63-swatch"><svg fill="#f1b6da" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>piyg</span><span class="plot-swatch"><svg width="15" height="15" fill="#f1b6da" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-63-swatch"><svg fill="#b8e186" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#b8e186" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-63-swatch"><svg fill="#4dac26" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#4dac26" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-64" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-64 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-64-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-64 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-64-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-64-swatch"><svg fill="#c51b7d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#c51b7d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>piyg</span><span class="plot-64-swatch"><svg fill="#de77ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>piyg</span><span class="plot-swatch"><svg width="15" height="15" fill="#de77ae" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-64-swatch"><svg fill="#f1b6da" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#f1b6da" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-64-swatch"><svg fill="#fde0ef" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fde0ef" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-64-swatch"><svg fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-64-swatch"><svg fill="#e6f5d0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e6f5d0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-64-swatch"><svg fill="#b8e186" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#b8e186" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-64-swatch"><svg fill="#7fbc41" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#7fbc41" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-64-swatch"><svg fill="#4d9221" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#4d9221" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-65" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-65 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-65-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-65 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-65-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-65-swatch"><svg fill="rgb(142, 1, 82)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(142, 1, 82)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>piyg</span><span class="plot-65-swatch"><svg fill="rgb(179, 24, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>piyg</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(179, 24, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-65-swatch"><svg fill="rgb(207, 68, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(207, 68, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-65-swatch"><svg fill="rgb(224, 125, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(224, 125, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-65-swatch"><svg fill="rgb(238, 171, 209)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(238, 171, 209)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-65-swatch"><svg fill="rgb(247, 205, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(247, 205, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-65-swatch"><svg fill="rgb(250, 229, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(250, 229, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-65-swatch"><svg fill="rgb(245, 243, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(245, 243, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-65-swatch"><svg fill="rgb(233, 244, 217)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(233, 244, 217)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-65-swatch"><svg fill="rgb(209, 236, 175)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(209, 236, 175)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-65-swatch"><svg fill="rgb(175, 218, 125)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 218, 125)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-65-swatch"><svg fill="rgb(136, 193, 79)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(136, 193, 79)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-65-swatch"><svg fill="rgb(99, 164, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(99, 164, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-65-swatch"><svg fill="rgb(67, 133, 32)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(67, 133, 32)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-65-swatch"><svg fill="rgb(39, 100, 25)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(39, 100, 25)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-66" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-66 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-66-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-66 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-66-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-66-swatch"><svg fill="#998ec3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#998ec3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>puor</span>
   </div>
-  <div class="plot-67" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-67 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-67-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-67 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-67-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-67-swatch"><svg fill="#998ec3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#998ec3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>puor</span><span class="plot-67-swatch"><svg fill="#f1a340" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>puor</span><span class="plot-swatch"><svg width="15" height="15" fill="#f1a340" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-68" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-68 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-68-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-68 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-68-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-68-swatch"><svg fill="#5e3c99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#5e3c99" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>puor</span><span class="plot-68-swatch"><svg fill="#b2abd2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>puor</span><span class="plot-swatch"><svg width="15" height="15" fill="#b2abd2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-68-swatch"><svg fill="#fdb863" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdb863" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-68-swatch"><svg fill="#e66101" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e66101" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-69" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-69 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-69-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-69 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-69-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-69-swatch"><svg fill="#542788" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#542788" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>puor</span><span class="plot-69-swatch"><svg fill="#8073ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>puor</span><span class="plot-swatch"><svg width="15" height="15" fill="#8073ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-69-swatch"><svg fill="#b2abd2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#b2abd2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-69-swatch"><svg fill="#d8daeb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d8daeb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-69-swatch"><svg fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-69-swatch"><svg fill="#fee0b6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#fee0b6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-69-swatch"><svg fill="#fdb863" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdb863" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-69-swatch"><svg fill="#e08214" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#e08214" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-69-swatch"><svg fill="#b35806" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#b35806" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-70" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-70 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-70-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-70 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-70-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-70-swatch"><svg fill="rgb(45, 0, 75)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(45, 0, 75)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>puor</span><span class="plot-70-swatch"><svg fill="rgb(73, 30, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>puor</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(73, 30, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-70-swatch"><svg fill="rgb(103, 72, 151)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(103, 72, 151)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-70-swatch"><svg fill="rgb(136, 121, 178)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(136, 121, 178)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-70-swatch"><svg fill="rgb(170, 162, 203)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(170, 162, 203)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-70-swatch"><svg fill="rgb(199, 197, 224)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(199, 197, 224)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-70-swatch"><svg fill="rgb(224, 225, 237)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(224, 225, 237)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-70-swatch"><svg fill="rgb(243, 238, 234)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(243, 238, 234)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-70-swatch"><svg fill="rgb(251, 229, 199)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 229, 199)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-70-swatch"><svg fill="rgb(253, 206, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 206, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-70-swatch"><svg fill="rgb(246, 175, 88)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(246, 175, 88)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-70-swatch"><svg fill="rgb(226, 139, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(226, 139, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-70-swatch"><svg fill="rgb(198, 107, 13)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(198, 107, 13)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-70-swatch"><svg fill="rgb(164, 81, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(164, 81, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-70-swatch"><svg fill="rgb(127, 59, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(127, 59, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-71" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-71 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-71-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-71 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-71-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-71-swatch"><svg fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>rdbu</span>
   </div>
-  <div class="plot-72" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-72 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-72-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-72 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-72-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-72-swatch"><svg fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdbu</span><span class="plot-72-swatch"><svg fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-73" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-73 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-73-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-73 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-73-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-73-swatch"><svg fill="#ca0020" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ca0020" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdbu</span><span class="plot-73-swatch"><svg fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-73-swatch"><svg fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-73-swatch"><svg fill="#0571b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#0571b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-74" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-74 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-74-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-74 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-74-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-74-swatch"><svg fill="#b2182b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#b2182b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdbu</span><span class="plot-74-swatch"><svg fill="#d6604d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#d6604d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-74-swatch"><svg fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-74-swatch"><svg fill="#fddbc7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fddbc7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-74-swatch"><svg fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-74-swatch"><svg fill="#d1e5f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#d1e5f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-74-swatch"><svg fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-74-swatch"><svg fill="#4393c3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#4393c3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-74-swatch"><svg fill="#2166ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#2166ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-75" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-75 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-75-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-75 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-75-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-75-swatch"><svg fill="rgb(103, 0, 31)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(103, 0, 31)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdbu</span><span class="plot-75-swatch"><svg fill="rgb(154, 20, 41)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdbu</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(154, 20, 41)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-75-swatch"><svg fill="rgb(192, 56, 59)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(192, 56, 59)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-75-swatch"><svg fill="rgb(218, 106, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(218, 106, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-75-swatch"><svg fill="rgb(238, 154, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(238, 154, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-75-swatch"><svg fill="rgb(248, 195, 169)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(248, 195, 169)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-75-swatch"><svg fill="rgb(250, 225, 211)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(250, 225, 211)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-75-swatch"><svg fill="rgb(242, 239, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(242, 239, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-75-swatch"><svg fill="rgb(218, 233, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(218, 233, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-75-swatch"><svg fill="rgb(181, 215, 232)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(181, 215, 232)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-75-swatch"><svg fill="rgb(133, 188, 217)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(133, 188, 217)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-75-swatch"><svg fill="rgb(83, 155, 199)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(83, 155, 199)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-75-swatch"><svg fill="rgb(48, 121, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(48, 121, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-75-swatch"><svg fill="rgb(25, 86, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(25, 86, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-75-swatch"><svg fill="rgb(5, 48, 97)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(5, 48, 97)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-76" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-76 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-76-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-76 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-76-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-76-swatch"><svg fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>rdgy</span>
   </div>
-  <div class="plot-77" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-77 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-77-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-77 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-77-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-77-swatch"><svg fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdgy</span><span class="plot-77-swatch"><svg fill="#999999" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdgy</span><span class="plot-swatch"><svg width="15" height="15" fill="#999999" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-78" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-78 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-78-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-78 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-78-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-78-swatch"><svg fill="#ca0020" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ca0020" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdgy</span><span class="plot-78-swatch"><svg fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdgy</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-78-swatch"><svg fill="#bababa" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#bababa" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-78-swatch"><svg fill="#404040" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#404040" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-79" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-79 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-79-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-79 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-79-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-79-swatch"><svg fill="#b2182b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#b2182b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdgy</span><span class="plot-79-swatch"><svg fill="#d6604d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdgy</span><span class="plot-swatch"><svg width="15" height="15" fill="#d6604d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-79-swatch"><svg fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-79-swatch"><svg fill="#fddbc7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fddbc7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-79-swatch"><svg fill="#ffffff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-79-swatch"><svg fill="#e0e0e0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e0e0e0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-79-swatch"><svg fill="#bababa" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#bababa" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-79-swatch"><svg fill="#878787" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#878787" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-79-swatch"><svg fill="#4d4d4d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#4d4d4d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-80" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-80 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-80-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-80 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-80-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-80-swatch"><svg fill="rgb(103, 0, 31)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(103, 0, 31)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdgy</span><span class="plot-80-swatch"><svg fill="rgb(154, 20, 41)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdgy</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(154, 20, 41)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-80-swatch"><svg fill="rgb(192, 56, 59)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(192, 56, 59)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-80-swatch"><svg fill="rgb(218, 106, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(218, 106, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-80-swatch"><svg fill="rgb(238, 154, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(238, 154, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-80-swatch"><svg fill="rgb(249, 195, 169)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(249, 195, 169)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-80-swatch"><svg fill="rgb(253, 228, 214)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 228, 214)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-80-swatch"><svg fill="rgb(250, 244, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(250, 244, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-80-swatch"><svg fill="rgb(232, 232, 232)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(232, 232, 232)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-80-swatch"><svg fill="rgb(207, 207, 207)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(207, 207, 207)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-80-swatch"><svg fill="rgb(177, 177, 177)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(177, 177, 177)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-80-swatch"><svg fill="rgb(142, 142, 142)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(142, 142, 142)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-80-swatch"><svg fill="rgb(102, 102, 102)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(102, 102, 102)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-80-swatch"><svg fill="rgb(63, 63, 63)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(63, 63, 63)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-80-swatch"><svg fill="rgb(26, 26, 26)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(26, 26, 26)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-81" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-81 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-81-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-81 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-81-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-81-swatch"><svg fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>rdylbu</span>
   </div>
-  <div class="plot-82" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-82 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-82-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-82 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-82-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-82-swatch"><svg fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdylbu</span><span class="plot-82-swatch"><svg fill="#91bfdb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdylbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#91bfdb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-83" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-83 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-83-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-83 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-83-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-83-swatch"><svg fill="#d7191c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#d7191c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdylbu</span><span class="plot-83-swatch"><svg fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdylbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-83-swatch"><svg fill="#abd9e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#abd9e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-83-swatch"><svg fill="#2c7bb6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#2c7bb6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-84" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-84 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-84-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-84 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-84-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-84-swatch"><svg fill="#d73027" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#d73027" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdylbu</span><span class="plot-84-swatch"><svg fill="#f46d43" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdylbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#f46d43" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-84-swatch"><svg fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-84-swatch"><svg fill="#fee090" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fee090" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-84-swatch"><svg fill="#ffffbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-84-swatch"><svg fill="#e0f3f8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e0f3f8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-84-swatch"><svg fill="#abd9e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#abd9e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-84-swatch"><svg fill="#74add1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#74add1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-84-swatch"><svg fill="#4575b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#4575b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-85" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-85 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-85-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-85 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-85-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-85-swatch"><svg fill="rgb(165, 0, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(165, 0, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdylbu</span><span class="plot-85-swatch"><svg fill="rgb(199, 35, 40)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdylbu</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(199, 35, 40)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-85-swatch"><svg fill="rgb(227, 75, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(227, 75, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-85-swatch"><svg fill="rgb(243, 119, 72)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(243, 119, 72)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-85-swatch"><svg fill="rgb(251, 163, 94)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 163, 94)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-85-swatch"><svg fill="rgb(253, 202, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 202, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-85-swatch"><svg fill="rgb(254, 232, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 232, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-85-swatch"><svg fill="rgb(250, 248, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(250, 248, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-85-swatch"><svg fill="rgb(231, 245, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(231, 245, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-85-swatch"><svg fill="rgb(201, 231, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(201, 231, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-85-swatch"><svg fill="rgb(163, 209, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(163, 209, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-85-swatch"><svg fill="rgb(125, 178, 212)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(125, 178, 212)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-85-swatch"><svg fill="rgb(90, 141, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(90, 141, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-85-swatch"><svg fill="rgb(65, 99, 171)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(65, 99, 171)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-85-swatch"><svg fill="rgb(49, 54, 149)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(49, 54, 149)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-86" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-86 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-86-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-86 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-86-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-86-swatch"><svg fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>rdylgn</span>
   </div>
-  <div class="plot-87" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-87 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-87-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-87 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-87-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-87-swatch"><svg fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdylgn</span><span class="plot-87-swatch"><svg fill="#91cf60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdylgn</span><span class="plot-swatch"><svg width="15" height="15" fill="#91cf60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-88" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-88 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-88-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-88 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-88-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-88-swatch"><svg fill="#d7191c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#d7191c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdylgn</span><span class="plot-88-swatch"><svg fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdylgn</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-88-swatch"><svg fill="#a6d96a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6d96a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-88-swatch"><svg fill="#1a9641" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#1a9641" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-89" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-89 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-89-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-89 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-89-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-89-swatch"><svg fill="#d73027" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#d73027" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdylgn</span><span class="plot-89-swatch"><svg fill="#f46d43" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdylgn</span><span class="plot-swatch"><svg width="15" height="15" fill="#f46d43" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-89-swatch"><svg fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-89-swatch"><svg fill="#fee08b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fee08b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-89-swatch"><svg fill="#ffffbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-89-swatch"><svg fill="#d9ef8b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#d9ef8b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-89-swatch"><svg fill="#a6d96a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6d96a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-89-swatch"><svg fill="#66bd63" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#66bd63" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-89-swatch"><svg fill="#1a9850" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#1a9850" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-90" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-90 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-90-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-90 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-90-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-90-swatch"><svg fill="rgb(165, 0, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(165, 0, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdylgn</span><span class="plot-90-swatch"><svg fill="rgb(199, 35, 40)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdylgn</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(199, 35, 40)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-90-swatch"><svg fill="rgb(227, 75, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(227, 75, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-90-swatch"><svg fill="rgb(243, 119, 72)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(243, 119, 72)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-90-swatch"><svg fill="rgb(251, 163, 94)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 163, 94)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-90-swatch"><svg fill="rgb(253, 202, 121)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 202, 121)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-90-swatch"><svg fill="rgb(254, 232, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 232, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-90-swatch"><svg fill="rgb(249, 247, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(249, 247, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-90-swatch"><svg fill="rgb(227, 243, 155)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(227, 243, 155)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-90-swatch"><svg fill="rgb(195, 229, 126)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(195, 229, 126)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-90-swatch"><svg fill="rgb(155, 212, 108)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(155, 212, 108)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-90-swatch"><svg fill="rgb(110, 192, 99)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 192, 99)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-90-swatch"><svg fill="rgb(60, 167, 88)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(60, 167, 88)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-90-swatch"><svg fill="rgb(22, 138, 72)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(22, 138, 72)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-90-swatch"><svg fill="rgb(0, 104, 55)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 104, 55)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-91" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-91 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-91-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-91 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-91-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-91-swatch"><svg fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>spectral</span>
   </div>
-  <div class="plot-92" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-92 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-92-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-92 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-92-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-92-swatch"><svg fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>spectral</span><span class="plot-92-swatch"><svg fill="#99d594" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>spectral</span><span class="plot-swatch"><svg width="15" height="15" fill="#99d594" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-93" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-93 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-93-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-93 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-93-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-93-swatch"><svg fill="#d7191c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#d7191c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>spectral</span><span class="plot-93-swatch"><svg fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>spectral</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-93-swatch"><svg fill="#abdda4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#abdda4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-93-swatch"><svg fill="#2b83ba" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#2b83ba" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-94" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-94 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-94-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-94 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-94-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-94-swatch"><svg fill="#d53e4f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#d53e4f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>spectral</span><span class="plot-94-swatch"><svg fill="#f46d43" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>spectral</span><span class="plot-swatch"><svg width="15" height="15" fill="#f46d43" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-94-swatch"><svg fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-94-swatch"><svg fill="#fee08b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fee08b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-94-swatch"><svg fill="#ffffbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-94-swatch"><svg fill="#e6f598" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e6f598" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-94-swatch"><svg fill="#abdda4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#abdda4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-94-swatch"><svg fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-94-swatch"><svg fill="#3288bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#3288bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-95" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-95 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-95-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-95 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-95-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-95-swatch"><svg fill="rgb(158, 1, 66)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(158, 1, 66)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>spectral</span><span class="plot-95-swatch"><svg fill="rgb(196, 44, 74)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>spectral</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(196, 44, 74)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-95-swatch"><svg fill="rgb(225, 82, 74)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(225, 82, 74)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-95-swatch"><svg fill="rgb(243, 120, 76)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(243, 120, 76)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-95-swatch"><svg fill="rgb(251, 163, 94)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 163, 94)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-95-swatch"><svg fill="rgb(253, 202, 121)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 202, 121)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-95-swatch"><svg fill="rgb(254, 232, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 232, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-95-swatch"><svg fill="rgb(251, 248, 176)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 248, 176)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-95-swatch"><svg fill="rgb(235, 247, 166)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(235, 247, 166)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-95-swatch"><svg fill="rgb(204, 234, 159)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(204, 234, 159)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-95-swatch"><svg fill="rgb(160, 217, 163)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(160, 217, 163)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-95-swatch"><svg fill="rgb(114, 195, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(114, 195, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-95-swatch"><svg fill="rgb(75, 160, 177)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(75, 160, 177)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-95-swatch"><svg fill="rgb(68, 120, 178)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(68, 120, 178)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-95-swatch"><svg fill="rgb(94, 79, 162)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(94, 79, 162)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-96" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-96 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-96-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-96 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-96-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-96-swatch"><svg fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>burd</span>
   </div>
-  <div class="plot-97" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-97 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-97-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-97 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-97-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-97-swatch"><svg fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>burd</span><span class="plot-97-swatch"><svg fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>burd</span><span class="plot-swatch"><svg width="15" height="15" fill="#ef8a62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-98" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-98 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-98-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-98 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-98-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-98-swatch"><svg fill="#0571b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#0571b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>burd</span><span class="plot-98-swatch"><svg fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>burd</span><span class="plot-swatch"><svg width="15" height="15" fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-98-swatch"><svg fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-98-swatch"><svg fill="#ca0020" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#ca0020" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-99" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-99 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-99-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-99 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-99-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-99-swatch"><svg fill="#2166ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#2166ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>burd</span><span class="plot-99-swatch"><svg fill="#4393c3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>burd</span><span class="plot-swatch"><svg width="15" height="15" fill="#4393c3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-99-swatch"><svg fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-99-swatch"><svg fill="#d1e5f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d1e5f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-99-swatch"><svg fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-99-swatch"><svg fill="#fddbc7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#fddbc7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-99-swatch"><svg fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-99-swatch"><svg fill="#d6604d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#d6604d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-99-swatch"><svg fill="#b2182b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#b2182b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-100" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-100 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-100-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-100 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-100-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-100-swatch"><svg fill="rgb(5, 48, 97)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(5, 48, 97)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>burd</span><span class="plot-100-swatch"><svg fill="rgb(25, 86, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>burd</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(25, 86, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-100-swatch"><svg fill="rgb(48, 121, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(48, 121, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-100-swatch"><svg fill="rgb(83, 155, 199)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(83, 155, 199)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-100-swatch"><svg fill="rgb(133, 188, 217)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(133, 188, 217)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-100-swatch"><svg fill="rgb(181, 215, 232)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(181, 215, 232)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-100-swatch"><svg fill="rgb(218, 233, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(218, 233, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-100-swatch"><svg fill="rgb(242, 239, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(242, 239, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-100-swatch"><svg fill="rgb(250, 225, 211)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(250, 225, 211)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-100-swatch"><svg fill="rgb(248, 195, 169)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(248, 195, 169)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-100-swatch"><svg fill="rgb(238, 154, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(238, 154, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-100-swatch"><svg fill="rgb(218, 106, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(218, 106, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-100-swatch"><svg fill="rgb(192, 56, 59)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(192, 56, 59)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-100-swatch"><svg fill="rgb(154, 20, 41)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(154, 20, 41)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-100-swatch"><svg fill="rgb(103, 0, 31)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(103, 0, 31)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-101" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-101 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-101-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-101 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-101-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-101-swatch"><svg fill="#91bfdb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#91bfdb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>buylrd</span>
   </div>
-  <div class="plot-102" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-102 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-102-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-102 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-102-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-102-swatch"><svg fill="#91bfdb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#91bfdb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>buylrd</span><span class="plot-102-swatch"><svg fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>buylrd</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-103" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-103 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-103-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-103 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-103-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-103-swatch"><svg fill="#2c7bb6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#2c7bb6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>buylrd</span><span class="plot-103-swatch"><svg fill="#abd9e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>buylrd</span><span class="plot-swatch"><svg width="15" height="15" fill="#abd9e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-103-swatch"><svg fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-103-swatch"><svg fill="#d7191c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d7191c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-104" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-104 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-104-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-104 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-104-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-104-swatch"><svg fill="#4575b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4575b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>buylrd</span><span class="plot-104-swatch"><svg fill="#74add1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>buylrd</span><span class="plot-swatch"><svg width="15" height="15" fill="#74add1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-104-swatch"><svg fill="#abd9e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#abd9e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-104-swatch"><svg fill="#e0f3f8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e0f3f8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-104-swatch"><svg fill="#ffffbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffffbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-104-swatch"><svg fill="#fee090" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#fee090" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-104-swatch"><svg fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdae61" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-104-swatch"><svg fill="#f46d43" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#f46d43" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-104-swatch"><svg fill="#d73027" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#d73027" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-105" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-105 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-105-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-105 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-105-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-105-swatch"><svg fill="rgb(49, 54, 149)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(49, 54, 149)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>buylrd</span><span class="plot-105-swatch"><svg fill="rgb(65, 99, 171)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>buylrd</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(65, 99, 171)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-105-swatch"><svg fill="rgb(90, 141, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(90, 141, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-105-swatch"><svg fill="rgb(125, 178, 212)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(125, 178, 212)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-105-swatch"><svg fill="rgb(163, 209, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(163, 209, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-105-swatch"><svg fill="rgb(201, 231, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(201, 231, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-105-swatch"><svg fill="rgb(231, 245, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(231, 245, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-105-swatch"><svg fill="rgb(250, 248, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(250, 248, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-105-swatch"><svg fill="rgb(254, 232, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 232, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-105-swatch"><svg fill="rgb(253, 202, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 202, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-105-swatch"><svg fill="rgb(251, 163, 94)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 163, 94)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-105-swatch"><svg fill="rgb(243, 119, 72)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(243, 119, 72)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-105-swatch"><svg fill="rgb(227, 75, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(227, 75, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-105-swatch"><svg fill="rgb(199, 35, 40)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(199, 35, 40)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-105-swatch"><svg fill="rgb(165, 0, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(165, 0, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-106" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-106 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-106-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-106 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-106-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-106-swatch"><svg fill="#9ecae1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#9ecae1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>blues</span>
   </div>
-  <div class="plot-107" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-107 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-107-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-107 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-107-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-107-swatch"><svg fill="#9ecae1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#9ecae1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>blues</span><span class="plot-107-swatch"><svg fill="#3182bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>blues</span><span class="plot-swatch"><svg width="15" height="15" fill="#3182bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-108" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-108 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-108-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-108 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-108-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-108-swatch"><svg fill="#eff3ff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#eff3ff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>blues</span><span class="plot-108-swatch"><svg fill="#bdd7e7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>blues</span><span class="plot-swatch"><svg width="15" height="15" fill="#bdd7e7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-108-swatch"><svg fill="#6baed6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#6baed6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-108-swatch"><svg fill="#2171b5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#2171b5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-109" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-109 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-109-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-109 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-109-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-109-swatch"><svg fill="#f7fbff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f7fbff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>blues</span><span class="plot-109-swatch"><svg fill="#deebf7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>blues</span><span class="plot-swatch"><svg width="15" height="15" fill="#deebf7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-109-swatch"><svg fill="#c6dbef" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#c6dbef" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-109-swatch"><svg fill="#9ecae1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#9ecae1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-109-swatch"><svg fill="#6baed6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#6baed6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-109-swatch"><svg fill="#4292c6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#4292c6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-109-swatch"><svg fill="#2171b5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#2171b5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-109-swatch"><svg fill="#08519c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#08519c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-109-swatch"><svg fill="#08306b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#08306b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-110" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-110 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-110-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-110 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-110-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-110-swatch"><svg fill="rgb(247, 251, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(247, 251, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>blues</span><span class="plot-110-swatch"><svg fill="rgb(233, 242, 250)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>blues</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(233, 242, 250)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-110-swatch"><svg fill="rgb(219, 233, 246)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(219, 233, 246)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-110-swatch"><svg fill="rgb(204, 224, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(204, 224, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-110-swatch"><svg fill="rgb(186, 214, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(186, 214, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-110-swatch"><svg fill="rgb(163, 203, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(163, 203, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-110-swatch"><svg fill="rgb(136, 190, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(136, 190, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-110-swatch"><svg fill="rgb(109, 174, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(109, 174, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-110-swatch"><svg fill="rgb(84, 158, 205)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(84, 158, 205)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-110-swatch"><svg fill="rgb(62, 141, 195)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(62, 141, 195)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-110-swatch"><svg fill="rgb(43, 122, 185)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(43, 122, 185)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-110-swatch"><svg fill="rgb(26, 104, 173)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(26, 104, 173)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-110-swatch"><svg fill="rgb(14, 85, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(14, 85, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-110-swatch"><svg fill="rgb(9, 67, 134)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(9, 67, 134)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-110-swatch"><svg fill="rgb(8, 48, 107)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(8, 48, 107)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-111" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-111 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-111-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-111 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-111-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-111-swatch"><svg fill="#a1d99b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a1d99b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>greens</span>
   </div>
-  <div class="plot-112" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-112 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-112-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-112 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-112-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-112-swatch"><svg fill="#a1d99b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a1d99b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>greens</span><span class="plot-112-swatch"><svg fill="#31a354" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>greens</span><span class="plot-swatch"><svg width="15" height="15" fill="#31a354" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-113" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-113 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-113-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-113 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-113-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-113-swatch"><svg fill="#edf8e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#edf8e9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>greens</span><span class="plot-113-swatch"><svg fill="#bae4b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>greens</span><span class="plot-swatch"><svg width="15" height="15" fill="#bae4b3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-113-swatch"><svg fill="#74c476" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#74c476" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-113-swatch"><svg fill="#238b45" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#238b45" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-114" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-114 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-114-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-114 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-114-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-114-swatch"><svg fill="#f7fcf5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f7fcf5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>greens</span><span class="plot-114-swatch"><svg fill="#e5f5e0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>greens</span><span class="plot-swatch"><svg width="15" height="15" fill="#e5f5e0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-114-swatch"><svg fill="#c7e9c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#c7e9c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-114-swatch"><svg fill="#a1d99b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#a1d99b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-114-swatch"><svg fill="#74c476" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#74c476" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-114-swatch"><svg fill="#41ab5d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#41ab5d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-114-swatch"><svg fill="#238b45" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#238b45" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-114-swatch"><svg fill="#006d2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#006d2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-114-swatch"><svg fill="#00441b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#00441b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-115" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-115 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-115-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-115 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-115-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-115-swatch"><svg fill="rgb(247, 252, 245)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(247, 252, 245)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>greens</span><span class="plot-115-swatch"><svg fill="rgb(236, 248, 233)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>greens</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(236, 248, 233)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-115-swatch"><svg fill="rgb(223, 243, 218)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(223, 243, 218)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-115-swatch"><svg fill="rgb(207, 236, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(207, 236, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-115-swatch"><svg fill="rgb(188, 228, 181)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(188, 228, 181)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-115-swatch"><svg fill="rgb(166, 219, 160)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(166, 219, 160)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-115-swatch"><svg fill="rgb(141, 208, 139)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(141, 208, 139)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-115-swatch"><svg fill="rgb(115, 195, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(115, 195, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-115-swatch"><svg fill="rgb(87, 181, 104)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(87, 181, 104)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-115-swatch"><svg fill="rgb(63, 166, 90)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(63, 166, 90)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-115-swatch"><svg fill="rgb(43, 148, 76)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(43, 148, 76)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-115-swatch"><svg fill="rgb(25, 131, 62)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(25, 131, 62)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-115-swatch"><svg fill="rgb(9, 112, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(9, 112, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-115-swatch"><svg fill="rgb(1, 91, 37)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(1, 91, 37)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-115-swatch"><svg fill="rgb(0, 68, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 68, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-116" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-116 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-116-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-116 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-116-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-116-swatch"><svg fill="#bdbdbd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#bdbdbd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>greys</span>
   </div>
-  <div class="plot-117" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-117 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-117-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-117 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-117-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-117-swatch"><svg fill="#bdbdbd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#bdbdbd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>greys</span><span class="plot-117-swatch"><svg fill="#636363" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>greys</span><span class="plot-swatch"><svg width="15" height="15" fill="#636363" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-118" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-118 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-118-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-118 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-118-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-118-swatch"><svg fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>greys</span><span class="plot-118-swatch"><svg fill="#cccccc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>greys</span><span class="plot-swatch"><svg width="15" height="15" fill="#cccccc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-118-swatch"><svg fill="#969696" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#969696" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-118-swatch"><svg fill="#525252" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#525252" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-119" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-119 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-119-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-119 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-119-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-119-swatch"><svg fill="#ffffff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ffffff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>greys</span><span class="plot-119-swatch"><svg fill="#f0f0f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>greys</span><span class="plot-swatch"><svg width="15" height="15" fill="#f0f0f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-119-swatch"><svg fill="#d9d9d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#d9d9d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-119-swatch"><svg fill="#bdbdbd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#bdbdbd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-119-swatch"><svg fill="#969696" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#969696" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-119-swatch"><svg fill="#737373" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#737373" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-119-swatch"><svg fill="#525252" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#525252" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-119-swatch"><svg fill="#252525" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#252525" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-119-swatch"><svg fill="#000000" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#000000" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-120" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-120 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-120-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-120 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-120-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-120-swatch"><svg fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>greys</span><span class="plot-120-swatch"><svg fill="rgb(246, 246, 246)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>greys</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(246, 246, 246)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-120-swatch"><svg fill="rgb(236, 236, 236)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(236, 236, 236)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-120-swatch"><svg fill="rgb(223, 223, 223)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(223, 223, 223)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-120-swatch"><svg fill="rgb(209, 209, 209)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(209, 209, 209)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-120-swatch"><svg fill="rgb(192, 192, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(192, 192, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-120-swatch"><svg fill="rgb(172, 172, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(172, 172, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-120-swatch"><svg fill="rgb(151, 151, 151)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(151, 151, 151)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-120-swatch"><svg fill="rgb(130, 130, 130)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(130, 130, 130)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-120-swatch"><svg fill="rgb(110, 110, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 110, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-120-swatch"><svg fill="rgb(91, 91, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(91, 91, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-120-swatch"><svg fill="rgb(68, 68, 68)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(68, 68, 68)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-120-swatch"><svg fill="rgb(44, 44, 44)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(44, 44, 44)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-120-swatch"><svg fill="rgb(21, 21, 21)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(21, 21, 21)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-120-swatch"><svg fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-121" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-121 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-121-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-121 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-121-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-121-swatch"><svg fill="#fdae6b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fdae6b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>oranges</span>
   </div>
-  <div class="plot-122" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-122 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-122-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-122 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-122-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-122-swatch"><svg fill="#fdae6b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fdae6b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>oranges</span><span class="plot-122-swatch"><svg fill="#e6550d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>oranges</span><span class="plot-swatch"><svg width="15" height="15" fill="#e6550d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-123" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-123 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-123-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-123 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-123-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-123-swatch"><svg fill="#feedde" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#feedde" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>oranges</span><span class="plot-123-swatch"><svg fill="#fdbe85" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>oranges</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdbe85" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-123-swatch"><svg fill="#fd8d3c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fd8d3c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-123-swatch"><svg fill="#d94701" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d94701" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-124" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-124 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-124-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-124 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-124-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-124-swatch"><svg fill="#fff5eb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fff5eb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>oranges</span><span class="plot-124-swatch"><svg fill="#fee6ce" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>oranges</span><span class="plot-swatch"><svg width="15" height="15" fill="#fee6ce" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-124-swatch"><svg fill="#fdd0a2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdd0a2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-124-swatch"><svg fill="#fdae6b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdae6b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-124-swatch"><svg fill="#fd8d3c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#fd8d3c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-124-swatch"><svg fill="#f16913" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#f16913" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-124-swatch"><svg fill="#d94801" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#d94801" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-124-swatch"><svg fill="#a63603" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#a63603" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-124-swatch"><svg fill="#7f2704" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#7f2704" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-125" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-125 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-125-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-125 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-125-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-125-swatch"><svg fill="rgb(255, 245, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 245, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>oranges</span><span class="plot-125-swatch"><svg fill="rgb(254, 236, 218)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>oranges</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 236, 218)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-125-swatch"><svg fill="rgb(254, 226, 198)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 226, 198)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-125-swatch"><svg fill="rgb(253, 214, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 214, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-125-swatch"><svg fill="rgb(253, 198, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 198, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-125-swatch"><svg fill="rgb(253, 179, 116)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 179, 116)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-125-swatch"><svg fill="rgb(253, 160, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 160, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-125-swatch"><svg fill="rgb(251, 141, 61)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 141, 61)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-125-swatch"><svg fill="rgb(246, 120, 37)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(246, 120, 37)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-125-swatch"><svg fill="rgb(236, 101, 19)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(236, 101, 19)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-125-swatch"><svg fill="rgb(222, 82, 7)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(222, 82, 7)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-125-swatch"><svg fill="rgb(201, 68, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(201, 68, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-125-swatch"><svg fill="rgb(175, 57, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 57, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-125-swatch"><svg fill="rgb(150, 48, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(150, 48, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-125-swatch"><svg fill="rgb(127, 39, 4)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(127, 39, 4)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-126" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-126 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-126-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-126 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-126-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-126-swatch"><svg fill="#bcbddc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#bcbddc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>purples</span>
   </div>
-  <div class="plot-127" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-127 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-127-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-127 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-127-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-127-swatch"><svg fill="#bcbddc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#bcbddc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>purples</span><span class="plot-127-swatch"><svg fill="#756bb1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>purples</span><span class="plot-swatch"><svg width="15" height="15" fill="#756bb1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-128" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-128 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-128-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-128 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-128-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-128-swatch"><svg fill="#f2f0f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f2f0f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>purples</span><span class="plot-128-swatch"><svg fill="#cbc9e2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>purples</span><span class="plot-swatch"><svg width="15" height="15" fill="#cbc9e2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-128-swatch"><svg fill="#9e9ac8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#9e9ac8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-128-swatch"><svg fill="#6a51a3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#6a51a3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-129" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-129 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-129-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-129 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-129-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-129-swatch"><svg fill="#fcfbfd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fcfbfd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>purples</span><span class="plot-129-swatch"><svg fill="#efedf5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>purples</span><span class="plot-swatch"><svg width="15" height="15" fill="#efedf5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-129-swatch"><svg fill="#dadaeb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#dadaeb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-129-swatch"><svg fill="#bcbddc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#bcbddc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-129-swatch"><svg fill="#9e9ac8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#9e9ac8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-129-swatch"><svg fill="#807dba" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#807dba" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-129-swatch"><svg fill="#6a51a3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#6a51a3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-129-swatch"><svg fill="#54278f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#54278f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-129-swatch"><svg fill="#3f007d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#3f007d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-130" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-130 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-130-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-130 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-130-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-130-swatch"><svg fill="rgb(252, 251, 253)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(252, 251, 253)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>purples</span><span class="plot-130-swatch"><svg fill="rgb(244, 243, 248)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>purples</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(244, 243, 248)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-130-swatch"><svg fill="rgb(235, 234, 243)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(235, 234, 243)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-130-swatch"><svg fill="rgb(223, 223, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(223, 223, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-130-swatch"><svg fill="rgb(209, 209, 230)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(209, 209, 230)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-130-swatch"><svg fill="rgb(192, 193, 222)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(192, 193, 222)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-130-swatch"><svg fill="rgb(175, 174, 211)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 174, 211)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-130-swatch"><svg fill="rgb(158, 155, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(158, 155, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-130-swatch"><svg fill="rgb(141, 137, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(141, 137, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-130-swatch"><svg fill="rgb(126, 117, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(126, 117, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-130-swatch"><svg fill="rgb(112, 94, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(112, 94, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-130-swatch"><svg fill="rgb(100, 69, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(100, 69, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-130-swatch"><svg fill="rgb(87, 45, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(87, 45, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-130-swatch"><svg fill="rgb(75, 22, 135)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(75, 22, 135)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-130-swatch"><svg fill="rgb(63, 0, 125)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(63, 0, 125)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-131" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-131 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-131-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-131 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-131-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-131-swatch"><svg fill="#fc9272" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fc9272" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>reds</span>
   </div>
-  <div class="plot-132" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-132 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-132-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-132 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-132-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-132-swatch"><svg fill="#fc9272" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fc9272" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>reds</span><span class="plot-132-swatch"><svg fill="#de2d26" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>reds</span><span class="plot-swatch"><svg width="15" height="15" fill="#de2d26" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-133" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-133 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-133-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-133 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-133-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-133-swatch"><svg fill="#fee5d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fee5d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>reds</span><span class="plot-133-swatch"><svg fill="#fcae91" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>reds</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcae91" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-133-swatch"><svg fill="#fb6a4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fb6a4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-133-swatch"><svg fill="#cb181d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#cb181d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-134" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-134 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-134-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-134 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-134-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-134-swatch"><svg fill="#fff5f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fff5f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>reds</span><span class="plot-134-swatch"><svg fill="#fee0d2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>reds</span><span class="plot-swatch"><svg width="15" height="15" fill="#fee0d2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-134-swatch"><svg fill="#fcbba1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcbba1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-134-swatch"><svg fill="#fc9272" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc9272" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-134-swatch"><svg fill="#fb6a4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#fb6a4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-134-swatch"><svg fill="#ef3b2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#ef3b2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-134-swatch"><svg fill="#cb181d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#cb181d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-134-swatch"><svg fill="#a50f15" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#a50f15" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-134-swatch"><svg fill="#67000d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#67000d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-135" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-135 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-135-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-135 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-135-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-135-swatch"><svg fill="rgb(255, 245, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 245, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>reds</span><span class="plot-135-swatch"><svg fill="rgb(254, 233, 222)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>reds</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 233, 222)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-135-swatch"><svg fill="rgb(254, 217, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 217, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-135-swatch"><svg fill="rgb(253, 197, 175)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 197, 175)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-135-swatch"><svg fill="rgb(252, 175, 148)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(252, 175, 148)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-135-swatch"><svg fill="rgb(252, 152, 121)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(252, 152, 121)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-135-swatch"><svg fill="rgb(251, 129, 97)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 129, 97)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-135-swatch"><svg fill="rgb(249, 105, 76)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(249, 105, 76)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-135-swatch"><svg fill="rgb(243, 79, 57)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(243, 79, 57)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-135-swatch"><svg fill="rgb(231, 55, 43)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(231, 55, 43)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-135-swatch"><svg fill="rgb(213, 36, 34)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(213, 36, 34)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-135-swatch"><svg fill="rgb(192, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(192, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-135-swatch"><svg fill="rgb(168, 16, 22)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(168, 16, 22)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-135-swatch"><svg fill="rgb(138, 8, 18)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(138, 8, 18)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-135-swatch"><svg fill="rgb(103, 0, 13)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(103, 0, 13)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-136" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-136 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-136-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-136 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-136-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-136-swatch"><svg fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>turbo</span>
   </div>
-  <div class="plot-137" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-137 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-137-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-137 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-137-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-137-swatch"><svg fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>turbo</span><span class="plot-137-swatch"><svg fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>turbo</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-138" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-138 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-138-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-138 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-138-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-138-swatch"><svg fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>turbo</span><span class="plot-138-swatch"><svg fill="rgb(46, 229, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>turbo</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(46, 229, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-138-swatch"><svg fill="rgb(254, 185, 39)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 185, 39)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-138-swatch"><svg fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-139" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-139 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-139-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-139 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-139-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-139-swatch"><svg fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>turbo</span><span class="plot-139-swatch"><svg fill="rgb(69, 105, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>turbo</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(69, 105, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-139-swatch"><svg fill="rgb(38, 188, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(38, 188, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-139-swatch"><svg fill="rgb(63, 243, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(63, 243, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-139-swatch"><svg fill="rgb(149, 251, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(149, 251, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-139-swatch"><svg fill="rgb(236, 209, 46)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(236, 209, 46)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-139-swatch"><svg fill="rgb(255, 130, 29)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 130, 29)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-139-swatch"><svg fill="rgb(203, 47, 13)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(203, 47, 13)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-139-swatch"><svg fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-140" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-140 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-140-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-140 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-140-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-140-swatch"><svg fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 23, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>turbo</span><span class="plot-140-swatch"><svg fill="rgb(74, 68, 188)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>turbo</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(74, 68, 188)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-140-swatch"><svg fill="rgb(64, 118, 245)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(64, 118, 245)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-140-swatch"><svg fill="rgb(44, 166, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(44, 166, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-140-swatch"><svg fill="rgb(38, 208, 205)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(38, 208, 205)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-140-swatch"><svg fill="rgb(55, 237, 159)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(55, 237, 159)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-140-swatch"><svg fill="rgb(95, 252, 115)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(95, 252, 115)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-140-swatch"><svg fill="rgb(149, 251, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(149, 251, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-140-swatch"><svg fill="rgb(203, 232, 57)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(203, 232, 57)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-140-swatch"><svg fill="rgb(245, 199, 43)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(245, 199, 43)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-140-swatch"><svg fill="rgb(255, 155, 33)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 155, 33)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-140-swatch"><svg fill="rgb(251, 105, 25)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 105, 25)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-140-swatch"><svg fill="rgb(214, 57, 15)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(214, 57, 15)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-140-swatch"><svg fill="rgb(168, 22, 4)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(168, 22, 4)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-140-swatch"><svg fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(144, 12, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-141" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-141 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-141-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-141 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-141-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-141-swatch"><svg fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>viridis</span>
   </div>
-  <div class="plot-142" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-142 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-142-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-142 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-142-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-142-swatch"><svg fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>viridis</span><span class="plot-142-swatch"><svg fill="#fde725" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>viridis</span><span class="plot-swatch"><svg width="15" height="15" fill="#fde725" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-143" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-143 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-143-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-143 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-143-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-143-swatch"><svg fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>viridis</span><span class="plot-143-swatch"><svg fill="#31688e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>viridis</span><span class="plot-swatch"><svg width="15" height="15" fill="#31688e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-143-swatch"><svg fill="#35b779" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#35b779" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-143-swatch"><svg fill="#fde725" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fde725" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-144" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-144 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-144-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-144 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-144-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-144-swatch"><svg fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>viridis</span><span class="plot-144-swatch"><svg fill="#472d7b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>viridis</span><span class="plot-swatch"><svg width="15" height="15" fill="#472d7b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-144-swatch"><svg fill="#3b528b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#3b528b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-144-swatch"><svg fill="#2c728e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#2c728e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-144-swatch"><svg fill="#21918c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#21918c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-144-swatch"><svg fill="#28ae80" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#28ae80" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-144-swatch"><svg fill="#5ec962" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#5ec962" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-144-swatch"><svg fill="#addc30" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#addc30" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-144-swatch"><svg fill="#fde725" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#fde725" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-145" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-145 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-145-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-145 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-145-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-145-swatch"><svg fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#440154" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>viridis</span><span class="plot-145-swatch"><svg fill="#481b6d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>viridis</span><span class="plot-swatch"><svg width="15" height="15" fill="#481b6d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-145-swatch"><svg fill="#46327e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#46327e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-145-swatch"><svg fill="#3f4788" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#3f4788" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-145-swatch"><svg fill="#365c8d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#365c8d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-145-swatch"><svg fill="#2e6e8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#2e6e8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-145-swatch"><svg fill="#277f8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#277f8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-145-swatch"><svg fill="#21918c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#21918c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-145-swatch"><svg fill="#1fa187" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#1fa187" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-145-swatch"><svg fill="#2db27d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#2db27d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-145-swatch"><svg fill="#4ac16d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#4ac16d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-145-swatch"><svg fill="#73d056" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#73d056" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-145-swatch"><svg fill="#a0da39" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#a0da39" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-145-swatch"><svg fill="#d0e11c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#d0e11c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-145-swatch"><svg fill="#fde725" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#fde725" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-146" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-146 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-146-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-146 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-146-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-146-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>magma</span>
   </div>
-  <div class="plot-147" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-147 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-147-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-147 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-147-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-147-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>magma</span><span class="plot-147-swatch"><svg fill="#fcfdbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>magma</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcfdbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-148" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-148 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-148-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-148 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-148-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-148-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>magma</span><span class="plot-148-swatch"><svg fill="#721f81" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>magma</span><span class="plot-swatch"><svg width="15" height="15" fill="#721f81" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-148-swatch"><svg fill="#f1605d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#f1605d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-148-swatch"><svg fill="#fcfdbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcfdbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-149" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-149 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-149-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-149 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-149-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-149-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>magma</span><span class="plot-149-swatch"><svg fill="#1d1147" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>magma</span><span class="plot-swatch"><svg width="15" height="15" fill="#1d1147" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-149-swatch"><svg fill="#51127c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#51127c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-149-swatch"><svg fill="#832681" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#832681" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-149-swatch"><svg fill="#b73779" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#b73779" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-149-swatch"><svg fill="#e75263" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e75263" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-149-swatch"><svg fill="#fc8961" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc8961" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-149-swatch"><svg fill="#fec488" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#fec488" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-149-swatch"><svg fill="#fcfdbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcfdbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-150" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-150 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-150-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-150 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-150-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-150-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>magma</span><span class="plot-150-swatch"><svg fill="#0c0926" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>magma</span><span class="plot-swatch"><svg width="15" height="15" fill="#0c0926" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-150-swatch"><svg fill="#221150" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#221150" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-150-swatch"><svg fill="#400f74" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#400f74" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-150-swatch"><svg fill="#5f187f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#5f187f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-150-swatch"><svg fill="#7b2382" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#7b2382" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-150-swatch"><svg fill="#982d80" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#982d80" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-150-swatch"><svg fill="#b73779" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#b73779" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-150-swatch"><svg fill="#d3436e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#d3436e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-150-swatch"><svg fill="#eb5760" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#eb5760" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-150-swatch"><svg fill="#f8765c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#f8765c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-150-swatch"><svg fill="#fd9a6a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#fd9a6a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-150-swatch"><svg fill="#febb81" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#febb81" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-150-swatch"><svg fill="#fddc9e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#fddc9e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-150-swatch"><svg fill="#fcfdbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcfdbf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-151" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-151 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-151-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-151 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-151-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-151-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>inferno</span>
   </div>
-  <div class="plot-152" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-152 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-152-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-152 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-152-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-152-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>inferno</span><span class="plot-152-swatch"><svg fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>inferno</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-153" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-153 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-153-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-153 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-153-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-153-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>inferno</span><span class="plot-153-swatch"><svg fill="#781c6d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>inferno</span><span class="plot-swatch"><svg width="15" height="15" fill="#781c6d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-153-swatch"><svg fill="#ed6925" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#ed6925" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-153-swatch"><svg fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-154" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-154 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-154-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-154 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-154-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-154-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>inferno</span><span class="plot-154-swatch"><svg fill="#210c4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>inferno</span><span class="plot-swatch"><svg width="15" height="15" fill="#210c4a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-154-swatch"><svg fill="#57106e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#57106e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-154-swatch"><svg fill="#8a226a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#8a226a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-154-swatch"><svg fill="#bc3754" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#bc3754" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-154-swatch"><svg fill="#e45a31" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e45a31" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-154-swatch"><svg fill="#f98e09" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#f98e09" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-154-swatch"><svg fill="#f9cb35" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#f9cb35" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-154-swatch"><svg fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-155" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-155 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-155-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-155 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-155-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-155-swatch"><svg fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#000004" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>inferno</span><span class="plot-155-swatch"><svg fill="#0d0829" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>inferno</span><span class="plot-swatch"><svg width="15" height="15" fill="#0d0829" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-155-swatch"><svg fill="#280b53" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#280b53" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-155-swatch"><svg fill="#470b6a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#470b6a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-155-swatch"><svg fill="#65156e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#65156e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-155-swatch"><svg fill="#82206c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#82206c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-155-swatch"><svg fill="#9f2a63" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#9f2a63" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-155-swatch"><svg fill="#bc3754" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#bc3754" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-155-swatch"><svg fill="#d44842" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#d44842" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-155-swatch"><svg fill="#e8602d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#e8602d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-155-swatch"><svg fill="#f57d15" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#f57d15" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-155-swatch"><svg fill="#fc9f07" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc9f07" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-155-swatch"><svg fill="#fac228" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#fac228" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-155-swatch"><svg fill="#f3e55d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#f3e55d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-155-swatch"><svg fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcffa4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-156" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-156 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-156-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-156 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-156-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-156-swatch"><svg fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>plasma</span>
   </div>
-  <div class="plot-157" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-157 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-157-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-157 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-157-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-157-swatch"><svg fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>plasma</span><span class="plot-157-swatch"><svg fill="#f0f921" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>plasma</span><span class="plot-swatch"><svg width="15" height="15" fill="#f0f921" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-158" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-158 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-158-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-158 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-158-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-158-swatch"><svg fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>plasma</span><span class="plot-158-swatch"><svg fill="#9c179e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>plasma</span><span class="plot-swatch"><svg width="15" height="15" fill="#9c179e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-158-swatch"><svg fill="#ed7953" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#ed7953" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-158-swatch"><svg fill="#f0f921" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#f0f921" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-159" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-159 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-159-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-159 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-159-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-159-swatch"><svg fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>plasma</span><span class="plot-159-swatch"><svg fill="#4c02a1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>plasma</span><span class="plot-swatch"><svg width="15" height="15" fill="#4c02a1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-159-swatch"><svg fill="#7e03a8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#7e03a8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-159-swatch"><svg fill="#aa2395" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#aa2395" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-159-swatch"><svg fill="#cc4778" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#cc4778" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-159-swatch"><svg fill="#e66c5c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e66c5c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-159-swatch"><svg fill="#f89540" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#f89540" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-159-swatch"><svg fill="#fdc527" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdc527" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-159-swatch"><svg fill="#f0f921" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#f0f921" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-160" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-160 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-160-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-160 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-160-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-160-swatch"><svg fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#0d0887" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>plasma</span><span class="plot-160-swatch"><svg fill="#350498" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>plasma</span><span class="plot-swatch"><svg width="15" height="15" fill="#350498" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-160-swatch"><svg fill="#5302a3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#5302a3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-160-swatch"><svg fill="#6f00a8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#6f00a8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-160-swatch"><svg fill="#8b0aa5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#8b0aa5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-160-swatch"><svg fill="#a31e9a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#a31e9a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-160-swatch"><svg fill="#b83289" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#b83289" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-160-swatch"><svg fill="#cc4778" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#cc4778" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-160-swatch"><svg fill="#db5c68" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#db5c68" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-160-swatch"><svg fill="#e97158" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="#e97158" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-160-swatch"><svg fill="#f48849" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="#f48849" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-160-swatch"><svg fill="#fba238" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="#fba238" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-160-swatch"><svg fill="#febd2a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#febd2a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-160-swatch"><svg fill="#fada24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#fada24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-160-swatch"><svg fill="#f0f921" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#f0f921" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-161" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-161 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-161-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-161 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-161-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-161-swatch"><svg fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>cividis</span>
   </div>
-  <div class="plot-162" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-162 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-162-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-162 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-162-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-162-swatch"><svg fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cividis</span><span class="plot-162-swatch"><svg fill="rgb(253, 234, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cividis</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 234, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-163" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-163 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-163-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-163 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-163-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-163-swatch"><svg fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cividis</span><span class="plot-163-swatch"><svg fill="rgb(87, 92, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cividis</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(87, 92, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-163-swatch"><svg fill="rgb(164, 157, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(164, 157, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-163-swatch"><svg fill="rgb(253, 234, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 234, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-164" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-164 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-164-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-164 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-164-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-164-swatch"><svg fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cividis</span><span class="plot-164-swatch"><svg fill="rgb(17, 54, 108)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cividis</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(17, 54, 108)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-164-swatch"><svg fill="rgb(60, 77, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(60, 77, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-164-swatch"><svg fill="rgb(98, 100, 111)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(98, 100, 111)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-164-swatch"><svg fill="rgb(127, 124, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(127, 124, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-164-swatch"><svg fill="rgb(154, 148, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(154, 148, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-164-swatch"><svg fill="rgb(187, 175, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(187, 175, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-164-swatch"><svg fill="rgb(226, 203, 92)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(226, 203, 92)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-164-swatch"><svg fill="rgb(253, 234, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 234, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-165" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-165 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-165-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-165 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-165-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-165-swatch"><svg fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 32, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cividis</span><span class="plot-165-swatch"><svg fill="rgb(3, 45, 102)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cividis</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(3, 45, 102)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-165-swatch"><svg fill="rgb(23, 58, 109)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(23, 58, 109)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-165-swatch"><svg fill="rgb(48, 71, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(48, 71, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-165-swatch"><svg fill="rgb(72, 84, 109)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(72, 84, 109)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-165-swatch"><svg fill="rgb(93, 97, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(93, 97, 110)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-165-swatch"><svg fill="rgb(112, 110, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(112, 110, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-165-swatch"><svg fill="rgb(127, 124, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(127, 124, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-165-swatch"><svg fill="rgb(142, 137, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(142, 137, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-165-swatch"><svg fill="rgb(158, 152, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(158, 152, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-165-swatch"><svg fill="rgb(177, 167, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(177, 167, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-165-swatch"><svg fill="rgb(198, 183, 108)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(198, 183, 108)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-165-swatch"><svg fill="rgb(221, 199, 95)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(221, 199, 95)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-165-swatch"><svg fill="rgb(241, 216, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(241, 216, 81)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-165-swatch"><svg fill="rgb(253, 234, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 234, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-166" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-166 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-166-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-166 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-166-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-166-swatch"><svg fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>cubehelix</span>
   </div>
-  <div class="plot-167" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-167 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-167-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-167 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-167-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-167-swatch"><svg fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cubehelix</span><span class="plot-167-swatch"><svg fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cubehelix</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-168" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-168 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-168-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-168 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-168-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-168-swatch"><svg fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cubehelix</span><span class="plot-168-swatch"><svg fill="rgb(43, 111, 57)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cubehelix</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(43, 111, 57)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-168-swatch"><svg fill="rgb(212, 144, 198)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(212, 144, 198)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-168-swatch"><svg fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-169" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-169 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-169-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-169 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-169-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-169-swatch"><svg fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cubehelix</span><span class="plot-169-swatch"><svg fill="rgb(27, 29, 59)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cubehelix</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(27, 29, 59)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-169-swatch"><svg fill="rgb(22, 83, 76)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(22, 83, 76)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-169-swatch"><svg fill="rgb(67, 119, 49)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(67, 119, 49)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-169-swatch"><svg fill="rgb(160, 121, 73)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(160, 121, 73)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-169-swatch"><svg fill="rgb(212, 131, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(212, 131, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-169-swatch"><svg fill="rgb(199, 179, 237)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(199, 179, 237)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-169-swatch"><svg fill="rgb(202, 231, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(202, 231, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-169-swatch"><svg fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-170" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-170 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-170-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-170 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-170-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-170-swatch"><svg fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cubehelix</span><span class="plot-170-swatch"><svg fill="rgb(23, 13, 34)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cubehelix</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(23, 13, 34)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-170-swatch"><svg fill="rgb(26, 36, 66)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(26, 36, 66)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-170-swatch"><svg fill="rgb(21, 67, 79)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(21, 67, 79)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-170-swatch"><svg fill="rgb(27, 97, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(27, 97, 69)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-170-swatch"><svg fill="rgb(56, 116, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(56, 116, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-170-swatch"><svg fill="rgb(106, 123, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(106, 123, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-170-swatch"><svg fill="rgb(160, 121, 73)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(160, 121, 73)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-170-swatch"><svg fill="rgb(199, 123, 123)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(199, 123, 123)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-170-swatch"><svg fill="rgb(213, 136, 181)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(213, 136, 181)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-170-swatch"><svg fill="rgb(205, 163, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(205, 163, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-170-swatch"><svg fill="rgb(194, 196, 243)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(194, 196, 243)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-170-swatch"><svg fill="rgb(198, 225, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(198, 225, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-170-swatch"><svg fill="rgb(222, 244, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(222, 244, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-170-swatch"><svg fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 255, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-171" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-171 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-171-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-171 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-171-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-171-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>warm</span>
   </div>
-  <div class="plot-172" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-172 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-172-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-172 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-172-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-172-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>warm</span><span class="plot-172-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>warm</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-173" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-173 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-173-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-173 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-173-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-173-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>warm</span><span class="plot-173-swatch"><svg fill="rgb(238, 67, 149)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>warm</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(238, 67, 149)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-173-swatch"><svg fill="rgb(255, 140, 56)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 140, 56)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-173-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-174" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-174 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-174-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-174 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-174-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-174-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>warm</span><span class="plot-174-swatch"><svg fill="rgb(160, 61, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>warm</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(160, 61, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-174-swatch"><svg fill="rgb(210, 62, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(210, 62, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-174-swatch"><svg fill="rgb(249, 72, 138)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(249, 72, 138)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-174-swatch"><svg fill="rgb(255, 94, 99)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 94, 99)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-174-swatch"><svg fill="rgb(255, 127, 65)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 127, 65)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-174-swatch"><svg fill="rgb(239, 167, 47)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(239, 167, 47)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-174-swatch"><svg fill="rgb(205, 207, 55)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(205, 207, 55)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-174-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-175" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-175 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-175-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-175 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-175-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-175-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>warm</span><span class="plot-175-swatch"><svg fill="rgb(138, 62, 178)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>warm</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(138, 62, 178)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-175-swatch"><svg fill="rgb(168, 60, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(168, 60, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-175-swatch"><svg fill="rgb(197, 61, 173)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(197, 61, 173)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-175-swatch"><svg fill="rgb(223, 64, 161)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(223, 64, 161)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-175-swatch"><svg fill="rgb(244, 70, 143)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(244, 70, 143)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-175-swatch"><svg fill="rgb(255, 80, 122)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 80, 122)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-175-swatch"><svg fill="rgb(255, 94, 99)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 94, 99)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-175-swatch"><svg fill="rgb(255, 112, 78)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 112, 78)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-175-swatch"><svg fill="rgb(255, 132, 61)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 132, 61)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-175-swatch"><svg fill="rgb(248, 155, 49)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(248, 155, 49)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-175-swatch"><svg fill="rgb(230, 179, 46)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(230, 179, 46)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-175-swatch"><svg fill="rgb(210, 201, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(210, 201, 52)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-175-swatch"><svg fill="rgb(191, 222, 67)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(191, 222, 67)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-175-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-176" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-176 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-176-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-176 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-176-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-176-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>cool</span>
   </div>
-  <div class="plot-177" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-177 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-177-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-177 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-177-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-177-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cool</span><span class="plot-177-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cool</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-178" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-178 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-178-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-178 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-178-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-178-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cool</span><span class="plot-178-swatch"><svg fill="rgb(47, 150, 224)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cool</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(47, 150, 224)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-178-swatch"><svg fill="rgb(40, 234, 141)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(40, 234, 141)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-178-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-179" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-179 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-179-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-179 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-179-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-179-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cool</span><span class="plot-179-swatch"><svg fill="rgb(92, 90, 206)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cool</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(92, 90, 206)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-179-swatch"><svg fill="rgb(65, 125, 224)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(65, 125, 224)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-179-swatch"><svg fill="rgb(39, 163, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(39, 163, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-179-swatch"><svg fill="rgb(26, 199, 194)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(26, 199, 194)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-179-swatch"><svg fill="rgb(33, 227, 155)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(33, 227, 155)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-179-swatch"><svg fill="rgb(64, 243, 115)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(64, 243, 115)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-179-swatch"><svg fill="rgb(115, 246, 90)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(115, 246, 90)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-179-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-180" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-180 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-180-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-180 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-180-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-180-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>cool</span><span class="plot-180-swatch"><svg fill="rgb(101, 78, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>cool</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(101, 78, 192)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-180-swatch"><svg fill="rgb(88, 95, 210)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(88, 95, 210)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-180-swatch"><svg fill="rgb(73, 115, 221)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(73, 115, 221)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-180-swatch"><svg fill="rgb(57, 136, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(57, 136, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-180-swatch"><svg fill="rgb(43, 158, 222)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(43, 158, 222)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-180-swatch"><svg fill="rgb(31, 179, 211)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(31, 179, 211)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-180-swatch"><svg fill="rgb(26, 199, 194)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(26, 199, 194)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-180-swatch"><svg fill="rgb(27, 217, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(27, 217, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-180-swatch"><svg fill="rgb(36, 230, 149)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(36, 230, 149)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-180-swatch"><svg fill="rgb(52, 240, 126)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(52, 240, 126)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-180-swatch"><svg fill="rgb(77, 245, 106)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(77, 245, 106)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-180-swatch"><svg fill="rgb(107, 247, 92)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(107, 247, 92)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-180-swatch"><svg fill="rgb(140, 244, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(140, 244, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-180-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-181" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-181 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-181-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-181 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-181-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-181-swatch"><svg fill="#99d8c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#99d8c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>bugn</span>
   </div>
-  <div class="plot-182" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-182 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-182-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-182 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-182-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-182-swatch"><svg fill="#99d8c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#99d8c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>bugn</span><span class="plot-182-swatch"><svg fill="#2ca25f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>bugn</span><span class="plot-swatch"><svg width="15" height="15" fill="#2ca25f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-183" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-183 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-183-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-183 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-183-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-183-swatch"><svg fill="#edf8fb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#edf8fb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>bugn</span><span class="plot-183-swatch"><svg fill="#b2e2e2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>bugn</span><span class="plot-swatch"><svg width="15" height="15" fill="#b2e2e2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-183-swatch"><svg fill="#66c2a4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-183-swatch"><svg fill="#238b45" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#238b45" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-184" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-184 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-184-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-184 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-184-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-184-swatch"><svg fill="#f7fcfd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f7fcfd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>bugn</span><span class="plot-184-swatch"><svg fill="#e5f5f9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>bugn</span><span class="plot-swatch"><svg width="15" height="15" fill="#e5f5f9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-184-swatch"><svg fill="#ccece6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#ccece6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-184-swatch"><svg fill="#99d8c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#99d8c9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-184-swatch"><svg fill="#66c2a4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#66c2a4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-184-swatch"><svg fill="#41ae76" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#41ae76" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-184-swatch"><svg fill="#238b45" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#238b45" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-184-swatch"><svg fill="#006d2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#006d2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-184-swatch"><svg fill="#00441b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#00441b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-185" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-185 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-185-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-185 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-185-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-185-swatch"><svg fill="rgb(247, 252, 253)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(247, 252, 253)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>bugn</span><span class="plot-185-swatch"><svg fill="rgb(236, 248, 250)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>bugn</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(236, 248, 250)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-185-swatch"><svg fill="rgb(225, 243, 245)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(225, 243, 245)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-185-swatch"><svg fill="rgb(210, 238, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(210, 238, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-185-swatch"><svg fill="rgb(188, 230, 221)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(188, 230, 221)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-185-swatch"><svg fill="rgb(160, 219, 204)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(160, 219, 204)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-185-swatch"><svg fill="rgb(131, 207, 185)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(131, 207, 185)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-185-swatch"><svg fill="rgb(104, 194, 163)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(104, 194, 163)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-185-swatch"><svg fill="rgb(81, 182, 138)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(81, 182, 138)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-185-swatch"><svg fill="rgb(61, 167, 111)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(61, 167, 111)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-185-swatch"><svg fill="rgb(43, 149, 84)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(43, 149, 84)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-185-swatch"><svg fill="rgb(25, 131, 63)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(25, 131, 63)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-185-swatch"><svg fill="rgb(9, 112, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(9, 112, 48)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-185-swatch"><svg fill="rgb(1, 91, 37)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(1, 91, 37)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-185-swatch"><svg fill="rgb(0, 68, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 68, 27)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-186" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-186 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-186-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-186 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-186-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-186-swatch"><svg fill="#9ebcda" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#9ebcda" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>bupu</span>
   </div>
-  <div class="plot-187" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-187 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-187-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-187 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-187-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-187-swatch"><svg fill="#9ebcda" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#9ebcda" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>bupu</span><span class="plot-187-swatch"><svg fill="#8856a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>bupu</span><span class="plot-swatch"><svg width="15" height="15" fill="#8856a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-188" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-188 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-188-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-188 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-188-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-188-swatch"><svg fill="#edf8fb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#edf8fb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>bupu</span><span class="plot-188-swatch"><svg fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>bupu</span><span class="plot-swatch"><svg width="15" height="15" fill="#b3cde3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-188-swatch"><svg fill="#8c96c6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#8c96c6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-188-swatch"><svg fill="#88419d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#88419d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-189" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-189 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-189-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-189 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-189-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-189-swatch"><svg fill="#f7fcfd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f7fcfd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>bupu</span><span class="plot-189-swatch"><svg fill="#e0ecf4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>bupu</span><span class="plot-swatch"><svg width="15" height="15" fill="#e0ecf4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-189-swatch"><svg fill="#bfd3e6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#bfd3e6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-189-swatch"><svg fill="#9ebcda" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#9ebcda" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-189-swatch"><svg fill="#8c96c6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#8c96c6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-189-swatch"><svg fill="#8c6bb1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#8c6bb1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-189-swatch"><svg fill="#88419d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#88419d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-189-swatch"><svg fill="#810f7c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#810f7c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-189-swatch"><svg fill="#4d004b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#4d004b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-190" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-190 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-190-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-190 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-190-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-190-swatch"><svg fill="rgb(247, 252, 253)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(247, 252, 253)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>bupu</span><span class="plot-190-swatch"><svg fill="rgb(234, 243, 248)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>bupu</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(234, 243, 248)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-190-swatch"><svg fill="rgb(218, 231, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(218, 231, 241)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-190-swatch"><svg fill="rgb(200, 218, 234)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(200, 218, 234)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-190-swatch"><svg fill="rgb(182, 204, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(182, 204, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-190-swatch"><svg fill="rgb(164, 190, 219)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(164, 190, 219)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-190-swatch"><svg fill="rgb(151, 171, 209)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(151, 171, 209)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-190-swatch"><svg fill="rgb(143, 149, 198)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(143, 149, 198)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-190-swatch"><svg fill="rgb(140, 125, 186)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(140, 125, 186)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-190-swatch"><svg fill="rgb(139, 101, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(139, 101, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-190-swatch"><svg fill="rgb(137, 77, 162)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(137, 77, 162)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-190-swatch"><svg fill="rgb(134, 50, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(134, 50, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-190-swatch"><svg fill="rgb(125, 26, 127)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(125, 26, 127)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-190-swatch"><svg fill="rgb(105, 10, 103)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(105, 10, 103)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-190-swatch"><svg fill="rgb(77, 0, 75)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(77, 0, 75)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-191" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-191 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-191-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-191 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-191-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-191-swatch"><svg fill="#a8ddb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a8ddb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>gnbu</span>
   </div>
-  <div class="plot-192" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-192 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-192-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-192 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-192-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-192-swatch"><svg fill="#a8ddb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a8ddb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>gnbu</span><span class="plot-192-swatch"><svg fill="#43a2ca" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>gnbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#43a2ca" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-193" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-193 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-193-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-193 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-193-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-193-swatch"><svg fill="#f0f9e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f0f9e8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>gnbu</span><span class="plot-193-swatch"><svg fill="#bae4bc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>gnbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#bae4bc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-193-swatch"><svg fill="#7bccc4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#7bccc4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-193-swatch"><svg fill="#2b8cbe" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#2b8cbe" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-194" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-194 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-194-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-194 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-194-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-194-swatch"><svg fill="#f7fcf0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f7fcf0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>gnbu</span><span class="plot-194-swatch"><svg fill="#e0f3db" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>gnbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#e0f3db" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-194-swatch"><svg fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#ccebc5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-194-swatch"><svg fill="#a8ddb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#a8ddb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-194-swatch"><svg fill="#7bccc4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#7bccc4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-194-swatch"><svg fill="#4eb3d3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#4eb3d3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-194-swatch"><svg fill="#2b8cbe" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#2b8cbe" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-194-swatch"><svg fill="#0868ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#0868ac" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-194-swatch"><svg fill="#084081" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#084081" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-195" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-195 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-195-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-195 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-195-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-195-swatch"><svg fill="rgb(247, 252, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(247, 252, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>gnbu</span><span class="plot-195-swatch"><svg fill="rgb(234, 247, 228)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>gnbu</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(234, 247, 228)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-195-swatch"><svg fill="rgb(221, 242, 216)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(221, 242, 216)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-195-swatch"><svg fill="rgb(209, 237, 204)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(209, 237, 204)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-195-swatch"><svg fill="rgb(193, 231, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(193, 231, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-195-swatch"><svg fill="rgb(172, 223, 187)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(172, 223, 187)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-195-swatch"><svg fill="rgb(148, 214, 188)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(148, 214, 188)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-195-swatch"><svg fill="rgb(123, 203, 196)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(123, 203, 196)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-195-swatch"><svg fill="rgb(98, 189, 203)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(98, 189, 203)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-195-swatch"><svg fill="rgb(74, 172, 204)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(74, 172, 204)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-195-swatch"><svg fill="rgb(53, 151, 196)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(53, 151, 196)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-195-swatch"><svg fill="rgb(33, 130, 185)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(33, 130, 185)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-195-swatch"><svg fill="rgb(17, 109, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(17, 109, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-195-swatch"><svg fill="rgb(9, 87, 153)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(9, 87, 153)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-195-swatch"><svg fill="rgb(8, 64, 129)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(8, 64, 129)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-196" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-196 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-196-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-196 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-196-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-196-swatch"><svg fill="#fdbb84" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fdbb84" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>orrd</span>
   </div>
-  <div class="plot-197" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-197 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-197-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-197 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-197-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-197-swatch"><svg fill="#fdbb84" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fdbb84" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>orrd</span><span class="plot-197-swatch"><svg fill="#e34a33" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>orrd</span><span class="plot-swatch"><svg width="15" height="15" fill="#e34a33" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-198" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-198 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-198-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-198 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-198-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-198-swatch"><svg fill="#fef0d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fef0d9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>orrd</span><span class="plot-198-swatch"><svg fill="#fdcc8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>orrd</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdcc8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-198-swatch"><svg fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-198-swatch"><svg fill="#d7301f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#d7301f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-199" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-199 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-199-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-199 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-199-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-199-swatch"><svg fill="#fff7ec" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fff7ec" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>orrd</span><span class="plot-199-swatch"><svg fill="#fee8c8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>orrd</span><span class="plot-swatch"><svg width="15" height="15" fill="#fee8c8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-199-swatch"><svg fill="#fdd49e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdd49e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-199-swatch"><svg fill="#fdbb84" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fdbb84" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-199-swatch"><svg fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc8d59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-199-swatch"><svg fill="#ef6548" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#ef6548" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-199-swatch"><svg fill="#d7301f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#d7301f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-199-swatch"><svg fill="#b30000" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#b30000" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-199-swatch"><svg fill="#7f0000" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#7f0000" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-200" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-200 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-200-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-200 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-200-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-200-swatch"><svg fill="rgb(255, 247, 236)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 247, 236)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>orrd</span><span class="plot-200-swatch"><svg fill="rgb(254, 238, 215)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>orrd</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 238, 215)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-200-swatch"><svg fill="rgb(254, 229, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 229, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-200-swatch"><svg fill="rgb(253, 217, 171)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 217, 171)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-200-swatch"><svg fill="rgb(253, 204, 151)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 204, 151)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-200-swatch"><svg fill="rgb(253, 188, 134)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 188, 134)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-200-swatch"><svg fill="rgb(252, 167, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(252, 167, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-200-swatch"><svg fill="rgb(250, 142, 93)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(250, 142, 93)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-200-swatch"><svg fill="rgb(244, 118, 79)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(244, 118, 79)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-200-swatch"><svg fill="rgb(234, 92, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(234, 92, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-200-swatch"><svg fill="rgb(221, 63, 43)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(221, 63, 43)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-200-swatch"><svg fill="rgb(204, 35, 23)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(204, 35, 23)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-200-swatch"><svg fill="rgb(182, 12, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(182, 12, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-200-swatch"><svg fill="rgb(156, 1, 1)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(156, 1, 1)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-200-swatch"><svg fill="rgb(127, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(127, 0, 0)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-201" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-201 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-201-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-201 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-201-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-201-swatch"><svg fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>pubu</span>
   </div>
-  <div class="plot-202" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-202 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-202-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-202 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-202-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-202-swatch"><svg fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pubu</span><span class="plot-202-swatch"><svg fill="#2b8cbe" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pubu</span><span class="plot-swatch"><svg width="15" height="15" fill="#2b8cbe" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-203" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-203 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-203-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-203 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-203-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-203-swatch"><svg fill="#f1eef6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f1eef6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pubu</span><span class="plot-203-swatch"><svg fill="#bdc9e1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pubu</span><span class="plot-swatch"><svg width="15" height="15" fill="#bdc9e1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-203-swatch"><svg fill="#74a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#74a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-203-swatch"><svg fill="#0570b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#0570b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-204" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-204 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-204-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-204 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-204-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-204-swatch"><svg fill="#fff7fb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fff7fb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pubu</span><span class="plot-204-swatch"><svg fill="#ece7f2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pubu</span><span class="plot-swatch"><svg width="15" height="15" fill="#ece7f2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-204-swatch"><svg fill="#d0d1e6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#d0d1e6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-204-swatch"><svg fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-204-swatch"><svg fill="#74a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#74a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-204-swatch"><svg fill="#3690c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#3690c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-204-swatch"><svg fill="#0570b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#0570b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-204-swatch"><svg fill="#045a8d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#045a8d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-204-swatch"><svg fill="#023858" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#023858" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-205" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-205 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-205-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-205 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-205-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-205-swatch"><svg fill="rgb(255, 247, 251)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 247, 251)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pubu</span><span class="plot-205-swatch"><svg fill="rgb(244, 238, 246)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pubu</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(244, 238, 246)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-205-swatch"><svg fill="rgb(231, 227, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(231, 227, 240)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-205-swatch"><svg fill="rgb(215, 215, 233)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(215, 215, 233)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-205-swatch"><svg fill="rgb(195, 203, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(195, 203, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-205-swatch"><svg fill="rgb(171, 192, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(171, 192, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-205-swatch"><svg fill="rgb(144, 180, 214)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(144, 180, 214)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-205-swatch"><svg fill="rgb(114, 168, 207)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(114, 168, 207)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-205-swatch"><svg fill="rgb(81, 154, 198)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(81, 154, 198)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-205-swatch"><svg fill="rgb(48, 139, 190)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(48, 139, 190)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-205-swatch"><svg fill="rgb(22, 122, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(22, 122, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-205-swatch"><svg fill="rgb(8, 106, 165)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(8, 106, 165)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-205-swatch"><svg fill="rgb(4, 92, 144)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(4, 92, 144)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-205-swatch"><svg fill="rgb(3, 75, 118)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(3, 75, 118)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-205-swatch"><svg fill="rgb(2, 56, 88)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(2, 56, 88)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-206" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-206 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-206-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-206 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-206-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-206-swatch"><svg fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>pubugn</span>
   </div>
-  <div class="plot-207" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-207 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-207-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-207 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-207-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-207-swatch"><svg fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pubugn</span><span class="plot-207-swatch"><svg fill="#1c9099" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pubugn</span><span class="plot-swatch"><svg width="15" height="15" fill="#1c9099" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-208" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-208 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-208-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-208 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-208-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-208-swatch"><svg fill="#f6eff7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f6eff7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pubugn</span><span class="plot-208-swatch"><svg fill="#bdc9e1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pubugn</span><span class="plot-swatch"><svg width="15" height="15" fill="#bdc9e1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-208-swatch"><svg fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-208-swatch"><svg fill="#02818a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#02818a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-209" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-209 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-209-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-209 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-209-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-209-swatch"><svg fill="#fff7fb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fff7fb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pubugn</span><span class="plot-209-swatch"><svg fill="#ece2f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pubugn</span><span class="plot-swatch"><svg width="15" height="15" fill="#ece2f0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-209-swatch"><svg fill="#d0d1e6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#d0d1e6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-209-swatch"><svg fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#a6bddb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-209-swatch"><svg fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#67a9cf" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-209-swatch"><svg fill="#3690c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#3690c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-209-swatch"><svg fill="#02818a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#02818a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-209-swatch"><svg fill="#016c59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#016c59" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-209-swatch"><svg fill="#014636" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#014636" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-210" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-210 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-210-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-210 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-210-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-210-swatch"><svg fill="rgb(255, 247, 251)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 247, 251)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>pubugn</span><span class="plot-210-swatch"><svg fill="rgb(244, 235, 245)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>pubugn</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(244, 235, 245)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-210-swatch"><svg fill="rgb(231, 224, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(231, 224, 239)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-210-swatch"><svg fill="rgb(215, 214, 233)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(215, 214, 233)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-210-swatch"><svg fill="rgb(195, 203, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(195, 203, 227)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-210-swatch"><svg fill="rgb(170, 192, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(170, 192, 220)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-210-swatch"><svg fill="rgb(139, 180, 214)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(139, 180, 214)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-210-swatch"><svg fill="rgb(105, 168, 207)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(105, 168, 207)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-210-swatch"><svg fill="rgb(75, 155, 197)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(75, 155, 197)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-210-swatch"><svg fill="rgb(46, 143, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(46, 143, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-210-swatch"><svg fill="rgb(20, 133, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(20, 133, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-210-swatch"><svg fill="rgb(5, 123, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(5, 123, 124)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-210-swatch"><svg fill="rgb(1, 109, 97)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(1, 109, 97)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-210-swatch"><svg fill="rgb(1, 91, 74)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(1, 91, 74)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-210-swatch"><svg fill="rgb(1, 70, 54)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(1, 70, 54)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-211" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-211 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-211-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-211 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-211-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-211-swatch"><svg fill="#c994c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#c994c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>purd</span>
   </div>
-  <div class="plot-212" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-212 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-212-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-212 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-212-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-212-swatch"><svg fill="#c994c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#c994c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>purd</span><span class="plot-212-swatch"><svg fill="#dd1c77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>purd</span><span class="plot-swatch"><svg width="15" height="15" fill="#dd1c77" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-213" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-213 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-213-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-213 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-213-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-213-swatch"><svg fill="#f1eef6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f1eef6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>purd</span><span class="plot-213-swatch"><svg fill="#d7b5d8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>purd</span><span class="plot-swatch"><svg width="15" height="15" fill="#d7b5d8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-213-swatch"><svg fill="#df65b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#df65b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-213-swatch"><svg fill="#ce1256" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#ce1256" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-214" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-214 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-214-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-214 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-214-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-214-swatch"><svg fill="#f7f4f9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#f7f4f9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>purd</span><span class="plot-214-swatch"><svg fill="#e7e1ef" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>purd</span><span class="plot-swatch"><svg width="15" height="15" fill="#e7e1ef" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-214-swatch"><svg fill="#d4b9da" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#d4b9da" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-214-swatch"><svg fill="#c994c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#c994c7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-214-swatch"><svg fill="#df65b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#df65b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-214-swatch"><svg fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#e7298a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-214-swatch"><svg fill="#ce1256" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#ce1256" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-214-swatch"><svg fill="#980043" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#980043" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-214-swatch"><svg fill="#67001f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#67001f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-215" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-215 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-215-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-215 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-215-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-215-swatch"><svg fill="rgb(247, 244, 249)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(247, 244, 249)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>purd</span><span class="plot-215-swatch"><svg fill="rgb(238, 232, 243)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>purd</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(238, 232, 243)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-215-swatch"><svg fill="rgb(228, 217, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(228, 217, 235)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-215-swatch"><svg fill="rgb(218, 197, 224)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(218, 197, 224)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-215-swatch"><svg fill="rgb(209, 175, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(209, 175, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-215-swatch"><svg fill="rgb(206, 152, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(206, 152, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-215-swatch"><svg fill="rgb(211, 127, 189)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(211, 127, 189)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-215-swatch"><svg fill="rgb(221, 99, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(221, 99, 174)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-215-swatch"><svg fill="rgb(226, 68, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(226, 68, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-215-swatch"><svg fill="rgb(224, 42, 129)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(224, 42, 129)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-215-swatch"><svg fill="rgb(211, 25, 103)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(211, 25, 103)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-215-swatch"><svg fill="rgb(189, 13, 83)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(189, 13, 83)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-215-swatch"><svg fill="rgb(160, 4, 68)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(160, 4, 68)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-215-swatch"><svg fill="rgb(131, 1, 51)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(131, 1, 51)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-215-swatch"><svg fill="rgb(103, 0, 31)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(103, 0, 31)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-216" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-216 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-216-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-216 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-216-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-216-swatch"><svg fill="#fa9fb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fa9fb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>rdpu</span>
   </div>
-  <div class="plot-217" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-217 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-217-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-217 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-217-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-217-swatch"><svg fill="#fa9fb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fa9fb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdpu</span><span class="plot-217-swatch"><svg fill="#c51b8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdpu</span><span class="plot-swatch"><svg width="15" height="15" fill="#c51b8a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-218" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-218 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-218-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-218 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-218-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-218-swatch"><svg fill="#feebe2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#feebe2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdpu</span><span class="plot-218-swatch"><svg fill="#fbb4b9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdpu</span><span class="plot-swatch"><svg width="15" height="15" fill="#fbb4b9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-218-swatch"><svg fill="#f768a1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#f768a1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-218-swatch"><svg fill="#ae017e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#ae017e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-219" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-219 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-219-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-219 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-219-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-219-swatch"><svg fill="#fff7f3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fff7f3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdpu</span><span class="plot-219-swatch"><svg fill="#fde0dd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdpu</span><span class="plot-swatch"><svg width="15" height="15" fill="#fde0dd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-219-swatch"><svg fill="#fcc5c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fcc5c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-219-swatch"><svg fill="#fa9fb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fa9fb5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-219-swatch"><svg fill="#f768a1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#f768a1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-219-swatch"><svg fill="#dd3497" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#dd3497" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-219-swatch"><svg fill="#ae017e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#ae017e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-219-swatch"><svg fill="#7a0177" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#7a0177" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-219-swatch"><svg fill="#49006a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#49006a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-220" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-220 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-220-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-220 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-220-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-220-swatch"><svg fill="rgb(255, 247, 243)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 247, 243)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rdpu</span><span class="plot-220-swatch"><svg fill="rgb(254, 234, 230)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rdpu</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 234, 230)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-220-swatch"><svg fill="rgb(253, 220, 216)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 220, 216)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-220-swatch"><svg fill="rgb(252, 204, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(252, 204, 201)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-220-swatch"><svg fill="rgb(251, 185, 190)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 185, 190)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-220-swatch"><svg fill="rgb(250, 163, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(250, 163, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-220-swatch"><svg fill="rgb(248, 135, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(248, 135, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-220-swatch"><svg fill="rgb(243, 105, 163)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(243, 105, 163)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-220-swatch"><svg fill="rgb(231, 74, 155)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(231, 74, 155)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-220-swatch"><svg fill="rgb(212, 45, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(212, 45, 146)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-220-swatch"><svg fill="rgb(187, 19, 134)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(187, 19, 134)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-220-swatch"><svg fill="rgb(159, 4, 125)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(159, 4, 125)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-220-swatch"><svg fill="rgb(130, 1, 119)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(130, 1, 119)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-220-swatch"><svg fill="rgb(101, 1, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(101, 1, 113)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-220-swatch"><svg fill="rgb(73, 0, 106)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(73, 0, 106)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-221" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-221 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-221-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-221 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-221-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-221-swatch"><svg fill="#addd8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#addd8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>ylgn</span>
   </div>
-  <div class="plot-222" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-222 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-222-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-222 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-222-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-222-swatch"><svg fill="#addd8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#addd8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylgn</span><span class="plot-222-swatch"><svg fill="#31a354" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylgn</span><span class="plot-swatch"><svg width="15" height="15" fill="#31a354" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-223" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-223 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-223-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-223 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-223-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-223-swatch"><svg fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylgn</span><span class="plot-223-swatch"><svg fill="#c2e699" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylgn</span><span class="plot-swatch"><svg width="15" height="15" fill="#c2e699" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-223-swatch"><svg fill="#78c679" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#78c679" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-223-swatch"><svg fill="#238443" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#238443" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-224" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-224 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-224-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-224 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-224-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-224-swatch"><svg fill="#ffffe5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ffffe5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylgn</span><span class="plot-224-swatch"><svg fill="#f7fcb9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylgn</span><span class="plot-swatch"><svg width="15" height="15" fill="#f7fcb9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-224-swatch"><svg fill="#d9f0a3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#d9f0a3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-224-swatch"><svg fill="#addd8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#addd8e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-224-swatch"><svg fill="#78c679" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#78c679" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-224-swatch"><svg fill="#41ab5d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#41ab5d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-224-swatch"><svg fill="#238443" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#238443" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-224-swatch"><svg fill="#006837" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#006837" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-224-swatch"><svg fill="#004529" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#004529" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-225" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-225 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-225-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-225 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-225-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-225-swatch"><svg fill="rgb(255, 255, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 255, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylgn</span><span class="plot-225-swatch"><svg fill="rgb(250, 253, 205)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylgn</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(250, 253, 205)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-225-swatch"><svg fill="rgb(240, 249, 184)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(240, 249, 184)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-225-swatch"><svg fill="rgb(225, 243, 169)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(225, 243, 169)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-225-swatch"><svg fill="rgb(204, 234, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(204, 234, 157)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-225-swatch"><svg fill="rgb(178, 223, 145)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(178, 223, 145)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-225-swatch"><svg fill="rgb(150, 211, 133)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(150, 211, 133)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-225-swatch"><svg fill="rgb(120, 197, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(120, 197, 120)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-225-swatch"><svg fill="rgb(89, 182, 105)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(89, 182, 105)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-225-swatch"><svg fill="rgb(63, 164, 90)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(63, 164, 90)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-225-swatch"><svg fill="rgb(43, 144, 75)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(43, 144, 75)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-225-swatch"><svg fill="rgb(25, 125, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(25, 125, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-225-swatch"><svg fill="rgb(9, 107, 57)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(9, 107, 57)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-225-swatch"><svg fill="rgb(1, 89, 49)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(1, 89, 49)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-225-swatch"><svg fill="rgb(0, 69, 41)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 69, 41)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-226" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-226 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-226-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-226 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-226-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-226-swatch"><svg fill="#7fcdbb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#7fcdbb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>ylgnbu</span>
   </div>
-  <div class="plot-227" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-227 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-227-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-227 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-227-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-227-swatch"><svg fill="#7fcdbb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#7fcdbb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylgnbu</span><span class="plot-227-swatch"><svg fill="#2c7fb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylgnbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#2c7fb8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-228" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-228 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-228-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-228 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-228-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-228-swatch"><svg fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylgnbu</span><span class="plot-228-swatch"><svg fill="#a1dab4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylgnbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#a1dab4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-228-swatch"><svg fill="#41b6c4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#41b6c4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-228-swatch"><svg fill="#225ea8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#225ea8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-229" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-229 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-229-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-229 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-229-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-229-swatch"><svg fill="#ffffd9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ffffd9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylgnbu</span><span class="plot-229-swatch"><svg fill="#edf8b1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylgnbu</span><span class="plot-swatch"><svg width="15" height="15" fill="#edf8b1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-229-swatch"><svg fill="#c7e9b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#c7e9b4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-229-swatch"><svg fill="#7fcdbb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#7fcdbb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-229-swatch"><svg fill="#41b6c4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#41b6c4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-229-swatch"><svg fill="#1d91c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#1d91c0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-229-swatch"><svg fill="#225ea8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#225ea8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-229-swatch"><svg fill="#253494" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#253494" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-229-swatch"><svg fill="#081d58" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#081d58" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-230" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-230 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-230-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-230 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-230-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-230-swatch"><svg fill="rgb(255, 255, 217)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 255, 217)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylgnbu</span><span class="plot-230-swatch"><svg fill="rgb(244, 251, 195)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylgnbu</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(244, 251, 195)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-230-swatch"><svg fill="rgb(229, 245, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(229, 245, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-230-swatch"><svg fill="rgb(208, 236, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(208, 236, 180)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-230-swatch"><svg fill="rgb(176, 224, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(176, 224, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-230-swatch"><svg fill="rgb(138, 210, 186)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(138, 210, 186)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-230-swatch"><svg fill="rgb(101, 195, 191)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(101, 195, 191)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-230-swatch"><svg fill="rgb(69, 180, 194)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(69, 180, 194)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-230-swatch"><svg fill="rgb(46, 160, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(46, 160, 193)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-230-swatch"><svg fill="rgb(34, 136, 186)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(34, 136, 186)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-230-swatch"><svg fill="rgb(33, 109, 175)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(33, 109, 175)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-230-swatch"><svg fill="rgb(35, 83, 162)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 83, 162)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-230-swatch"><svg fill="rgb(33, 60, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(33, 60, 147)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-230-swatch"><svg fill="rgb(24, 43, 121)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(24, 43, 121)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-230-swatch"><svg fill="rgb(8, 29, 88)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(8, 29, 88)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-231" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-231 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-231-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-231 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-231-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-231-swatch"><svg fill="#fec44f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fec44f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>ylorbr</span>
   </div>
-  <div class="plot-232" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-232 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-232-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-232 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-232-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-232-swatch"><svg fill="#fec44f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#fec44f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylorbr</span><span class="plot-232-swatch"><svg fill="#d95f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylorbr</span><span class="plot-swatch"><svg width="15" height="15" fill="#d95f0e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-233" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-233 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-233-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-233 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-233-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-233-swatch"><svg fill="#ffffd4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ffffd4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylorbr</span><span class="plot-233-swatch"><svg fill="#fed98e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylorbr</span><span class="plot-swatch"><svg width="15" height="15" fill="#fed98e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-233-swatch"><svg fill="#fe9929" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fe9929" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-233-swatch"><svg fill="#cc4c02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#cc4c02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-234" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-234 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-234-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-234 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-234-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-234-swatch"><svg fill="#ffffe5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ffffe5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylorbr</span><span class="plot-234-swatch"><svg fill="#fff7bc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylorbr</span><span class="plot-swatch"><svg width="15" height="15" fill="#fff7bc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-234-swatch"><svg fill="#fee391" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fee391" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-234-swatch"><svg fill="#fec44f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#fec44f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-234-swatch"><svg fill="#fe9929" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#fe9929" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-234-swatch"><svg fill="#ec7014" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#ec7014" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-234-swatch"><svg fill="#cc4c02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#cc4c02" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-234-swatch"><svg fill="#993404" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#993404" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-234-swatch"><svg fill="#662506" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#662506" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-235" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-235 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-235-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-235 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-235-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-235-swatch"><svg fill="rgb(255, 255, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 255, 229)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylorbr</span><span class="plot-235-swatch"><svg fill="rgb(255, 250, 206)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylorbr</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 250, 206)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-235-swatch"><svg fill="rgb(255, 243, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 243, 182)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-235-swatch"><svg fill="rgb(254, 232, 156)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 232, 156)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-235-swatch"><svg fill="rgb(254, 217, 125)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 217, 125)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-235-swatch"><svg fill="rgb(254, 199, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 199, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-235-swatch"><svg fill="rgb(254, 177, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 177, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-235-swatch"><svg fill="rgb(251, 153, 44)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(251, 153, 44)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-235-swatch"><svg fill="rgb(243, 130, 29)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(243, 130, 29)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-235-swatch"><svg fill="rgb(230, 107, 18)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(230, 107, 18)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-235-swatch"><svg fill="rgb(212, 87, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(212, 87, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-235-swatch"><svg fill="rgb(188, 70, 4)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(188, 70, 4)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-235-swatch"><svg fill="rgb(160, 56, 4)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(160, 56, 4)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-235-swatch"><svg fill="rgb(131, 46, 5)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(131, 46, 5)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-235-swatch"><svg fill="rgb(102, 37, 6)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(102, 37, 6)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-236" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-236 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-236-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-236 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-236-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-236-swatch"><svg fill="#feb24c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#feb24c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>ylorrd</span>
   </div>
-  <div class="plot-237" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-237 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-237-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-237 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-237-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-237-swatch"><svg fill="#feb24c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#feb24c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylorrd</span><span class="plot-237-swatch"><svg fill="#f03b20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylorrd</span><span class="plot-swatch"><svg width="15" height="15" fill="#f03b20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-238" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-238 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-238-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-238 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-238-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-238-swatch"><svg fill="#ffffb2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ffffb2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylorrd</span><span class="plot-238-swatch"><svg fill="#fecc5c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylorrd</span><span class="plot-swatch"><svg width="15" height="15" fill="#fecc5c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-238-swatch"><svg fill="#fd8d3c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fd8d3c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-238-swatch"><svg fill="#e31a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#e31a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-239" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-239 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-239-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-239 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-239-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-239-swatch"><svg fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ffffcc" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylorrd</span><span class="plot-239-swatch"><svg fill="#ffeda0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylorrd</span><span class="plot-swatch"><svg width="15" height="15" fill="#ffeda0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-239-swatch"><svg fill="#fed976" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="#fed976" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-239-swatch"><svg fill="#feb24c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="#feb24c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-239-swatch"><svg fill="#fd8d3c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="#fd8d3c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-239-swatch"><svg fill="#fc4e2a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="#fc4e2a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-239-swatch"><svg fill="#e31a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="#e31a1c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-239-swatch"><svg fill="#bd0026" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="#bd0026" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-239-swatch"><svg fill="#800026" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="#800026" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-240" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-240 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-240-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-240 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-240-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-240-swatch"><svg fill="rgb(255, 255, 204)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 255, 204)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>ylorrd</span><span class="plot-240-swatch"><svg fill="rgb(255, 245, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>ylorrd</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 245, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-240-swatch"><svg fill="rgb(255, 234, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 234, 154)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-240-swatch"><svg fill="rgb(254, 222, 130)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 222, 130)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-240-swatch"><svg fill="rgb(254, 205, 106)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 205, 106)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-240-swatch"><svg fill="rgb(254, 184, 85)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 184, 85)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-240-swatch"><svg fill="rgb(254, 162, 70)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 162, 70)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-240-swatch"><svg fill="rgb(253, 137, 60)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(253, 137, 60)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-240-swatch"><svg fill="rgb(252, 105, 50)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(252, 105, 50)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-240-swatch"><svg fill="rgb(246, 72, 40)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(246, 72, 40)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-240-swatch"><svg fill="rgb(233, 42, 33)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(233, 42, 33)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-240-swatch"><svg fill="rgb(215, 20, 32)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(215, 20, 32)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-240-swatch"><svg fill="rgb(192, 6, 36)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(192, 6, 36)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-240-swatch"><svg fill="rgb(162, 1, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(162, 1, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-240-swatch"><svg fill="rgb(128, 0, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(128, 0, 38)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-241" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-241 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-241-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-241 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-241-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-241-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>rainbow</span>
   </div>
-  <div class="plot-242" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-242 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-242-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-242 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-242-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-242-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rainbow</span><span class="plot-242-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rainbow</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-243" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-243 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-243-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-243 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-243-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-243-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rainbow</span><span class="plot-243-swatch"><svg fill="rgb(255, 94, 99)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rainbow</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 94, 99)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-243-swatch"><svg fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(175, 240, 91)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-243-swatch"><svg fill="rgb(26, 199, 194)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(26, 199, 194)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-244" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-244 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-244-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-244 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-244-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-244-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rainbow</span><span class="plot-244-swatch"><svg fill="rgb(200, 61, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rainbow</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(200, 61, 172)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-244-swatch"><svg fill="rgb(255, 83, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 83, 117)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-244-swatch"><svg fill="rgb(255, 140, 56)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 140, 56)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-244-swatch"><svg fill="rgb(201, 211, 58)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(201, 211, 58)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-244-swatch"><svg fill="rgb(121, 246, 89)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(121, 246, 89)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-244-swatch"><svg fill="rgb(40, 234, 141)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(40, 234, 141)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-244-swatch"><svg fill="rgb(30, 184, 208)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(30, 184, 208)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-244-swatch"><svg fill="rgb(71, 117, 222)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(71, 117, 222)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-245" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-245 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-245-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-245 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-245-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-245-swatch"><svg fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(110, 64, 170)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>rainbow</span><span class="plot-245-swatch"><svg fill="rgb(164, 61, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>rainbow</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(164, 61, 179)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-245-swatch"><svg fill="rgb(216, 63, 164)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(216, 63, 164)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-245-swatch"><svg fill="rgb(254, 75, 131)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(254, 75, 131)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-245-swatch"><svg fill="rgb(255, 102, 89)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 102, 89)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-245-swatch"><svg fill="rgb(255, 140, 56)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 140, 56)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-245-swatch"><svg fill="rgb(226, 183, 47)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(226, 183, 47)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-245-swatch"><svg fill="rgb(190, 224, 68)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(190, 224, 68)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-245-swatch"><svg fill="rgb(143, 244, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(143, 244, 87)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-245-swatch"><svg fill="rgb(82, 246, 103)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(82, 246, 103)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-245-swatch"><svg fill="rgb(40, 234, 141)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(40, 234, 141)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-245-swatch"><svg fill="rgb(25, 208, 184)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(25, 208, 184)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-245-swatch"><svg fill="rgb(35, 171, 216)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(35, 171, 216)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-245-swatch"><svg fill="rgb(61, 130, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(61, 130, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-245-swatch"><svg fill="rgb(90, 93, 208)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(90, 93, 208)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>
-  <div class="plot-246" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-246 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-246-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-246 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-246-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-246-swatch"><svg fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>sinebow</span>
   </div>
-  <div class="plot-247" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-247 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-247-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-247 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-247-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-247-swatch"><svg fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>sinebow</span><span class="plot-247-swatch"><svg fill="rgb(0, 191, 191)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>sinebow</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 191, 191)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>1</span>
   </div>
-  <div class="plot-248" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-248 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-248-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-248 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-248-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-248-swatch"><svg fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>sinebow</span><span class="plot-248-swatch"><svg fill="rgb(127, 238, 17)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>sinebow</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(127, 238, 17)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-248-swatch"><svg fill="rgb(0, 191, 191)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(0, 191, 191)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-248-swatch"><svg fill="rgb(127, 17, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(127, 17, 238)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>3</span>
   </div>
-  <div class="plot-249" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-249 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-249-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-249 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-249-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-249-swatch"><svg fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>sinebow</span><span class="plot-249-swatch"><svg fill="rgb(225, 150, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>sinebow</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(225, 150, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-249-swatch"><svg fill="rgb(150, 225, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(150, 225, 8)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-249-swatch"><svg fill="rgb(64, 255, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(64, 255, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-249-swatch"><svg fill="rgb(8, 225, 150)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(8, 225, 150)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-249-swatch"><svg fill="rgb(8, 150, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(8, 150, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-249-swatch"><svg fill="rgb(64, 64, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(64, 64, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-249-swatch"><svg fill="rgb(150, 8, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(150, 8, 225)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-249-swatch"><svg fill="rgb(225, 8, 150)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(225, 8, 150)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>8</span>
   </div>
-  <div class="plot-250" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-250 {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-250-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot-250 {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-250-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-250-swatch"><svg fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="rgb(255, 64, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>sinebow</span><span class="plot-250-swatch"><svg fill="rgb(244, 114, 24)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>sinebow</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(244, 114, 24)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>1</span><span class="plot-250-swatch"><svg fill="rgb(213, 167, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>1</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(213, 167, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>2</span><span class="plot-250-swatch"><svg fill="rgb(167, 213, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>2</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(167, 213, 3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>3</span><span class="plot-250-swatch"><svg fill="rgb(114, 244, 24)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>3</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(114, 244, 24)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>4</span><span class="plot-250-swatch"><svg fill="rgb(64, 255, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>4</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(64, 255, 64)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>5</span><span class="plot-250-swatch"><svg fill="rgb(24, 244, 114)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>5</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(24, 244, 114)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>6</span><span class="plot-250-swatch"><svg fill="rgb(3, 213, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>6</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(3, 213, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>7</span><span class="plot-250-swatch"><svg fill="rgb(3, 167, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>7</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(3, 167, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>8</span><span class="plot-250-swatch"><svg fill="rgb(24, 114, 244)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>8</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(24, 114, 244)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>9</span><span class="plot-250-swatch"><svg fill="rgb(64, 64, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>9</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(64, 64, 255)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>0</span><span class="plot-250-swatch"><svg fill="rgb(114, 24, 244)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>0</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(114, 24, 244)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>A</span><span class="plot-250-swatch"><svg fill="rgb(167, 3, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(167, 3, 213)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>B</span><span class="plot-250-swatch"><svg fill="rgb(213, 3, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(213, 3, 167)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>C</span><span class="plot-250-swatch"><svg fill="rgb(244, 24, 114)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="rgb(244, 24, 114)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>D</span>
   </div>

--- a/test/output/colorSchemesQuantitative.html
+++ b/test/output/colorSchemesQuantitative.html
@@ -1,6 +1,6 @@
-<div><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<div><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,16 +9,16 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA2UlEQVQ4jXWLy41DMQwDhzK2nxST/jt54h4s2zKSHAQOP9L79ecQRMCQCMHyocqKo/GIvtXWsf3a6upXNxrvPKL5QCvbGq2LlgUaQcQ4+Vg8rk5jFI/iaFx5+cVXvjr1LA6rZW2DmldAqTRAax+TS+dPYwLUji+MQIFRZcLM3AhLhxGGD03A5jCQ25v0VPv2aR81PJvnPTZJTl1+a8uzbyY/mcfn0trl2cysNpnVVZ5ts7q8u/zR5xe92Vf+6+yz98rq0oedxs1Tv5PnLz4dduPSTGxvPrk3/wOC4FZ8+BQyxQAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">brbg</text>
-  </svg><svg class="plot-2" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -27,16 +27,16 @@
         overflow: visible;
       }
 
-      .plot-2 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA1klEQVQ4jXWOQZbDMAhDJfli3ff+xwFmAcY4zbw+KumLkPCDb0iCKEgLkrAoSDWDa/I5XK+cEiRCa2ZB6+7YbGY+dPb/K1fdlcBVemX2u8991jcfnzp3ee5291RBzPzT8WYUQeJkTk5IaI/aPXsonkoCKI7OOSTb5wSA9EEAiPRTEf0Dj48YHn7+Y3uvHYe3VhdevZdPFsU9XubBbXY+s6UvZmGn9+zM68bI5laseD8zco1vXzc6e7T/UYvO7refah6InW3z7KL87t9yNHeE3ezs5zPP7g/alWNv64eNqAAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">prgn</text>
-  </svg><svg class="plot-3" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-3 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -45,16 +45,16 @@
         overflow: visible;
       }
 
-      .plot-3 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA0UlEQVQ4jW2NQRLDMAgDJdIX9mH9caQeMBhncvBotUDCH78OBoJEMHAN7hezExEPP3tkJwNxpWO5q5LdeeVeMtudPsDPY/4JYM4ft7wCmG79F82rL89Ij+baZXIU1w6BmnHu7QSHI8b+6bID5GaQAPHej0R3FyNzdtMnz4QBGt3oZQ1Ai8pV15gLtvas+Yaac0e4M33DeOSaNzt53pzvxenpBGn3u+fTJ9/WvpeW17jT6SXIHs4750x+YcODy7tYOLuxeGfOsb519tybbtx73/wBiwBVtFSSoDIAAAAASUVORK5CYII="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">piyg</text>
-  </svg><svg class="plot-4" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-4 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -63,16 +63,16 @@
         overflow: visible;
       }
 
-      .plot-4 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA0ElEQVQ4jX2OwXHEMAwDAaieVHL9d3Mi8pBkkraTB4eLJewRf/CxJJADfQvS2FugBkSBWj453cnp1N0QJBYWNLg648mrx/cslm96p3VLXt8k1/c8btWfNx8eJZOlv9+vm3t0ALHfz78oZJ+EdqYIEq2zcvLr4LAXw40Bg4gXDtDRNrzZAWAmewI+ee5ZzJjFTSBe+NV9gZjwreft4QlHcTunW77n+8TFcbLTR8TmuLhvI7x3eHkfXjt8GHkz9q1uwD49ZP/iMv/dWgcI8w+/5hefJCvShWv1kAAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">puor</text>
-  </svg><svg class="plot-5" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-5 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -81,16 +81,16 @@
         overflow: visible;
       }
 
-      .plot-5 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA2ElEQVQ4jXWLwZEDMAgDV1BIykv/BRjuYWxjz+XBSFoJffmkC1ziVfvJhduzsfK2emHFzFp+Tr68YS5kwnzm1cl7N7nc9mb3bsjs2pw8vZr/xaf6lbmyI+vMoTjWsjm0Hjt/mCEdPtVA7VeLTc21VzsTyMjGUgJKdxYpkRhIJCJh6puT44FYOSFeTQjy+My9X/4/HbFyY+VHHL78aD+bBcVz85UvFmy293F29/buo/Xx8H3V5cMzk4jYfGqQ2XwkGVF97IuMK89NkDEql45R3Xi6ftWPlw/+AP61XqZckQ8kAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdbu</text>
-  </svg><svg class="plot-6" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-6 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -99,16 +99,16 @@
         overflow: visible;
       }
 
-      .plot-6 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApElEQVQ4jaWOyxGDMBBDn7SFpLz0XwA4h8XxJ0CcyUEjPWnHoCePEoKQmN2XvQhPNz6y6y58dHbHkxQ1G4eQhSO5bop+y17h9817DyN7uGmcWV2+6tNjYAYO5L4LOHp8ww7w2OH2Fjbok/O+5ew71iGrZWUuqDGiDE7uQKkqJJfKpXmp3rTPvO+n3PdnecVX8xnP+rZv23a7X9380618d+W/ftELRnlxXnkBnbYAAAAASUVORK5CYII="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdgy</text>
-  </svg><svg class="plot-7" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-7 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -117,16 +117,16 @@
         overflow: visible;
       }
 
-      .plot-7 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAwklEQVQ4jZWQSY7EMAwDi/Jf+uf9TItzcLzFBhpzEEQW6QCRvnwcAdto9wpxdALi4bp6bW/HLiJCo6PQwoRK65687xg55Z0Jlg4XzustnZXnpzu/aCK2N+uxVN6Hu2uNAx1Hnkxx2dr9pnUwK4DZdd9cNi0f+jaeOglsDZ7oyUW6ZY2J3DSPZ/H3sSFt6mBuOz21/fipq01m73v2s/E69MpfOtdv/R5feZL1zFxn7vTWcRrXXPTOO/M/GNU4c3aqYfF/AzFBDLI2NnAAAAAASUVORK5CYII="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdylbu</text>
-  </svg><svg class="plot-8" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-8 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -135,16 +135,16 @@
         overflow: visible;
       }
 
-      .plot-8 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA0ElEQVQ4jW2QSY6FMAxEn8Nd+uZ9TFx/4SEDEYpqBhT7509jwHZs1zaMT2fASN+u2rZt42OMYd2xYYtn2BPdr184Ouc5M4Olw8Xn2FJedqhtd0b7c7teUmDsv/5+mfk+u13yom1FO3Ri9YsnqnV4ag4iuKC1AJkAgvcDjpBKO5LCw3GVF9yLo/Rmp7jLe+vLbtPF0aLPfJ5XwkW+q3R4r89s7b1XjP7qvRLugd2R9t6auzKn/6Nzn9pPnbz27vFdl5Bry0srPTmbp9xs3iWr8wPcXFevq8XGRAAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdylgn</text>
-  </svg><svg class="plot-9" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-9 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -153,16 +153,16 @@
         overflow: visible;
       }
 
-      .plot-9 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA50lEQVQ4jXWQSXLEMAwDG9TP8tD8VEQOpBZ7JgcVgAapsqxf/ThCxIAIMVoj2Kx8657pboDivXOyLlZzt/dmuvryn93XM5YXxPEaQKj4aBaCIRTdDcFmcfnF4+HPfT0bR+uuT3507a+H3jxAev+cM6cvfM3rnbWzJUDNntlwKaWUWm7vyvb2YBJfzNg1m4t5zUDaZN+RhqTVVE/PGKa1u9zdk09DWq3P/u7mP/PTMPPLXl45z97mufZUmv1NKWZWn6k+bPXFnCJnqZM+wrM8nZlcPwCYoM5KUD9GWVzTxPJpYrZ+yfHKfyPr9lDWJbNPAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">spectral</text>
-  </svg><svg class="plot-10" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-10 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -171,16 +171,16 @@
         overflow: visible;
       }
 
-      .plot-10 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA2ElEQVQ4jY2OwXEFMQxCQZ70k5bSfw0SOViyZP/LP2iAB95Z/vz+ibZw3VowW6AZPrpkp19zV52l7zM+2ZieuSfI9rvPzJ3t4oQ9fA1v7Dy1rvr19hfH55bPe+6dXRxYHP9AXL664ja+0exWAhcjAcP0t9aeAAht5fAQKF0ZEogAJSB7qHKcvNlWRLOdA5QD0RkKKIqlRgDJdJhDk4cD3m+Pemd5v5OXJvM4WW8ePr7i2jlZuJq/m9DpI3Q24TpdxOw+z8sLnVUKeAiu9BI8sHsJXiw1njz1HzZ1S5at/iywAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">burd</text>
-  </svg><svg class="plot-11" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-11 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -189,16 +189,16 @@
         overflow: visible;
       }
 
-      .plot-11 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAxElEQVQ4jY2QO3IEMAxCAZ8oTW6a41qksOX/zmyhAT2wC/Hn988UwUJAAguROyVg2wkWNf2SaWE6uQiNTKMrzclO5lf2xRQ+ON++dbFzpsf8i4SI3Y8Mg5XuSXT+HtIQANHLbogenjTEAGGQ0VmAiN7pHjH5MUjv6eGHuimylz4Wbt8sfRzZqmsWO/PJPnjXkxuoAedemzr89tX7m+r+Nv82nKzrya+8d9Ys1n4Yrrh4hPs5Gmun2nV2mt/OOTr7+OS+O/9B2ELbANj+6QAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">buylrd</text>
-  </svg><svg class="plot-12" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-12 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -207,16 +207,16 @@
         overflow: visible;
       }
 
-      .plot-12 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAkUlEQVQ4jaWQwQ6DMAxDvf//4B0m5e1AS9KQrKBJSNR+dmh4vT8AEkLjUadBUtJII9drhvlE/3MfINzDdZdb/Ss3YtY7NrMxNzxna85mN8yzlDPmjA2vZmYuPEeRa7v+P879wzeXzLl/0JkXmmWfxHbdbafxzM8qO65VsOypYWr4oe3CD2Y/tC3ePAOSZXb//QWX9h3CsjlyFgAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">blues</text>
-  </svg><svg class="plot-13" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-13 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -225,16 +225,16 @@
         overflow: visible;
       }
 
-      .plot-13 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAnUlEQVQ4jZWQwQrDMAxD3/7/e8cuQ+qhxVESB7ZDwZae5NDX5/u2MQC2gdqwY24YY3DMT2Yken/OOtiRs71kZn3V6qbV+p2mzrN5nNK0MTp2CM1dE6MtI4++vKOOj1n5hqnrxN99xVSGnTvuoCPT9VBs3srelame8G3Ht+49o5PP7x3/7Bx8FrZ2jZnowMbaNTT6UsuO+wczGO3sul+hF1R+lzbaKQAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">greens</text>
-  </svg><svg class="plot-14" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-14 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -243,16 +243,16 @@
         overflow: visible;
       }
 
-      .plot-14 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAARklEQVQ4jbWOMQ4AMAgC6f//LF06NWqk1sEgByYukgSAI6OqZtX9h49YxtVOZczsOfeyqK/yaq72ujedn2+e+em94rvM4xvdyaofV1ewywAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">greys</text>
-  </svg><svg class="plot-15" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-15 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -261,16 +261,16 @@
         overflow: visible;
       }
 
-      .plot-15 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAl0lEQVQ4jZ1SURbDMAii9z/yWu2HMaKxWbevqAiiL8f5uRQAVBX2Ah4YAAyEMEAHoCUf6cpPec9V91Ewn8sY+02xazGXYst1aszaxKMWWgUjLirWvVjrmddwZIP5zi2289NoCN/mt/fN7tjsk24rWmrGSTOE9dgD98YsSMx7ik3z/3h6ePTT8WNHSNxg1XnTX/5C6v+ueQMBXBvb4i5ZxwAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">purples</text>
-  </svg><svg class="plot-16" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-16 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -279,16 +279,16 @@
         overflow: visible;
       }
 
-      .plot-16 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAmklEQVQ4jY1SSxYDIQhL73/ZbrpNuhCEQbBdzDPk51Pnpc9bkAAIkH0jxsFrzwyt5g6ueIdZD42Nv6wcPPSZ0clbfuirmdvcakN3u0/fpVaruejd78MfPHVwShk1vpnD1pS5lFkYgS3jGA33z8qWD0wkLuGWB0AJQvB2lNW3/vpTyznYdULbS8sz6b4/8dTpfuvn4Gfx+yzd9S/BcQKTHhq9XAAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">reds</text>
-  </svg><svg class="plot-17" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-17 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -297,16 +297,16 @@
         overflow: visible;
       }
 
-      .plot-17 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAiklEQVQ4jZ2QOxIDIQxDxf2PmjqtlYL1B6Nlk1SSn2wNw+D7RYAAiVUBzVflQy41vN1k1pjp/MroXbWXlbU5+gT/i/3qv2Cmsmflxvcu1izYfsP6x8pbdmWeXc5oXHaUTo+ptrPu6buCxVMgmHukt9ifrM7KG8odnDWNm5G3ON/c5SdOjjb3/Dx/AOLs5ro4jjvpAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">oranges</text>
-  </svg><svg class="plot-18" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-18 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -315,16 +315,16 @@
         overflow: visible;
       }
 
-      .plot-18 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAABH0lEQVQ4jX2QQW4bUQxDn6hJ6sTtuosse/8jSuzi64/HblADAvlIDjDj+PP7y0f+4tCdQz9J3Tnyk9Qd6YPMT6QPlDekG5E3QjeUP4h8B43mO6E3yDm9QR44D9CBM4cTS0tTOAUpWsIZkwVW4ARn0BlYDDPedILlyT1+a5+MevKG7KWzQeusWv7M6uziGx9RxOxCRUQ/qU4uNHtFo9lo83dKk5csWT53TpPDYvW7S17OTeJ/2Zv90OkOb57s9Bduo531o1c/WBddf+32Rn7mKM6d2kQbFUsbokw00Ib6j5ahrzr+dfPEL88Nd4F79GTo8rrTQ8/umtepq6teXZXpnr5N1cW316uM757nPBt7vfZk7Z0t7/mM7c3lDMTy+/cXwM9vrI9SuXIAAAAASUVORK5CYII="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">turbo</text>
-  </svg><svg class="plot-19" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-19 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -333,16 +333,16 @@
         overflow: visible;
       }
 
-      .plot-19 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAuklEQVQ4jYWRyxGDMAwF98mtpYT0X4qVg2VZNgEOzPsthgF99HVkyERVTCAhM5AgVajs25Z5+oMrm0tgbNvZ1ewSKHx2kyVZz1wZwJY/t0u2J+6fastP7NZxz7+dt3neWL89Nzfq5mVfuW46OWZ/6uAkj9+69vF512bp92wcuejYwteLp65fcss8tla9HGP2s+sYoerJL138xjKeNfYeu0cf9wXbqL2v89LP9yRYaIKGwgtDkRXZwg/3A1HoiQrmmp1VAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">viridis</text>
-  </svg><svg class="plot-20" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-20 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -351,16 +351,16 @@
         overflow: visible;
       }
 
-      .plot-20 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAvklEQVQ4jW2SSwLEMAhCgc79r+ws/Leu8gQ0TVICPyMIkAAEZzlTAB6QAqv2dWrNntXSn+WXh+QHRPQguLQHMhVnTtDQvZPW7KcYTAbDHaaOtYqILLbH7EvGkUVlJ1c250ftbFs7+nq+1T7t2ytnw7djHzuyVrO+2c35HZOZGaZuPT/ryFOtMWeomRfLf8dkKH0A5TXvNS8qOC6H6kfgerjUdh0HPHQtf9XL00vToQ/moYVupc/8V7Olac2Y9R/4sC65xxNF4gAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">magma</text>
-  </svg><svg class="plot-21" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-21 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -369,16 +369,16 @@
         overflow: visible;
       }
 
-      .plot-21 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAzElEQVQ4jZWT0a7DIAxDjw33//+42QNJCt007T6g2McJILUIZgiBBBhhkFurtEb7rgcbSMZbr4tjXKw8K/NThzsvb5RMm1fdcGmVZ/OgR7UqB8HWx8b4P+ssPmTRc60BKfJO90yx9yy+sNjOjnVO6zj3PGY2n/WYKfajlgPrun2zQMV9ZtL1lfHscYCvnzV+93jtx5EH69eP/Li1lM9B95JTO9euTdjg8WC7H4SqZ3R/tP9UZ+qsmsnmYpuXJvhvVU2UTJpYc71PTezBC2/ibqA5x/tYAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">inferno</text>
-  </svg><svg class="plot-22" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-22 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -387,16 +387,16 @@
         overflow: visible;
       }
 
-      .plot-22 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAvklEQVQ4jYWSS3IEIQxDnz2bbHLunHpKs2hjBE1PFhSyPraLIn5//vRS8KKOkiTIqgdOMXGdaAwp5zBPYRmGzoZ2DuMnNzUIDW73MD3jjq0GMk63rBYRlS2cAdHYbxFpOB5w7tp1vMeNW7KnHI/6f/nOhuBb3vbiQT/xs+eWt1nY/t4Dm9v84qH7c5i3aLl7rn1PHmxm652ncXOp+jArz3iTrcb8unE01sKBRo8EFa/63LrxYfWle0a1k1KQbz5ggaELI65ogAAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">plasma</text>
-  </svg><svg class="plot-23" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-23 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -405,16 +405,16 @@
         overflow: visible;
       }
 
-      .plot-23 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApklEQVQ4jX1R0RXEMAgCJ7mVbv9hvI+q0WDvoy8IiDYhPl8HDc9HAHEK5ooJBjwYZNTBE7CGB0+0jPShfEbVrDICl1czxNt84i3sf7ScxzF7m3drc0+qXnjRCKDdk/ibF9ed5r6QXja/zh7+mKEZjzYz+s7KyX+99CrnOze83t7CF97bO7loVnX2XlzmDr3nvNS49a1ncmePORer79RY8Dm97hx0/AA3bzctFH85ygAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">cividis</text>
-  </svg><svg class="plot-24" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-24 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -423,16 +423,16 @@
         overflow: visible;
       }
 
-      .plot-24 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAA4klEQVQ4jW2TSQ7DMAwDZ+j+/8vqwfKStAeBQ1owAoQWqBhEYgiiIQRNs5s1eJ2t4Q9zcy4fN9NcK7u0dPoIOnceTDO9R2dcWYGcswBWc6FTCWh1Vth7bt96cfzVN5+BwfEDfnRYBCYDw4v32LnHrymfnvzRMCqbs7J2bz2bo7O+yZMvLwP9zGz7gXzQAdcOy7e+fTkgKw+kM0NlZaGWbyahEkqpLG+fzd7M7qyd2ZvVrdlDrrx71B2qq2OrT9796vqyO9RVtx7s5uO72g++dX+GEL28XX+b7afhyR7v2/lvlS+ApkP+iM1IhQAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">cubehelix</text>
-  </svg><svg class="plot-25" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-25 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -441,16 +441,16 @@
         overflow: visible;
       }
 
-      .plot-25 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApElEQVQ4jZWMyxFDMQgDJSpLRSksRVo54A/G+E1y8CBWa/h+fUQABoIiDACxTwPhDoLjPObhmKp+zWtWdHX0O1PoQqYmO6fWX44b3s/M5UQWb/geu8Wzk/t6toOjc/S8ZmJsIQ+vPe/VDap2fuYPz/7pkBiS57sMUHdGFjszzCwCstGlTOx/LfNqZ+p8b8w9r3vbWPBIyAqW33Ts4jjHyMjc5v4FFqjP+wXb8A8AAAAASUVORK5CYII="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">warm</text>
-  </svg><svg class="plot-26" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-26 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -459,16 +459,16 @@
         overflow: visible;
       }
 
-      .plot-26 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAtklEQVQ4jY2SSw7DMAhE3+RkPVEP1kN2ujDGkNhSFxbzA6QQvV8fWwIukBhYWJ2jC08u4aJR9fTU8xu852z8qrHRS73qjJ3PzSf7JiY1eiY+011bM33TCpej12WHY4eTc9JKf/Kc69Srt/AzM963Zw5+fZo6Ves58X14YvQpM4tLBjaY3q+YrX855jpqgWNH4uInB6TKVx2nn9hILMzC43cYdfKeoXtxwu4NvXHivI+MjlyeWPwAkPjY+7Bui08AAAAASUVORK5CYII="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">cool</text>
-  </svg><svg class="plot-27" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-27 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -477,16 +477,16 @@
         overflow: visible;
       }
 
-      .plot-27 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApUlEQVQ4jaVSQQ7DMAxi/3/wLhvsEMfGiXtapSqAAatVXu/PV8J6FhCcJ05NycOeiUfNehXFiSHbE3rboZ7PrKzHZ7vv0Fy3HI9McYGWp7a2vITzynH0Lz55J/+c5b0nPRz0yU/rZH2nBDU/L49nFTpF++c8fGze4tW/NarzPPGgX6dhDtqFJ/7PG3f60KS4o4EbZ2HkLDBvDaw+17wDtJnQOTFmf9Q+Q35w0pS+AAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">bugn</text>
-  </svg><svg class="plot-28" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-28 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -495,16 +495,16 @@
         overflow: visible;
       }
 
-      .plot-28 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApUlEQVQ4jZWQSRIDMQgDO/9/cC6JNAd7MF6YVA4uhCQW83p/vrYBjA0G9tzQeXfgyN39zRf1Sdt6hG/RE869ZzzXzP2K2nXen349zOepRzGbVe/LVDkbb9CBM1iOWipOs97ygUkz++ej7sYueBSHLbF/euY9qv2Onsd9Exc38eijkzflcbtdc9ZsLAWfNVvD0/F4QjdGM0fGTZOFWaKNGPH255j1C7yIFbeqeGCeAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">bupu</text>
-  </svg><svg class="plot-29" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-29 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -513,16 +513,16 @@
         overflow: visible;
       }
 
-      .plot-29 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAArklEQVQ4jXVQQQ7DMAgj///sbrtMeIc4YCBRK2GMbWjX9/cBDLbf85gZ7nhrBRsM4tWcbZ2YHXti5hT344aX93pP7J23o+CsPROS4cMj+dT74YvGzJvWw2PpiX5ddCt0ZV60q1RghX9yJ4+VOQ5mcKY7zmzsLXzfV/mOs0fj2LvOULWefPUoL9ibnxw6B8Ref+QcbIPvs9RHz49WjV05j5+lGh6XvGevntA1z9H/AaAq9dkQqjhOAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">gnbu</text>
-  </svg><svg class="plot-30" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-30 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -531,16 +531,16 @@
         overflow: visible;
       }
 
-      .plot-30 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAoElEQVQ4jaWSOw7DMAxD2ftftXs2soPUWJSVpECHQPEjKX9fOt4CBEiISvi4V9f1mJs4Z9+dZ+tDX0PNXOWMX/l/GWP2/P0R4MC51inOHANX5aaXM0tuXsHmiX+0+ZcnsrA+av447qoXjauf6zz1LVc8OxMkDiz9G2t616Yq5XUNXM5jmznGVwsWW9e6JshqvtLI4Dxm5KvOqvRUljncsw8WXwieRVb+eQAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">orrd</text>
-  </svg><svg class="plot-31" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-31 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -549,16 +549,16 @@
         overflow: visible;
       }
 
-      .plot-31 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAuklEQVQ4jY1TQRIDIQyi/39wD52BHiSKWe30FCRA4qz70vsjCQAECYAANQwBarj0t/4RA5B27KiJ92z7BzmzlH5jhH9qTvrQ8KYxZuolsOUzc+xlegV7tOqhX3OogWtO4a5laCuL2RfA2JHe8TRnZve5cbc+Z9wn8NTueL+3ObQ6swSJ3rs4hq56z6rQDp7+1q4iBHouIdFvbHmSQ+NgHUS/RfohPM+lh+euH6k0iZP753zh+Is/+IL/AtKqCZxDtul4AAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">pubugn</text>
-  </svg><svg class="plot-32" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-32 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -567,16 +567,16 @@
         overflow: visible;
       }
 
-      .plot-32 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAqklEQVQ4jY2SwQ7DIAxDvf//4B0m5e1ACk6g3aQiHNtxiuDF+wNIEhq7BBJC+Ukgkh8lR5/nbH0lY3nA+ykzLn+Z1/g9v2Y/4dAvvfIxceqGq75w2Fk2znDkOWJ6nSdnVT0OudHOFok9r+Jdm1z2XfXKSc76b3tueJqH/p/Ol716sHyaH7Bltaomu1cVjnyrXA9ucuc6Fn/ghs/qiWPT6VrZ/+Mg8rK7vvAXGugHsfUHYr8AAAAASUVORK5CYII="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">pubu</text>
-  </svg><svg class="plot-33" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-33 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -585,16 +585,16 @@
         overflow: visible;
       }
 
-      .plot-33 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAuElEQVQ4jX1Syw7DMAwi//+7k6ZdoIeQBLvRpErYgMmr4/v5SQIAYSIgCZgfIBnNT+o/n3lFd274Dtc81N2z0flMj0422wybLgG8ZNIHKVlvDoyczYXuvaHpvR7OXXkjPLd6OPPeC6PkGCkM72d47bcefNNKTW7vPp/5OsPQ6ftuvOh3oe+S8XaH0/IGCq1fXpyZ9M06NAgsvPtVN64iLjzOjP99pp5c+OaOUXwlBxV3ra7x6n9j9T3pGQylwGAEfQAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">purd</text>
-  </svg><svg class="plot-34" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-34 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -603,16 +603,16 @@
         overflow: visible;
       }
 
-      .plot-34 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAApklEQVQ4jY2SOw7DMAxD2fsft0M3vQ6WZVqwgwwBxZ8MAfnw+yKQJAnykySKs/E2wyvOk79pp9w9i+vld+2J66oR3TOMyU8aUmjdHPdMR7oerRcI107dYOQs4x61x+60zNxPZXweSO0ZPdf2OT0auo8UedfUorrmZzdgZdoc+Ubkv9GzhVq8suqYnqN2H5GaVtdz00vu8/JsxyVzytcd2+5T/9BN/ANROsvDP7wZzQAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdpu</text>
-  </svg><svg class="plot-35" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-35 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -621,16 +621,16 @@
         overflow: visible;
       }
 
-      .plot-35 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAuklEQVQ4jX2TSRYEIQhDw/1P2Icpfi9ABYtXK5IQcEANfiAkuQBJKDgCP7h4mpb81BQ+5rIycehlVa7YNMkzsiPywk/ett5iegLbxtXjRG3NBbfOB+25etZ+z91/r2Gvns9dv85X+N3/5Xmd9+QW/opfGCSczictLzZ4bIYcFn7FMqxVdw8PvwY9DNfaYWafNX14ICBrD2vwDZzxolLP3Mb4xjSe/y45eHr8/MmFly7vmvz48fN3d4+If66U7Y0gAHi6AAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">ylgnbu</text>
-  </svg><svg class="plot-36" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-36 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -639,16 +639,16 @@
         overflow: visible;
       }
 
-      .plot-36 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAnElEQVQ4jaWTUQ7DMAhDvfufc9fg7WNAgCRSp6kfNsa2kNq+4I2EkElCcoTF+75w95D6zC9veuA6452MfT4ghbvpU9PilOuYO79+6Eb3W/WfsqPH+HLzThtZ47l+8mz9k8cb9Tnuy1y5N/yrv9wR+R/0HXXR+27qm2ZL4+DDxlzu2vMn/h/G75Dfo+908yXveNOUfa7Z7teGJ3/HD8C0M41UATiVAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">ylgn</text>
-  </svg><svg class="plot-37" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-37 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -657,16 +657,16 @@
         overflow: visible;
       }
 
-      .plot-37 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAoklEQVQ4jY2QSxbFMAhCyf7X2W1AB/kotva9QU6Qi9ZmSJcAASIAxbGagNTUnS4z3rR+Mfqt8g0RMs6Y0fqZJS563k7NNKzrY5fPXMXLtZ4ZyrLaucMiJ/PnET0/n9TzkgAi6c1w+me0sDN/6TVHj3x4e6fs7V6dHSpLN7V+r/KpmXQ8RWTWumD1jO16zUDJWT1AvLOj//KGMdsFTa/x8Zm7ATvR4KH2ZvpqAAAAAElFTkSuQmCC"></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">ylorbr</text>
-  </svg><svg class="plot-38" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-38 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -675,16 +675,16 @@
         overflow: visible;
       }
 
-      .plot-38 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAkklEQVQ4jY1SyREDMQgT/beWmlAeDhtZIzt5MIAOPAtb5IsgATT2TIBWb9lq96dZN1/Efte8aXwu+z881e1c4oOmaZ4D9uAw7NyvzzXPwwvned4arWbVGs6AaWbAafOoHEcjmd4vj3Izk583N53+ttaP9nTCW6yTVT4jynqgR7uttPJZxg9bL3R19e01iIxbnPg3iRO1tm9FEn0AAAAASUVORK5CYII="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">ylorrd</text>
-  </svg><svg class="plot-39" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-39 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -693,16 +693,16 @@
         overflow: visible;
       }
 
-      .plot-39 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
     <image x="0" y="18" width="240" height="16" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAABBklEQVQ4jW2SwXHkMBADGzMb2EV0gTnGHcAPUhK99gPVaFD6sKj//77SiI5ojkQ08Lo36FzOndfVA00eJzvwIrRybDsKjSlCy3s3de0yLVNsXuHoMqWhZCSjGpBBm5fX3k7W8U2d/Owf6b96dn+YDinjDq6QBleWd3CB7+3qF3VzbtcPTgtX7W2z6kkXrj62JtVYTx+JUXgD7w+OWA68dx+0u3ij5YjR6cVEDLW3WtnbZLnTt/vyFM7qn8zNxi6SJl77T66LzHWhaeI6Lxdc6HC5YBZlrW1WlwuN7rP61UEjytobqx9P6NeTM9RknTn7n1DO9hzuj+71jX340fO4PChrJ7O2g9/scjRovHTSrgAAAABJRU5ErkJggg=="></image>
     <g transform="translate(0,34)" fill="none" text-anchor="middle" font-variant="tabular-nums"></g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">rainbow</text>
-  </svg><svg class="plot-40" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-40 {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -711,7 +711,7 @@
         overflow: visible;
       }
 
-      .plot-40 text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>

--- a/test/output/decathlon.html
+++ b/test/output/decathlon.html
@@ -1,58 +1,47 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
       .plot-swatch>svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
         margin-right: 0.5em;
         overflow: visible;
-        fill: none;
-        fill-opacity: 1;
-        stroke: undefined;
-        stroke-width: 1.5px;
-        stroke-opacity: 1;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#4e79a7" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-      </svg>BLS</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>BLS</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#f28e2c" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
-      </svg>DDR</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>DDR</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#e15759" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
-      </svg>FRG</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>FRG</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#76b7b2" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M0,-5.443L4.714,2.721L-4.714,2.721Z"></path>
-      </svg>GBR</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>GBR</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#59a14f" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M0,4.769L0,-4.769M-4.13,-2.384L4.13,2.384M-4.13,2.384L4.13,-2.384"></path>
-      </svg>SOV</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>SOV</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#edc949" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M3.534,3.534L3.534,-3.534L-3.534,-3.534L-3.534,3.534Z"></path>
-      </svg>TCH</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>TCH</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#af7aa1" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M0,-4.995L4.995,0L0,4.995L-4.995,0Z"></path>
       </svg>USA</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -60,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/dotSort.html
+++ b/test/output/dotSort.html
@@ -28,9 +28,9 @@
     <figcaption>default sort (r desc)</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot-2 {
+        .plot {
           display: block;
           background: white;
           height: auto;
@@ -38,8 +38,8 @@
           max-width: 100%;
         }
 
-        .plot-2 text,
-        .plot-2 tspan {
+        .plot text,
+        .plot tspan {
           white-space: pre;
         }
       </style>
@@ -57,9 +57,9 @@
     <figcaption>sort by r</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot-3" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot-3 {
+        .plot {
           display: block;
           background: white;
           height: auto;
@@ -67,8 +67,8 @@
           max-width: 100%;
         }
 
-        .plot-3 text,
-        .plot-3 tspan {
+        .plot text,
+        .plot tspan {
           white-space: pre;
         }
       </style>
@@ -86,9 +86,9 @@
     <figcaption>null sort</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot-4" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot-4 {
+        .plot {
           display: block;
           background: white;
           height: auto;
@@ -96,8 +96,8 @@
           max-width: 100%;
         }
 
-        .plot-4 text,
-        .plot-4 tspan {
+        .plot text,
+        .plot tspan {
           white-space: pre;
         }
       </style>
@@ -115,9 +115,9 @@
     <figcaption>reverse</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot-5" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot-5 {
+        .plot {
           display: block;
           background: white;
           height: auto;
@@ -125,8 +125,8 @@
           max-width: 100%;
         }
 
-        .plot-5 text,
-        .plot-5 tspan {
+        .plot text,
+        .plot tspan {
           white-space: pre;
         }
       </style>
@@ -144,9 +144,9 @@
     <figcaption>sort by x</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot-6" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot-6 {
+        .plot {
           display: block;
           background: white;
           height: auto;
@@ -154,8 +154,8 @@
           max-width: 100%;
         }
 
-        .plot-6 text,
-        .plot-6 tspan {
+        .plot text,
+        .plot tspan {
           white-space: pre;
         }
       </style>
@@ -173,9 +173,9 @@
     <figcaption>reverse sort by x</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot-7" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot-7 {
+        .plot {
           display: block;
           background: white;
           height: auto;
@@ -183,8 +183,8 @@
           max-width: 100%;
         }
 
-        .plot-7 text,
-        .plot-7 tspan {
+        .plot text,
+        .plot tspan {
           white-space: pre;
         }
       </style>

--- a/test/output/energyProduction.html
+++ b/test/output/energyProduction.html
@@ -1,44 +1,39 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Fossil fuels</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Fossil fuels</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Renewable</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Renewable</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>Nuclear</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -46,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/hexbinR.html
+++ b/test/output/hexbinR.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -33,9 +33,9 @@
       </g>
     </g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">Proportion of each sex (%)</text>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="320" viewBox="0 0 960 320" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="320" viewBox="0 0 960 320" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -43,8 +43,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/hexbinSymbol.html
+++ b/test/output/hexbinSymbol.html
@@ -1,50 +1,39 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
       .plot-swatch>svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
         margin-right: 0.5em;
         overflow: visible;
-        fill: none;
-        fill-opacity: 1;
-        stroke: currentColor;
-        stroke-width: 1.5px;
-        stroke-opacity: 1;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-      </svg>FEMALE</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>FEMALE</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
-      </svg>MALE</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>MALE</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
       </svg>null</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -52,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/hexbinZ.html
+++ b/test/output/hexbinZ.html
@@ -1,44 +1,39 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Adelie</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Adelie</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Chinstrap</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Chinstrap</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>Gentoo</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -46,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/likertSurvey.html
+++ b/test/output/likertSurvey.html
@@ -1,48 +1,43 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="#ca0020" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#ca0020" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Strongly Disagree</span><span class="plot-swatch"><svg fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Strongly Disagree</span><span class="plot-swatch"><svg width="15" height="15" fill="#f4a582" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Disagree</span><span class="plot-swatch"><svg fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Disagree</span><span class="plot-swatch"><svg width="15" height="15" fill="#f7f7f7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Neutral</span><span class="plot-swatch"><svg fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Neutral</span><span class="plot-swatch"><svg width="15" height="15" fill="#92c5de" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Agree</span><span class="plot-swatch"><svg fill="#0571b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Agree</span><span class="plot-swatch"><svg width="15" height="15" fill="#0571b0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>Strongly Agree</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="160" viewBox="0 0 640 160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="160" viewBox="0 0 640 160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -50,8 +45,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/opacityLegend.svg
+++ b/test/output/opacityLegend.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/opacityLegendColor.svg
+++ b/test/output/opacityLegendColor.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/opacityLegendLinear.svg
+++ b/test/output/opacityLegendLinear.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/opacityLegendLog.svg
+++ b/test/output/opacityLegendLog.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/opacityLegendRange.svg
+++ b/test/output/opacityLegendRange.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/opacityLegendSqrt.svg
+++ b/test/output/opacityLegendSqrt.svg
@@ -1,6 +1,6 @@
-<svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    .plot-ramp {
       display: block;
       background: white;
       height: auto;
@@ -9,7 +9,7 @@
       overflow: visible;
     }
 
-    .plot text {
+    .plot-ramp text {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinDensityFill.html
+++ b/test/output/penguinDensityFill.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -33,9 +33,9 @@
       </g>
     </g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">Density</text>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="360" viewBox="0 0 960 360" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="360" viewBox="0 0 960 360" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -43,8 +43,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinDensityZ.html
+++ b/test/output/penguinDensityZ.html
@@ -1,44 +1,39 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Adelie</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Adelie</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Chinstrap</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Chinstrap</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>Gentoo</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="360" viewBox="0 0 960 360" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="360" viewBox="0 0 960 360" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -46,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinFacetDodgeIsland.html
+++ b/test/output/penguinFacetDodgeIsland.html
@@ -1,44 +1,39 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Biscoe</span><span class="plot-swatch"><svg fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Biscoe</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Dream</span><span class="plot-swatch"><svg fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Dream</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>Torgersen</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -46,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinFacetDodgeSymbol.html
+++ b/test/output/penguinFacetDodgeSymbol.html
@@ -1,50 +1,39 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
       .plot-swatch>svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
         margin-right: 0.5em;
         overflow: visible;
-        fill: none;
-        fill-opacity: 1;
-        stroke: undefined;
-        stroke-width: 1.5px;
-        stroke-opacity: 1;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#4e79a7" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-      </svg>Adelie</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Adelie</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#f28e2c" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
-      </svg>Chinstrap</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Chinstrap</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#e15759" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
       </svg>Gentoo</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -52,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinQuantileUnknown.html
+++ b/test/output/penguinQuantileUnknown.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -39,9 +39,9 @@
       </g>
     </g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">body_mass_g</text>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinSizeSymbols.html
+++ b/test/output/penguinSizeSymbols.html
@@ -1,50 +1,39 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
       .plot-swatch>svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
         margin-right: 0.5em;
         overflow: visible;
-        fill: none;
-        fill-opacity: 1;
-        stroke: undefined;
-        stroke-width: 1.5px;
-        stroke-opacity: 1;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#4e79a7" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-      </svg>Adelie</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Adelie</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#f28e2c" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
-      </svg>Chinstrap</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Chinstrap</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#e15759" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
       </svg>Gentoo</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -52,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinSpeciesCheysson.html
+++ b/test/output/penguinSpeciesCheysson.html
@@ -1,44 +1,39 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="url(#grouped-12512014-1)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="url(#grouped-12512014-1)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Adelie</span><span class="plot-swatch"><svg fill="url(#grouped-12512014-2)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Adelie</span><span class="plot-swatch"><svg width="15" height="15" fill="url(#grouped-12512014-2)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>Chinstrap</span><span class="plot-swatch"><svg fill="url(#grouped-12512014-3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>Chinstrap</span><span class="plot-swatch"><svg width="15" height="15" fill="url(#grouped-12512014-3)" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>Gentoo</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -46,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/rasterVapor2.html
+++ b/test/output/rasterVapor2.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -32,9 +32,9 @@
         <text fill="currentColor" y="9" dy="0.71em">6</text>
       </g>
     </g>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -42,8 +42,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/seattleTemperatureAmplitude.html
+++ b/test/output/seattleTemperatureAmplitude.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -40,9 +40,9 @@
         <text fill="currentColor" y="9" dy="0.71em">Nov</text>
       </g>
     </g>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="441.5" viewBox="0 0 640 441.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="441.5" viewBox="0 0 640 441.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -50,8 +50,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/simpsonsViews.html
+++ b/test/output/simpsonsViews.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -44,9 +44,9 @@
       </g>
     </g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">season</text>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -54,8 +54,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/symbolLegendBasic.html
+++ b/test/output/symbolLegendBasic.html
@@ -1,50 +1,39 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: none;
-      fill-opacity: 1;
-      stroke: currentColor;
-      stroke-width: 1.5px;
-      stroke-opacity: 1;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
-    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
-    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-5.443L4.714,2.721L-4.714,2.721Z"></path>
-    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,4.769L0,-4.769M-4.13,-2.384L4.13,2.384M-4.13,2.384L4.13,-2.384"></path>
-    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M3.534,3.534L3.534,-3.534L-3.534,-3.534L-3.534,3.534Z"></path>
     </svg>F</span>
 </div>

--- a/test/output/symbolLegendColorFill.html
+++ b/test/output/symbolLegendColorFill.html
@@ -1,50 +1,39 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: undefined;
-      fill-opacity: 1;
-      stroke: none;
-      stroke-width: 1.5px;
-      stroke-opacity: 1;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#4e79a7" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#f28e2c" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-5.35,-1.783L-1.783,-1.783L-1.783,-5.35L1.783,-5.35L1.783,-1.783L5.35,-1.783L5.35,1.783L1.783,1.783L1.783,5.35L-1.783,5.35L-1.783,1.783L-5.35,1.783Z"></path>
-    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#e15759" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.423L4.285,0L0,7.423L-4.285,0Z"></path>
-    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#76b7b2" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-3.988,-3.988h7.976v7.976h-7.976Z"></path>
-    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#59a14f" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.528L1.69,-2.326L7.16,-2.326L2.735,0.889L4.425,6.09L0,2.875L-4.425,6.09L-2.735,0.889L-7.16,-2.326L-1.69,-2.326Z"></path>
-    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#edc949" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-6.998L6.06,3.499L-6.06,3.499Z"></path>
     </svg>F</span>
 </div>

--- a/test/output/symbolLegendColorStroke.html
+++ b/test/output/symbolLegendColorStroke.html
@@ -1,50 +1,39 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: none;
-      fill-opacity: 1;
-      stroke: undefined;
-      stroke-width: 1.5px;
-      stroke-opacity: 1;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#4e79a7" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#f28e2c" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
-    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#e15759" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
-    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#76b7b2" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-5.443L4.714,2.721L-4.714,2.721Z"></path>
-    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#59a14f" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,4.769L0,-4.769M-4.13,-2.384L4.13,2.384M-4.13,2.384L4.13,-2.384"></path>
-    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#edc949" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M3.534,3.534L3.534,-3.534L-3.534,-3.534L-3.534,3.534Z"></path>
     </svg>F</span>
 </div>

--- a/test/output/symbolLegendDifferentColor.html
+++ b/test/output/symbolLegendDifferentColor.html
@@ -1,50 +1,39 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: currentColor;
-      fill-opacity: 1;
-      stroke: none;
-      stroke-width: 1.5px;
-      stroke-opacity: 1;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="currentColor" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="currentColor" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-5.35,-1.783L-1.783,-1.783L-1.783,-5.35L1.783,-5.35L1.783,-1.783L5.35,-1.783L5.35,1.783L1.783,1.783L1.783,5.35L-1.783,5.35L-1.783,1.783L-5.35,1.783Z"></path>
-    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="currentColor" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.423L4.285,0L0,7.423L-4.285,0Z"></path>
-    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="currentColor" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-3.988,-3.988h7.976v7.976h-7.976Z"></path>
-    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="currentColor" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.528L1.69,-2.326L7.16,-2.326L2.735,0.889L4.425,6.09L0,2.875L-4.425,6.09L-2.735,0.889L-7.16,-2.326L-1.69,-2.326Z"></path>
-    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="currentColor" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-6.998L6.06,3.499L-6.06,3.499Z"></path>
     </svg>F</span>
 </div>

--- a/test/output/symbolLegendExplicitColor.html
+++ b/test/output/symbolLegendExplicitColor.html
@@ -1,50 +1,39 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: undefined;
-      fill-opacity: 1;
-      stroke: none;
-      stroke-width: 1.5px;
-      stroke-opacity: 1;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#4e79a7" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#f28e2c" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-5.35,-1.783L-1.783,-1.783L-1.783,-5.35L1.783,-5.35L1.783,-1.783L5.35,-1.783L5.35,1.783L1.783,1.783L1.783,5.35L-1.783,5.35L-1.783,1.783L-5.35,1.783Z"></path>
-    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#e15759" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.423L4.285,0L0,7.423L-4.285,0Z"></path>
-    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#76b7b2" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-3.988,-3.988h7.976v7.976h-7.976Z"></path>
-    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#59a14f" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.528L1.69,-2.326L7.16,-2.326L2.735,0.889L4.425,6.09L0,2.875L-4.425,6.09L-2.735,0.889L-7.16,-2.326L-1.69,-2.326Z"></path>
-    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#edc949" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-6.998L6.06,3.499L-6.06,3.499Z"></path>
     </svg>F</span>
 </div>

--- a/test/output/symbolLegendFill.html
+++ b/test/output/symbolLegendFill.html
@@ -1,50 +1,39 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: red;
-      fill-opacity: 1;
-      stroke: none;
-      stroke-width: 1.5px;
-      stroke-opacity: 1;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="red" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="red" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-5.35,-1.783L-1.783,-1.783L-1.783,-5.35L1.783,-5.35L1.783,-1.783L5.35,-1.783L5.35,1.783L1.783,1.783L1.783,5.35L-1.783,5.35L-1.783,1.783L-5.35,1.783Z"></path>
-    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="red" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.423L4.285,0L0,7.423L-4.285,0Z"></path>
-    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="red" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-3.988,-3.988h7.976v7.976h-7.976Z"></path>
-    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="red" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.528L1.69,-2.326L7.16,-2.326L2.735,0.889L4.425,6.09L0,2.875L-4.425,6.09L-2.735,0.889L-7.16,-2.326L-1.69,-2.326Z"></path>
-    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="red" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-6.998L6.06,3.499L-6.06,3.499Z"></path>
     </svg>F</span>
 </div>

--- a/test/output/symbolLegendImplicitRange.html
+++ b/test/output/symbolLegendImplicitRange.html
@@ -1,50 +1,39 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: undefined;
-      fill-opacity: 1;
-      stroke: none;
-      stroke-width: 1.5px;
-      stroke-opacity: 1;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#4e79a7" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#f28e2c" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-5.35,-1.783L-1.783,-1.783L-1.783,-5.35L1.783,-5.35L1.783,-1.783L5.35,-1.783L5.35,1.783L1.783,1.783L1.783,5.35L-1.783,5.35L-1.783,1.783L-5.35,1.783Z"></path>
-    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#e15759" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.423L4.285,0L0,7.423L-4.285,0Z"></path>
-    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#76b7b2" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-3.988,-3.988h7.976v7.976h-7.976Z"></path>
-    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#59a14f" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.528L1.69,-2.326L7.16,-2.326L2.735,0.889L4.425,6.09L0,2.875L-4.425,6.09L-2.735,0.889L-7.16,-2.326L-1.69,-2.326Z"></path>
-    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="#edc949" fill-opacity="1" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-6.998L6.06,3.499L-6.06,3.499Z"></path>
     </svg>F</span>
 </div>

--- a/test/output/symbolLegendOpacityColor.html
+++ b/test/output/symbolLegendOpacityColor.html
@@ -1,50 +1,39 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: none;
-      fill-opacity: 1;
-      stroke: undefined;
-      stroke-width: 1.5px;
-      stroke-opacity: 0.5;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#4e79a7" stroke-opacity="0.5" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#f28e2c" stroke-opacity="0.5" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
-    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#e15759" stroke-opacity="0.5" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
-    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#76b7b2" stroke-opacity="0.5" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-5.443L4.714,2.721L-4.714,2.721Z"></path>
-    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#59a14f" stroke-opacity="0.5" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,4.769L0,-4.769M-4.13,-2.384L4.13,2.384M-4.13,2.384L4.13,-2.384"></path>
-    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" stroke="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="#edc949" stroke-opacity="0.5" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M3.534,3.534L3.534,-3.534L-3.534,-3.534L-3.534,3.534Z"></path>
     </svg>F</span>
 </div>

--- a/test/output/symbolLegendOpacityFill.html
+++ b/test/output/symbolLegendOpacityFill.html
@@ -1,44 +1,33 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: red;
-      fill-opacity: 0.5;
-      stroke: none;
-      stroke-width: 1.5px;
-      stroke-opacity: 1;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="red" fill-opacity="0.5" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>Dream</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>Dream</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="red" fill-opacity="0.5" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-5.35,-1.783L-1.783,-1.783L-1.783,-5.35L1.783,-5.35L1.783,-1.783L5.35,-1.783L5.35,1.783L1.783,1.783L1.783,5.35L-1.783,5.35L-1.783,1.783L-5.35,1.783Z"></path>
-    </svg>Torgersen</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>Torgersen</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="red" fill-opacity="0.5" stroke="none" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-7.423L4.285,0L0,7.423L-4.285,0Z"></path>
     </svg>Biscoe</span>
 </div>

--- a/test/output/symbolLegendOpacityStroke.html
+++ b/test/output/symbolLegendOpacityStroke.html
@@ -1,44 +1,33 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: none;
-      fill-opacity: 1;
-      stroke: red;
-      stroke-width: 1.5px;
-      stroke-opacity: 0.5;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="red" stroke-opacity="0.5" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>Dream</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>Dream</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="red" stroke-opacity="0.5" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
-    </svg>Torgersen</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>Torgersen</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="red" stroke-opacity="0.5" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
     </svg>Biscoe</span>
 </div>

--- a/test/output/symbolLegendStroke.html
+++ b/test/output/symbolLegendStroke.html
@@ -1,50 +1,39 @@
-<div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+<div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot {
+    .plot-swatches {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
-      margin-left: 0px;
     }
 
     .plot-swatch>svg {
-      width: var(--swatchWidth);
-      height: var(--swatchHeight);
       margin-right: 0.5em;
       overflow: visible;
-      fill: none;
-      fill-opacity: 1;
-      stroke: red;
-      stroke-width: 1.5px;
-      stroke-opacity: 1;
     }
 
-    .plot {
+    .plot-swatches-wrap {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatch {
+    .plot-swatches-wrap .plot-swatch {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;
     }
-  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </style><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="red" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M4.5,0A4.5,4.5,0,1,1,-4.5,0A4.5,4.5,0,1,1,4.5,0"></path>
-    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>A</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="red" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
-    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>B</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="red" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
-    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>C</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="red" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,-5.443L4.714,2.721L-4.714,2.721Z"></path>
-    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>D</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="red" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M0,4.769L0,-4.769M-4.13,-2.384L4.13,2.384M-4.13,2.384L4.13,-2.384"></path>
-    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </svg>E</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="red" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M3.534,3.534L3.534,-3.534L-3.534,-3.534L-3.534,3.534Z"></path>
     </svg>F</span>
 </div>

--- a/test/output/trafficHorizon.html
+++ b/test/output/trafficHorizon.html
@@ -1,48 +1,43 @@
 <figure style="max-width: initial;">
-  <div class="plot" style="
-        --swatchWidth: 15px;
-        --swatchHeight: 15px;
-      ">
+  <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot {
+      .plot-swatches {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
-        margin-left: 0px;
       }
 
-      .plot-swatch svg {
-        width: var(--swatchWidth);
-        height: var(--swatchHeight);
+      .plot-swatch>svg {
         margin-right: 0.5em;
+        overflow: visible;
       }
 
-      .plot {
+      .plot-swatches-wrap {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatch {
+      .plot-swatches-wrap .plot-swatch {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
       }
-    </style><span class="plot-swatch"><svg fill="#eff3ff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#eff3ff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>≥0</span><span class="plot-swatch"><svg fill="#bdd7e7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>≥0</span><span class="plot-swatch"><svg width="15" height="15" fill="#bdd7e7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>≥2,000</span><span class="plot-swatch"><svg fill="#6baed6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>≥2,000</span><span class="plot-swatch"><svg width="15" height="15" fill="#6baed6" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>≥4,000</span><span class="plot-swatch"><svg fill="#3182bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>≥4,000</span><span class="plot-swatch"><svg width="15" height="15" fill="#3182bd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg>≥6,000</span><span class="plot-swatch"><svg fill="#08519c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      </svg>≥6,000</span><span class="plot-swatch"><svg width="15" height="15" fill="#08519c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
       </svg>≥8,000</span>
-  </div><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="1100" viewBox="0 0 960 1100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="1100" viewBox="0 0 960 1100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -50,8 +45,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/usCountyChoropleth.html
+++ b/test/output/usCountyChoropleth.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -59,9 +59,9 @@
       </g>
     </g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">Unemployment (%)</text>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -69,8 +69,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/output/walmarts.html
+++ b/test/output/walmarts.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;"><svg class="plot" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      .plot-ramp {
         display: block;
         background: white;
         height: auto;
@@ -9,7 +9,7 @@
         overflow: visible;
       }
 
-      .plot text {
+      .plot-ramp text {
         white-space: pre;
       }
     </style>
@@ -33,9 +33,9 @@
       </g>
     </g>
     <text x="0" y="12" fill="currentColor" font-weight="bold">First year opened</text>
-  </svg><svg class="plot-2" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-2 {
+      .plot {
         display: block;
         background: white;
         height: auto;
@@ -43,8 +43,8 @@
         max-width: 100%;
       }
 
-      .plot-2 text,
-      .plot-2 tspan {
+      .plot text,
+      .plot tspan {
         white-space: pre;
       }
     </style>

--- a/test/plot.js
+++ b/test/plot.js
@@ -65,15 +65,13 @@ for (const [name, plot] of Object.entries(plots)) {
 }
 
 function reindexStyle(root) {
-  let index = 0;
+  const uid = "plot-d6a7b5"; // see defaultClassName
   for (const style of root.querySelectorAll("style")) {
-    const name = `plot${index++ ? `-${index}` : ""}`;
     const parent = style.parentNode;
-    const uid = parent.getAttribute("class");
     for (const child of [parent, ...parent.querySelectorAll("[class]")]) {
-      child.setAttribute("class", child.getAttribute("class").replace(new RegExp(`\\b${uid}\\b`, "g"), name));
+      child.setAttribute("class", child.getAttribute("class").replace(new RegExp(`\\b${uid}\\b`, "g"), "plot"));
     }
-    style.textContent = style.textContent.replace(new RegExp(`[.]${uid}`, "g"), `.${name}`);
+    style.textContent = style.textContent.replace(new RegExp(`[.]${uid}\\b`, "g"), `.plot`);
   }
 }
 

--- a/test/style-test.js
+++ b/test/style-test.js
@@ -36,12 +36,7 @@ it("maybeClassName coerces to strings", () => {
   assert.strictEqual(maybeClassName({toString: () => "foo-bar"}), "foo-bar");
 });
 
-it("maybeClassName generates distinct random class names", () => {
-  const names = new Set();
-  for (let i = 0; i < 100; ++i) {
-    const name = maybeClassName();
-    assert.match(name, /^plot-[0-9a-f]{6,}$/);
-    assert.strictEqual(names.has(name), false);
-    names.add(name);
-  }
+it("maybeClassName generates a deterministic class name", () => {
+  assert.strictEqual(maybeClassName(), maybeClassName());
+  assert.strictEqual(maybeClassName(maybeClassName()), maybeClassName());
 });


### PR DESCRIPTION
Adopts a fixed class name as the default, instead of a random one, better determinism by default during server-side rendering. We’ll only need to change the default class name when we change the default styles.

When doing this, note that we now have to be careful that our internal styles don’t conflict. For example, ramp legends, swatches legends, and plots must now have different namespaces for styles. The swatches legend required a few additional changes because it was using a dynamic stylesheet; it now uses inline styles or attributes instead.

Fixes #1433.