### PR TITLE
allow CSS Color Module Level 5

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -1,4 +1,4 @@
-import {color, descending, quantile, range as rangei} from "d3";
+import {descending, quantile, range as rangei} from "d3";
 import {parse as isoParse} from "isoformat";
 import {defined} from "./defined.js";
 import {maybeTimeInterval, maybeUtcInterval} from "./time.js";
@@ -459,20 +459,20 @@ export function isEvery(values, is) {
   return every;
 }
 
-// Mostly relies on d3-color, with a few extra color keywords. Currently this
-// strictly requires that the value be a string; we might want to apply string
-// coercion here, though note that d3-color instances would need to support
-// valueOf to work correctly with InternMap.
+const namedColors = new Set("none,currentcolor,transparent,aliceblue,antiquewhite,aqua,aquamarine,azure,beige,bisque,black,blanchedalmond,blue,blueviolet,brown,burlywood,cadetblue,chartreuse,chocolate,coral,cornflowerblue,cornsilk,crimson,cyan,darkblue,darkcyan,darkgoldenrod,darkgray,darkgreen,darkgrey,darkkhaki,darkmagenta,darkolivegreen,darkorange,darkorchid,darkred,darksalmon,darkseagreen,darkslateblue,darkslategray,darkslategrey,darkturquoise,darkviolet,deeppink,deepskyblue,dimgray,dimgrey,dodgerblue,firebrick,floralwhite,forestgreen,fuchsia,gainsboro,ghostwhite,gold,goldenrod,gray,green,greenyellow,grey,honeydew,hotpink,indianred,indigo,ivory,khaki,lavender,lavenderblush,lawngreen,lemonchiffon,lightblue,lightcoral,lightcyan,lightgoldenrodyellow,lightgray,lightgreen,lightgrey,lightpink,lightsalmon,lightseagreen,lightskyblue,lightslategray,lightslategrey,lightsteelblue,lightyellow,lime,limegreen,linen,magenta,maroon,mediumaquamarine,mediumblue,mediumorchid,mediumpurple,mediumseagreen,mediumslateblue,mediumspringgreen,mediumturquoise,mediumvioletred,midnightblue,mintcream,mistyrose,moccasin,navajowhite,navy,oldlace,olive,olivedrab,orange,orangered,orchid,palegoldenrod,palegreen,paleturquoise,palevioletred,papayawhip,peachpuff,peru,pink,plum,powderblue,purple,rebeccapurple,red,rosybrown,royalblue,saddlebrown,salmon,sandybrown,seagreen,seashell,sienna,silver,skyblue,slateblue,slategray,slategrey,snow,springgreen,steelblue,tan,teal,thistle,tomato,turquoise,violet,wheat,white,whitesmoke,yellow".split(",")); // prettier-ignore
+
+// Returns true if value is a valid CSS color string. This is intentionally lax
+// because the CSS color spec keeps growing, and we don’t need to parse these
+// colors—we just need to disambiguate them from column names.
 // https://www.w3.org/TR/SVG11/painting.html#SpecifyingPaint
+// https://www.w3.org/TR/css-color-5/
 export function isColor(value) {
   if (typeof value !== "string") return false;
   value = value.toLowerCase().trim();
   return (
-    value === "none" ||
-    value === "currentcolor" ||
-    (value.startsWith("url(") && value.endsWith(")")) || // <funciri>, e.g. pattern or gradient
-    (value.startsWith("var(") && value.endsWith(")")) || // CSS variable
-    color(value) !== null
+    /^#[0-9a-f]{3,8}$/.test(value) || // hex rgb, rgba, rrggbb, rrggbbaa
+    /^(?:url|var|rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color|color-mix)\(.*\)$/.test(value) || // <funciri>, CSS variable, color, etc.
+    namedColors.has(value) // currentColor, red, etc.
   );
 }
 

