### PR TITLE
fix #1453; axis label and href

### DIFF
--- a/src/marks/axis.js
+++ b/src/marks/axis.js
@@ -2,8 +2,9 @@ import {extent, format, utcFormat} from "d3";
 import {formatDefault} from "../format.js";
 import {marks} from "../mark.js";
 import {radians} from "../math.js";
-import {range, valueof, arrayify, constant, keyword, identity, number} from "../options.js";
-import {isNoneish, isIterable, isTemporal, maybeRangeInterval, orderof} from "../options.js";
+import {arrayify, constant, identity, keyword, number, range, valueof} from "../options.js";
+import {isIterable, isNoneish, isTemporal, orderof} from "../options.js";
+import {maybeColorChannel, maybeNumberChannel, maybeRangeInterval} from "../options.js";
 import {isTemporalScale} from "../scales.js";
 import {offset} from "../style.js";
 import {initializer} from "../transforms/basic.js";
@@ -124,16 +125,9 @@ function axisKy(
         })
       : null,
     !isNoneish(fill) && label !== null
-      ? text([], {
-          fill,
-          fillOpacity,
-          ...options,
-          lineWidth: undefined,
-          textOverflow: undefined,
-          facet: "super",
-          x: null,
-          y: null,
-          initializer: function (data, facets, channels, scales, dimensions) {
+      ? text(
+          [],
+          labelOptions({fill, fillOpacity, ...options}, function (data, facets, channels, scales, dimensions) {
             const scale = scales[k];
             const {marginTop, marginRight, marginBottom, marginLeft} = (k === "y" && dimensions.inset) || dimensions;
             const cla = labelAnchor ?? (scale.bandwidth ? "center" : "top");
@@ -160,8 +154,8 @@ function axisKy(
                 }
               }
             };
-          }
-        })
+          })
+        )
       : null
   );
 }
@@ -233,16 +227,9 @@ function axisKx(
         })
       : null,
     !isNoneish(fill) && label !== null
-      ? text([], {
-          fill,
-          fillOpacity,
-          ...options,
-          lineWidth: undefined,
-          textOverflow: undefined,
-          facet: "super",
-          x: null,
-          y: null,
-          initializer: function (data, facets, channels, scales, dimensions) {
+      ? text(
+          [],
+          labelOptions({fill, fillOpacity, ...options}, function (data, facets, channels, scales, dimensions) {
             const scale = scales[k];
             const {marginTop, marginRight, marginBottom, marginLeft} = (k === "x" && dimensions.inset) || dimensions;
             const cla = labelAnchor ?? (scale.bandwidth ? "center" : "right");
@@ -266,8 +253,8 @@ function axisKx(
                 }
               }
             };
-          }
-        })
+          })
+        )
       : null
   );
 }
@@ -493,6 +480,30 @@ function gridDefaults({
   ...options
 }) {
   return {stroke, strokeOpacity, strokeWidth, ...options};
+}
+
+function labelOptions(
+  {fill, fillOpacity, fontFamily, fontSize, fontStyle, fontWeight, monospace, pointerEvents, shapeRendering},
+  initializer
+) {
+  // Only propagate these options if constant.
+  [, fill] = maybeColorChannel(fill);
+  [, fillOpacity] = maybeNumberChannel(fillOpacity);
+  return {
+    facet: "super",
+    x: null,
+    y: null,
+    fill,
+    fillOpacity,
+    fontFamily,
+    fontSize,
+    fontStyle,
+    fontWeight,
+    monospace,
+    pointerEvents,
+    shapeRendering,
+    initializer
+  };
 }
 
 function axisMark(mark, k, ariaLabel, data, options, initialize) {

--- a/test/output/axisLabelHref.svg
+++ b/test/output/axisLabelHref.svg
@@ -1,0 +1,45 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)"><a fill="inherit" href="https://en.wikipedia.org/wiki/A">
+      <path transform="translate(70,30)" d="M0,0L0,6"></path>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/B">
+      <path transform="translate(170,30)" d="M0,0L0,6"></path>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/C">
+      <path transform="translate(270,30)" d="M0,0L0,6"></path>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/D">
+      <path transform="translate(370,30)" d="M0,0L0,6"></path>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/E">
+      <path transform="translate(470,30)" d="M0,0L0,6"></path>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/F">
+      <path transform="translate(570,30)" d="M0,0L0,6"></path>
+    </a></g>
+  <g aria-label="x-axis tick label" transform="translate(0.5,9.5)"><a fill="inherit" href="https://en.wikipedia.org/wiki/A">
+      <text y="0.71em" transform="translate(70,30)">A</text>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/B">
+      <text y="0.71em" transform="translate(170,30)">B</text>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/C">
+      <text y="0.71em" transform="translate(270,30)">C</text>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/D">
+      <text y="0.71em" transform="translate(370,30)">D</text>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/E">
+      <text y="0.71em" transform="translate(470,30)">E</text>
+    </a><a fill="inherit" href="https://en.wikipedia.org/wiki/F">
+      <text y="0.71em" transform="translate(570,30)">F</text>
+    </a></g>
+  <g aria-label="x-axis label" transform="translate(0.5,27.5)">
+    <text transform="translate(320,30)">Letter</text>
+  </g>
+</svg>

--- a/test/output/axisLabelVaryingFill.svg
+++ b/test/output/axisLabelVaryingFill.svg
@@ -1,0 +1,35 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(70,30)" d="M0,0L0,6"></path>
+    <path transform="translate(170,30)" d="M0,0L0,6"></path>
+    <path transform="translate(270,30)" d="M0,0L0,6"></path>
+    <path transform="translate(370,30)" d="M0,0L0,6"></path>
+    <path transform="translate(470,30)" d="M0,0L0,6"></path>
+    <path transform="translate(570,30)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(70,30)" fill="rgb(35, 23, 27)">A</text>
+    <text y="0.71em" transform="translate(170,30)" fill="rgb(47, 157, 245)">B</text>
+    <text y="0.71em" transform="translate(270,30)" fill="rgb(77, 248, 132)">C</text>
+    <text y="0.71em" transform="translate(370,30)" fill="rgb(222, 221, 50)">D</text>
+    <text y="0.71em" transform="translate(470,30)" fill="rgb(246, 95, 24)">E</text>
+    <text y="0.71em" transform="translate(570,30)" fill="rgb(144, 12, 0)">F</text>
+  </g>
+  <g aria-label="x-axis label" transform="translate(0.5,27.5)">
+    <text transform="translate(320,30)">Letter</text>
+  </g>
+</svg>

--- a/test/plots/axis-labels.ts
+++ b/test/plots/axis-labels.ts
@@ -51,3 +51,17 @@ export async function axisLabelBothReverse() {
     marks: [Plot.ruleX([{x: 0}, {x: 1}], {x: "x"}), Plot.ruleY([{y: 0}, {y: 1}], {y: "y"})]
   });
 }
+
+export async function axisLabelVaryingFill() {
+  return Plot.plot({
+    x: {domain: "ABCDEF"},
+    marks: [Plot.axisX({label: "Letter", fill: (d, i) => i})]
+  });
+}
+
+export async function axisLabelHref() {
+  return Plot.plot({
+    x: {domain: "ABCDEF"},
+    marks: [Plot.axisX({label: "Letter", href: (d) => `https://en.wikipedia.org/wiki/${d}`})]
+  });
+}


### PR DESCRIPTION
Fixes #1453. The problem is that the **href** option was being passed to the axis label mark, too, which presumably caused the mark to be filtered out? I think we might need a more general solution for preventing channels on the singular axis label mark…