### PR TITLE
enter-append instead of join

### DIFF
--- a/src/marks/delaunay.js
+++ b/src/marks/delaunay.js
@@ -108,7 +108,8 @@ class DelaunayLink extends Mark {
       select(this)
         .selectAll()
         .data(newIndex)
-        .join("path")
+        .enter()
+        .append("path")
         .call(applyDirectStyles, mark)
         .attr("d", (i) => {
           const p = path();


### PR DESCRIPTION
This avoids an unnecessary querySelectorAll and compareDocumentPosition call when we know the selection is empty.