--- a/test/output/varColor.svg
+++ b/test/output/varColor.svg
@@ -1,0 +1,124 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" style="--a: 0.5; --b: rgba(255, 0, 0, var(--a));" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,9.5)">
+    <path transform="translate(40,26)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,46)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,66)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,86)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,106)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,126)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,146)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,166)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,186)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,206)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,226)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,246)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,266)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,286)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,306)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,326)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,346)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,366)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,386)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,406)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,426)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,446)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,466)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,486)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,506)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,526)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" transform="translate(-8.5,9.5)">
+    <text y="0.32em" transform="translate(40,26)">E</text>
+    <text y="0.32em" transform="translate(40,46)">T</text>
+    <text y="0.32em" transform="translate(40,66)">A</text>
+    <text y="0.32em" transform="translate(40,86)">O</text>
+    <text y="0.32em" transform="translate(40,106)">I</text>
+    <text y="0.32em" transform="translate(40,126)">N</text>
+    <text y="0.32em" transform="translate(40,146)">S</text>
+    <text y="0.32em" transform="translate(40,166)">H</text>
+    <text y="0.32em" transform="translate(40,186)">R</text>
+    <text y="0.32em" transform="translate(40,206)">D</text>
+    <text y="0.32em" transform="translate(40,226)">L</text>
+    <text y="0.32em" transform="translate(40,246)">C</text>
+    <text y="0.32em" transform="translate(40,266)">U</text>
+    <text y="0.32em" transform="translate(40,286)">M</text>
+    <text y="0.32em" transform="translate(40,306)">W</text>
+    <text y="0.32em" transform="translate(40,326)">F</text>
+    <text y="0.32em" transform="translate(40,346)">G</text>
+    <text y="0.32em" transform="translate(40,366)">Y</text>
+    <text y="0.32em" transform="translate(40,386)">P</text>
+    <text y="0.32em" transform="translate(40,406)">B</text>
+    <text y="0.32em" transform="translate(40,426)">V</text>
+    <text y="0.32em" transform="translate(40,446)">K</text>
+    <text y="0.32em" transform="translate(40,466)">J</text>
+    <text y="0.32em" transform="translate(40,486)">X</text>
+    <text y="0.32em" transform="translate(40,506)">Q</text>
+    <text y="0.32em" transform="translate(40,526)">Z</text>
+  </g>
+  <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
+    <text y="0.71em" transform="translate(40,285) rotate(-90)">letter</text>
+  </g>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(40,550)" d="M0,0L0,6"></path>
+    <path transform="translate(131.324200913242,550)" d="M0,0L0,6"></path>
+    <path transform="translate(222.64840182648402,550)" d="M0,0L0,6"></path>
+    <path transform="translate(313.972602739726,550)" d="M0,0L0,6"></path>
+    <path transform="translate(405.29680365296804,550)" d="M0,0L0,6"></path>
+    <path transform="translate(496.6210045662101,550)" d="M0,0L0,6"></path>
+    <path transform="translate(587.945205479452,550)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(40,550)">0.00</text>
+    <text y="0.71em" transform="translate(131.324200913242,550)">0.02</text>
+    <text y="0.71em" transform="translate(222.64840182648402,550)">0.04</text>
+    <text y="0.71em" transform="translate(313.972602739726,550)">0.06</text>
+    <text y="0.71em" transform="translate(405.29680365296804,550)">0.08</text>
+    <text y="0.71em" transform="translate(496.6210045662101,550)">0.10</text>
+    <text y="0.71em" transform="translate(587.945205479452,550)">0.12</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,550)">frequency →</text>
+  </g>
+  <g aria-label="bar" fill="var(--b)">
+    <rect x="40" width="580" y="26" height="18"></rect>
+    <rect x="40" width="413.51598173515987" y="46" height="18"></rect>
+    <rect x="40" width="372.9223744292238" y="66" height="18"></rect>
+    <rect x="40" width="342.7853881278539" y="86" height="18"></rect>
+    <rect x="40" width="318.0821917808219" y="106" height="18"></rect>
+    <rect x="40" width="308.17351598173514" y="126" height="18"></rect>
+    <rect x="40" width="288.9041095890411" y="146" height="18"></rect>
+    <rect x="40" width="278.2648401826484" y="166" height="18"></rect>
+    <rect x="40" width="273.37899543378995" y="186" height="18"></rect>
+    <rect x="40" width="194.20091324200914" y="206" height="18"></rect>
+    <rect x="40" width="183.78995433789956" y="226" height="18"></rect>
+    <rect x="40" width="127.03196347031965" y="246" height="18"></rect>
+    <rect x="40" width="125.93607305936072" y="266" height="18"></rect>
+    <rect x="40" width="109.86301369863014" y="286" height="18"></rect>
+    <rect x="40" width="107.76255707762556" y="306" height="18"></rect>
+    <rect x="40" width="104.47488584474888" y="326" height="18"></rect>
+    <rect x="40" width="92.00913242009133" y="346" height="18"></rect>
+    <rect x="40" width="90.13698630136986" y="366" height="18"></rect>
+    <rect x="40" width="88.08219178082192" y="386" height="18"></rect>
+    <rect x="40" width="68.12785388127853" y="406" height="18"></rect>
+    <rect x="40" width="44.65753424657535" y="426" height="18"></rect>
+    <rect x="40" width="35.25114155251143" y="446" height="18"></rect>
+    <rect x="40" width="6.986301369863014" y="466" height="18"></rect>
+    <rect x="40" width="6.849315068493155" y="486" height="18"></rect>
+    <rect x="40" width="4.337899543378995" y="506" height="18"></rect>
+    <rect x="40" width="3.37899543378996" y="526" height="18"></rect>
+  </g>
+</svg>

