### PR TITLE
avoid instanceof Node

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -296,7 +296,7 @@ export function plot(options = {}) {
     figure.appendChild(svg);
     if (caption != null) {
       const figcaption = document.createElement("figcaption");
-      figcaption.appendChild(caption instanceof Node ? caption : document.createTextNode(caption));
+      figcaption.appendChild(caption?.ownerDocument ? caption : document.createTextNode(caption));
       figure.appendChild(figcaption);
     }
   }


### PR DESCRIPTION
During server-side rendering, the global `Node` may not be available. And if the **document** option is used, we don’t want to use the global `Node` in any case. So this switches to a duck test using *node*.ownerDocument instead, which should be sufficiently unambiguous.