### PR TITLE
detect ordinal year intervals

### DIFF
--- a/src/marks/axis.js
+++ b/src/marks/axis.js
@@ -1,4 +1,4 @@
-import {extent, format, utcFormat} from "d3";
+import {extent, format, timeFormat, utcFormat} from "d3";
 import {formatDefault} from "../format.js";
 import {marks} from "../mark.js";
 import {radians} from "../math.js";
@@ -7,6 +7,7 @@ import {isIterable, isNoneish, isTemporal, orderof} from "../options.js";
 import {maybeColorChannel, maybeNumberChannel, maybeRangeInterval} from "../options.js";
 import {isTemporalScale} from "../scales.js";
 import {offset} from "../style.js";
+import {isTimeYear, isUtcYear} from "../time.js";
 import {initializer} from "../transforms/basic.js";
 import {ruleX, ruleY} from "./rule.js";
 import {text, textX, textY} from "./text.js";
@@ -579,7 +580,11 @@ function inferTickFormat(scale, ticks, tickFormat) {
   return scale.tickFormat
     ? scale.tickFormat(isIterable(ticks) ? null : ticks, tickFormat)
     : tickFormat === undefined
-    ? formatDefault
+    ? isUtcYear(scale.interval)
+      ? utcFormat("%Y")
+      : isTimeYear(scale.interval)
+      ? timeFormat("%Y")
+      : formatDefault
     : typeof tickFormat === "string"
     ? (isTemporal(scale.domain()) ? utcFormat : format)(tickFormat)
     : constant(tickFormat);

--- a/src/time.js
+++ b/src/time.js
@@ -70,3 +70,15 @@ export function maybeTimeInterval(interval) {
 export function maybeUtcInterval(interval) {
   return parseInterval(interval, utcIntervals);
 }
+
+export function isUtcYear(i) {
+  if (!i) return false;
+  const date = i.floor(new Date(Date.UTC(2000, 11, 31)));
+  return utcYear(date) >= date;
+}
+
+export function isTimeYear(i) {
+  if (!i) return false;
+  const date = i.floor(new Date(2000, 11, 31));
+  return timeYear(date) >= date;
+}

--- a/src/time.js
+++ b/src/time.js
@@ -74,11 +74,11 @@ export function maybeUtcInterval(interval) {
 export function isUtcYear(i) {
   if (!i) return false;
   const date = i.floor(new Date(Date.UTC(2000, 11, 31)));
-  return utcYear(date) >= date;
+  return utcYear(date) >= date; // coercing equality
 }
 
 export function isTimeYear(i) {
   if (!i) return false;
   const date = i.floor(new Date(2000, 11, 31));
-  return timeYear(date) >= date;
+  return timeYear(date) >= date; // coercing equality
 }

--- a/test/output/internFacetDate.svg
+++ b/test/output/internFacetDate.svg
@@ -15,7 +15,7 @@
   </style>
   <g aria-label="facet" transform="translate(0,0)">
     <g aria-label="fy-axis tick label" text-anchor="start" font-variant="tabular-nums" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(600,85)">1950-01-01</text>
+      <text y="0.32em" transform="translate(600,85)">1950</text>
     </g>
     <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
       <line x1="40" x2="600" y1="125.30000000000001" y2="125.30000000000001"></line>
@@ -60,7 +60,7 @@
   </g>
   <g aria-label="facet" transform="translate(0,144)">
     <g aria-label="fy-axis tick label" text-anchor="start" font-variant="tabular-nums" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(600,85)">1960-01-01</text>
+      <text y="0.32em" transform="translate(600,85)">1960</text>
     </g>
     <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
       <line x1="40" x2="600" y1="125.30000000000001" y2="125.30000000000001"></line>
@@ -170,7 +170,7 @@
   </g>
   <g aria-label="facet" transform="translate(0,288)">
     <g aria-label="fy-axis tick label" text-anchor="start" font-variant="tabular-nums" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(600,85)">1970-01-01</text>
+      <text y="0.32em" transform="translate(600,85)">1970</text>
     </g>
     <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
       <line x1="40" x2="600" y1="125.30000000000001" y2="125.30000000000001"></line>
@@ -593,7 +593,7 @@
   </g>
   <g aria-label="facet" transform="translate(0,432)">
     <g aria-label="fy-axis tick label" text-anchor="start" font-variant="tabular-nums" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(600,85)">1980-01-01</text>
+      <text y="0.32em" transform="translate(600,85)">1980</text>
     </g>
     <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
       <line x1="40" x2="600" y1="125.30000000000001" y2="125.30000000000001"></line>
@@ -5311,7 +5311,7 @@
   </g>
   <g aria-label="facet" transform="translate(0,576)">
     <g aria-label="fy-axis tick label" text-anchor="start" font-variant="tabular-nums" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(600,85)">1990-01-01</text>
+      <text y="0.32em" transform="translate(600,85)">1990</text>
     </g>
     <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
       <line x1="40" x2="600" y1="125.30000000000001" y2="125.30000000000001"></line>
@@ -11005,7 +11005,7 @@
   </g>
   <g aria-label="facet" transform="translate(0,720)">
     <g aria-label="fy-axis tick label" text-anchor="start" font-variant="tabular-nums" transform="translate(9.5,0.5)">
-      <text y="0.32em" transform="translate(600,85)">2000-01-01</text>
+      <text y="0.32em" transform="translate(600,85)">2000</text>
     </g>
     <g aria-label="y-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
       <line x1="40" x2="600" y1="125.30000000000001" y2="125.30000000000001"></line>

--- a/test/output/yearlyRequestsDot.svg
+++ b/test/output/yearlyRequestsDot.svg
@@ -36,29 +36,29 @@
     <text y="0.32em" transform="translate(40,40.58823529411765)">16</text>
   </g>
   <g aria-label="x-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0)">
-    <line x1="80" x2="80" y1="20" y2="370"></line>
-    <line x1="246.51459854014598" x2="246.51459854014598" y1="20" y2="370"></line>
-    <line x1="413.02919708029196" x2="413.02919708029196" y1="20" y2="370"></line>
-    <line x1="580" x2="580" y1="20" y2="370"></line>
+    <line x1="113" x2="113" y1="20" y2="370"></line>
+    <line x1="258" x2="258" y1="20" y2="370"></line>
+    <line x1="403" x2="403" y1="20" y2="370"></line>
+    <line x1="548" x2="548" y1="20" y2="370"></line>
   </g>
   <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
-    <path transform="translate(80,370)" d="M0,0L0,6"></path>
-    <path transform="translate(246.51459854014598,370)" d="M0,0L0,6"></path>
-    <path transform="translate(413.02919708029196,370)" d="M0,0L0,6"></path>
-    <path transform="translate(580,370)" d="M0,0L0,6"></path>
+    <path transform="translate(113,370)" d="M0,0L0,6"></path>
+    <path transform="translate(258,370)" d="M0,0L0,6"></path>
+    <path transform="translate(403,370)" d="M0,0L0,6"></path>
+    <path transform="translate(548,370)" d="M0,0L0,6"></path>
   </g>
   <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
-    <text y="0.71em" transform="translate(80,370)">2002</text>
-    <text y="0.71em" transform="translate(246.51459854014598,370)">2003</text>
-    <text y="0.71em" transform="translate(413.02919708029196,370)">2004</text>
-    <text y="0.71em" transform="translate(580,370)">2005</text>
+    <text y="0.71em" transform="translate(113,370)">2002</text>
+    <text y="0.71em" transform="translate(258,370)">2003</text>
+    <text y="0.71em" transform="translate(403,370)">2004</text>
+    <text y="0.71em" transform="translate(548,370)">2005</text>
   </g>
   <g aria-label="rule" stroke="currentColor" transform="translate(0,0.5)">
     <line x1="40" x2="620" y1="370" y2="370"></line>
   </g>
   <g aria-label="dot" fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(0.5,0.5)">
-    <circle cx="80" cy="184.7058823529412" r="3"></circle>
-    <circle cx="246.51459854014598" cy="20" r="3"></circle>
-    <circle cx="580" cy="267.0588235294117" r="3"></circle>
+    <circle cx="113" cy="184.7058823529412" r="3"></circle>
+    <circle cx="258" cy="20" r="3"></circle>
+    <circle cx="548" cy="267.0588235294117" r="3"></circle>
   </g>
 </svg>

--- a/test/plots/yearly-requests-dot.ts
+++ b/test/plots/yearly-requests-dot.ts
@@ -7,16 +7,8 @@ export async function yearlyRequestsDot() {
     [new Date("2005-01-01"), 5]
   ];
   return Plot.plot({
-    label: null,
-    x: {
-      type: "utc",
-      interval: "year",
-      inset: 40,
-      grid: true
-    },
-    y: {
-      zero: true
-    },
+    x: {type: "point", interval: "year", grid: true},
+    y: {zero: true},
     marks: [Plot.ruleY([0]), Plot.dot(requests)]
   });
 }


### PR DESCRIPTION
If an ordinal scale has a yearly interval, use the appropriate %Y tick format by default, instead of isoformat which adds a trailing -01-01. Ref. https://github.com/observablehq/plot/issues/768#issuecomment-1528924713.