--- a/test/output/varColor2.svg
+++ b/test/output/varColor2.svg
@@ -1,0 +1,124 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" style="--a: 0.5;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,9.5)">
+    <path transform="translate(40,26)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,46)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,66)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,86)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,106)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,126)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,146)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,166)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,186)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,206)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,226)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,246)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,266)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,286)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,306)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,326)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,346)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,366)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,386)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,406)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,426)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,446)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,466)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,486)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,506)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,526)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" transform="translate(-8.5,9.5)">
+    <text y="0.32em" transform="translate(40,26)">E</text>
+    <text y="0.32em" transform="translate(40,46)">T</text>
+    <text y="0.32em" transform="translate(40,66)">A</text>
+    <text y="0.32em" transform="translate(40,86)">O</text>
+    <text y="0.32em" transform="translate(40,106)">I</text>
+    <text y="0.32em" transform="translate(40,126)">N</text>
+    <text y="0.32em" transform="translate(40,146)">S</text>
+    <text y="0.32em" transform="translate(40,166)">H</text>
+    <text y="0.32em" transform="translate(40,186)">R</text>
+    <text y="0.32em" transform="translate(40,206)">D</text>
+    <text y="0.32em" transform="translate(40,226)">L</text>
+    <text y="0.32em" transform="translate(40,246)">C</text>
+    <text y="0.32em" transform="translate(40,266)">U</text>
+    <text y="0.32em" transform="translate(40,286)">M</text>
+    <text y="0.32em" transform="translate(40,306)">W</text>
+    <text y="0.32em" transform="translate(40,326)">F</text>
+    <text y="0.32em" transform="translate(40,346)">G</text>
+    <text y="0.32em" transform="translate(40,366)">Y</text>
+    <text y="0.32em" transform="translate(40,386)">P</text>
+    <text y="0.32em" transform="translate(40,406)">B</text>
+    <text y="0.32em" transform="translate(40,426)">V</text>
+    <text y="0.32em" transform="translate(40,446)">K</text>
+    <text y="0.32em" transform="translate(40,466)">J</text>
+    <text y="0.32em" transform="translate(40,486)">X</text>
+    <text y="0.32em" transform="translate(40,506)">Q</text>
+    <text y="0.32em" transform="translate(40,526)">Z</text>
+  </g>
+  <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
+    <text y="0.71em" transform="translate(40,285) rotate(-90)">letter</text>
+  </g>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(40,550)" d="M0,0L0,6"></path>
+    <path transform="translate(131.324200913242,550)" d="M0,0L0,6"></path>
+    <path transform="translate(222.64840182648402,550)" d="M0,0L0,6"></path>
+    <path transform="translate(313.972602739726,550)" d="M0,0L0,6"></path>
+    <path transform="translate(405.29680365296804,550)" d="M0,0L0,6"></path>
+    <path transform="translate(496.6210045662101,550)" d="M0,0L0,6"></path>
+    <path transform="translate(587.945205479452,550)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(40,550)">0.00</text>
+    <text y="0.71em" transform="translate(131.324200913242,550)">0.02</text>
+    <text y="0.71em" transform="translate(222.64840182648402,550)">0.04</text>
+    <text y="0.71em" transform="translate(313.972602739726,550)">0.06</text>
+    <text y="0.71em" transform="translate(405.29680365296804,550)">0.08</text>
+    <text y="0.71em" transform="translate(496.6210045662101,550)">0.10</text>
+    <text y="0.71em" transform="translate(587.945205479452,550)">0.12</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,550)">frequency →</text>
+  </g>
+  <g aria-label="bar" fill="rgba(255, 0, 0, var(--a))">
+    <rect x="40" width="580" y="26" height="18"></rect>
+    <rect x="40" width="413.51598173515987" y="46" height="18"></rect>
+    <rect x="40" width="372.9223744292238" y="66" height="18"></rect>
+    <rect x="40" width="342.7853881278539" y="86" height="18"></rect>
+    <rect x="40" width="318.0821917808219" y="106" height="18"></rect>
+    <rect x="40" width="308.17351598173514" y="126" height="18"></rect>
+    <rect x="40" width="288.9041095890411" y="146" height="18"></rect>
+    <rect x="40" width="278.2648401826484" y="166" height="18"></rect>
+    <rect x="40" width="273.37899543378995" y="186" height="18"></rect>
+    <rect x="40" width="194.20091324200914" y="206" height="18"></rect>
+    <rect x="40" width="183.78995433789956" y="226" height="18"></rect>
+    <rect x="40" width="127.03196347031965" y="246" height="18"></rect>
+    <rect x="40" width="125.93607305936072" y="266" height="18"></rect>
+    <rect x="40" width="109.86301369863014" y="286" height="18"></rect>
+    <rect x="40" width="107.76255707762556" y="306" height="18"></rect>
+    <rect x="40" width="104.47488584474888" y="326" height="18"></rect>
+    <rect x="40" width="92.00913242009133" y="346" height="18"></rect>
+    <rect x="40" width="90.13698630136986" y="366" height="18"></rect>
+    <rect x="40" width="88.08219178082192" y="386" height="18"></rect>
+    <rect x="40" width="68.12785388127853" y="406" height="18"></rect>
+    <rect x="40" width="44.65753424657535" y="426" height="18"></rect>
+    <rect x="40" width="35.25114155251143" y="446" height="18"></rect>
+    <rect x="40" width="6.986301369863014" y="466" height="18"></rect>
+    <rect x="40" width="6.849315068493155" y="486" height="18"></rect>
+    <rect x="40" width="4.337899543378995" y="506" height="18"></rect>
+    <rect x="40" width="3.37899543378996" y="526" height="18"></rect>
+  </g>
+</svg>

--- a/test/output/varColorP3.svg
+++ b/test/output/varColorP3.svg
@@ -1,0 +1,124 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,9.5)">
+    <path transform="translate(40,26)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,46)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,66)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,86)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,106)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,126)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,146)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,166)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,186)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,206)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,226)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,246)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,266)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,286)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,306)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,326)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,346)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,366)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,386)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,406)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,426)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,446)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,466)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,486)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,506)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,526)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" transform="translate(-8.5,9.5)">
+    <text y="0.32em" transform="translate(40,26)">E</text>
+    <text y="0.32em" transform="translate(40,46)">T</text>
+    <text y="0.32em" transform="translate(40,66)">A</text>
+    <text y="0.32em" transform="translate(40,86)">O</text>
+    <text y="0.32em" transform="translate(40,106)">I</text>
+    <text y="0.32em" transform="translate(40,126)">N</text>
+    <text y="0.32em" transform="translate(40,146)">S</text>
+    <text y="0.32em" transform="translate(40,166)">H</text>
+    <text y="0.32em" transform="translate(40,186)">R</text>
+    <text y="0.32em" transform="translate(40,206)">D</text>
+    <text y="0.32em" transform="translate(40,226)">L</text>
+    <text y="0.32em" transform="translate(40,246)">C</text>
+    <text y="0.32em" transform="translate(40,266)">U</text>
+    <text y="0.32em" transform="translate(40,286)">M</text>
+    <text y="0.32em" transform="translate(40,306)">W</text>
+    <text y="0.32em" transform="translate(40,326)">F</text>
+    <text y="0.32em" transform="translate(40,346)">G</text>
+    <text y="0.32em" transform="translate(40,366)">Y</text>
+    <text y="0.32em" transform="translate(40,386)">P</text>
+    <text y="0.32em" transform="translate(40,406)">B</text>
+    <text y="0.32em" transform="translate(40,426)">V</text>
+    <text y="0.32em" transform="translate(40,446)">K</text>
+    <text y="0.32em" transform="translate(40,466)">J</text>
+    <text y="0.32em" transform="translate(40,486)">X</text>
+    <text y="0.32em" transform="translate(40,506)">Q</text>
+    <text y="0.32em" transform="translate(40,526)">Z</text>
+  </g>
+  <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
+    <text y="0.71em" transform="translate(40,285) rotate(-90)">letter</text>
+  </g>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(40,550)" d="M0,0L0,6"></path>
+    <path transform="translate(131.324200913242,550)" d="M0,0L0,6"></path>
+    <path transform="translate(222.64840182648402,550)" d="M0,0L0,6"></path>
+    <path transform="translate(313.972602739726,550)" d="M0,0L0,6"></path>
+    <path transform="translate(405.29680365296804,550)" d="M0,0L0,6"></path>
+    <path transform="translate(496.6210045662101,550)" d="M0,0L0,6"></path>
+    <path transform="translate(587.945205479452,550)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(40,550)">0.00</text>
+    <text y="0.71em" transform="translate(131.324200913242,550)">0.02</text>
+    <text y="0.71em" transform="translate(222.64840182648402,550)">0.04</text>
+    <text y="0.71em" transform="translate(313.972602739726,550)">0.06</text>
+    <text y="0.71em" transform="translate(405.29680365296804,550)">0.08</text>
+    <text y="0.71em" transform="translate(496.6210045662101,550)">0.10</text>
+    <text y="0.71em" transform="translate(587.945205479452,550)">0.12</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,550)">frequency →</text>
+  </g>
+  <g aria-label="bar" fill="color(display-p3 1 0.5 0)">
+    <rect x="40" width="580" y="26" height="18"></rect>
+    <rect x="40" width="413.51598173515987" y="46" height="18"></rect>
+    <rect x="40" width="372.9223744292238" y="66" height="18"></rect>
+    <rect x="40" width="342.7853881278539" y="86" height="18"></rect>
+    <rect x="40" width="318.0821917808219" y="106" height="18"></rect>
+    <rect x="40" width="308.17351598173514" y="126" height="18"></rect>
+    <rect x="40" width="288.9041095890411" y="146" height="18"></rect>
+    <rect x="40" width="278.2648401826484" y="166" height="18"></rect>
+    <rect x="40" width="273.37899543378995" y="186" height="18"></rect>
+    <rect x="40" width="194.20091324200914" y="206" height="18"></rect>
+    <rect x="40" width="183.78995433789956" y="226" height="18"></rect>
+    <rect x="40" width="127.03196347031965" y="246" height="18"></rect>
+    <rect x="40" width="125.93607305936072" y="266" height="18"></rect>
+    <rect x="40" width="109.86301369863014" y="286" height="18"></rect>
+    <rect x="40" width="107.76255707762556" y="306" height="18"></rect>
+    <rect x="40" width="104.47488584474888" y="326" height="18"></rect>
+    <rect x="40" width="92.00913242009133" y="346" height="18"></rect>
+    <rect x="40" width="90.13698630136986" y="366" height="18"></rect>
+    <rect x="40" width="88.08219178082192" y="386" height="18"></rect>
+    <rect x="40" width="68.12785388127853" y="406" height="18"></rect>
+    <rect x="40" width="44.65753424657535" y="426" height="18"></rect>
+    <rect x="40" width="35.25114155251143" y="446" height="18"></rect>
+    <rect x="40" width="6.986301369863014" y="466" height="18"></rect>
+    <rect x="40" width="6.849315068493155" y="486" height="18"></rect>
+    <rect x="40" width="4.337899543378995" y="506" height="18"></rect>
+    <rect x="40" width="3.37899543378996" y="526" height="18"></rect>
+  </g>
+</svg>

--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -318,6 +318,7 @@ export * from "./us-retail-sales.js";
 export * from "./us-state-capitals-voronoi.js";
 export * from "./us-state-capitals.js";
 export * from "./us-state-population-change.js";
+export * from "./var-color.js";
 export * from "./vector-field.js";
 export * from "./vector-frame.js";
 export * from "./volcano.js";

--- a/test/plots/var-color.ts
+++ b/test/plots/var-color.ts
@@ -1,0 +1,23 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export async function varColor() {
+  const alphabet = await d3.csv<any>("data/alphabet.csv", d3.autoType);
+  return Plot.plot({
+    style: "--a: 0.5; --b: rgba(255, 0, 0, var(--a));",
+    marks: [Plot.barX(alphabet, {x: "frequency", y: "letter", fill: "var(--b)", sort: {y: "-x"}})]
+  });
+}
+
+export async function varColor2() {
+  const alphabet = await d3.csv<any>("data/alphabet.csv", d3.autoType);
+  return Plot.plot({
+    style: "--a: 0.5;",
+    marks: [Plot.barX(alphabet, {x: "frequency", y: "letter", fill: "rgba(255, 0, 0, var(--a))", sort: {y: "-x"}})]
+  });
+}
+
+export async function varColorP3() {
+  const alphabet = await d3.csv<any>("data/alphabet.csv", d3.autoType);
+  return Plot.barX(alphabet, {x: "frequency", y: "letter", fill: "color(display-p3 1 0.5 0)", sort: {y: "-x"}}).plot();
+}


### PR DESCRIPTION
Ref. https://www.w3.org/TR/css-color-5/

Allows a variety of new ways of specifying colors, including mixing colors:

```
color-mix(in lch, purple 50%, plum 50%)
```

And relative colors:

```
lch(from currentColor calc(1 - l) c h)
```

Though, I can’t really seem to get the latter to work, so probably we should leave this as a draft until it works.

Fixes #1851.