### PR TITLE
tooltip: true

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -5,15 +5,16 @@ import {registry} from "./scales/index.js";
 import {isSymbol, maybeSymbol} from "./symbol.js";
 import {maybeReduce} from "./transforms/group.js";
 
-export function createChannel(data, {scale, type, value, filter, hint}, name) {
-  if (hint === undefined && typeof value?.transform === "function") hint = value.hint;
+export function createChannel(data, channel, name) {
+  if (channel.alias) return channel;
+  const {scale, type, value, filter, hint} = channel;
   return inferChannelScale(name, {
     scale,
     type,
     value: valueof(data, value),
     label: labelof(value),
     filter,
-    hint
+    hint: hint === undefined && typeof value?.transform === "function" ? value.hint : hint
   });
 }
 

--- a/src/mark.d.ts
+++ b/src/mark.d.ts
@@ -438,6 +438,9 @@ export interface MarkOptions {
    * by an **initializer** to declare extra channels.
    */
   channels?: Channels;
+
+  /** TODO */
+  tooltip?: boolean;
 }
 
 /** The abstract base class for Mark implementations. */

--- a/src/mark.js
+++ b/src/mark.js
@@ -14,6 +14,8 @@ export class Mark {
       fx,
       fy,
       sort,
+      tooltip,
+      tooltipAxis,
       dx = 0,
       dy = 0,
       margin = 0,
@@ -25,6 +27,8 @@ export class Mark {
       channels: extraChannels
     } = options;
     this.data = data;
+    this.tooltip = !!tooltip;
+    this.tooltipAxis = tooltipAxis; // TODO validate
     this.sort = isDomainSort(sort) ? sort : null;
     this.initializer = initializer(options).initializer;
     this.transform = this.initializer ? options.transform : basic(options).transform;
@@ -37,7 +41,7 @@ export class Mark {
     }
     this.facetAnchor = maybeFacetAnchor(facetAnchor);
     channels = maybeNamed(channels);
-    if (extraChannels !== undefined) channels = {...maybeNamed(extraChannels), ...channels};
+    if (extraChannels !== undefined) channels = {...channels, ...maybeNamed(extraChannels)};
     if (defaults !== undefined) channels = {...styles(this, options, defaults), ...channels};
     this.channels = Object.fromEntries(
       Object.entries(channels)
@@ -54,8 +58,8 @@ export class Mark {
           }
           return [name, channel];
         })
-        .filter(([name, {value, optional}]) => {
-          if (value != null) return true;
+        .filter(([name, {alias, value, optional}]) => {
+          if (value != null || alias) return true;
           if (optional) return false;
           throw new Error(`missing channel value: ${name}`);
         })

--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -8,54 +8,54 @@ export function stackX(stackOptions = {}, options = {}) {
   if (arguments.length === 1) [stackOptions, options] = mergeOptions(stackOptions);
   const {y1, y = y1, x, ...rest} = options; // note: consumes x!
   const [transform, Y, x1, x2] = stack(y, x, "y", "x", stackOptions, rest);
-  return {...transform, y1, y: Y, x1, x2, x: mid(x1, x2)};
+  return {...transform, y1, y: Y, x1, x2, x: mid(x1, x2), tooltipAxis: "y"};
 }
 
 export function stackX1(stackOptions = {}, options = {}) {
   if (arguments.length === 1) [stackOptions, options] = mergeOptions(stackOptions);
   const {y1, y = y1, x} = options;
   const [transform, Y, X] = stack(y, x, "y", "x", stackOptions, options);
-  return {...transform, y1, y: Y, x: X};
+  return {...transform, y1, y: Y, x: X, tooltipAxis: "y"};
 }
 
 export function stackX2(stackOptions = {}, options = {}) {
   if (arguments.length === 1) [stackOptions, options] = mergeOptions(stackOptions);
   const {y1, y = y1, x} = options;
   const [transform, Y, , X] = stack(y, x, "y", "x", stackOptions, options);
-  return {...transform, y1, y: Y, x: X};
+  return {...transform, y1, y: Y, x: X, tooltipAxis: "y"};
 }
 
 export function stackY(stackOptions = {}, options = {}) {
   if (arguments.length === 1) [stackOptions, options] = mergeOptions(stackOptions);
   const {x1, x = x1, y, ...rest} = options; // note: consumes y!
   const [transform, X, y1, y2] = stack(x, y, "x", "y", stackOptions, rest);
-  return {...transform, x1, x: X, y1, y2, y: mid(y1, y2)};
+  return {...transform, x1, x: X, y1, y2, y: mid(y1, y2), tooltipAxis: "x"};
 }
 
 export function stackY1(stackOptions = {}, options = {}) {
   if (arguments.length === 1) [stackOptions, options] = mergeOptions(stackOptions);
   const {x1, x = x1, y} = options;
   const [transform, X, Y] = stack(x, y, "x", "y", stackOptions, options);
-  return {...transform, x1, x: X, y: Y};
+  return {...transform, x1, x: X, y: Y, tooltipAxis: "x"};
 }
 
 export function stackY2(stackOptions = {}, options = {}) {
   if (arguments.length === 1) [stackOptions, options] = mergeOptions(stackOptions);
   const {x1, x = x1, y} = options;
   const [transform, X, , Y] = stack(x, y, "x", "y", stackOptions, options);
-  return {...transform, x1, x: X, y: Y};
+  return {...transform, x1, x: X, y: Y, tooltipAxis: "x"};
 }
 
 export function maybeStackX({x, x1, x2, ...options} = {}) {
   if (x1 === undefined && x2 === undefined) return stackX({x, ...options});
   [x1, x2] = maybeZero(x, x1, x2);
-  return {...options, x1, x2};
+  return {...options, x1, x2, tooltipAxis: "x"};
 }
 
 export function maybeStackY({y, y1, y2, ...options} = {}) {
   if (y1 === undefined && y2 === undefined) return stackY({y, ...options});
   [y1, y2] = maybeZero(y, y1, y2);
-  return {...options, y1, y2};
+  return {...options, y1, y2, tooltipAxis: "y"};
 }
 
 // The reverse option is ambiguous: it is both a stack option and a basic

--- a/test/plots/tooltip.ts
+++ b/test/plots/tooltip.ts
@@ -5,8 +5,8 @@ export async function tooltipBin() {
   const olympians = await d3.csv<any>("data/athletes.csv", d3.autoType);
   return Plot.plot({
     marks: [
-      Plot.rectY(olympians, Plot.binX({y: "count"}, {x: "weight"})),
-      Plot.tooltip(olympians, Plot.binX({y: "count"}, {x: "weight", axis: "x"}))
+      Plot.rectY(olympians, Plot.binX({y: "count"}, {x: "weight", tooltip: true})),
+      // Plot.tooltip(olympians, Plot.binX({y: "count"}, {x: "weight", axis: "x"}))
     ]
   });
 }


### PR DESCRIPTION
In this branch, I’m trying to figure out how we could provide shorthand syntax for tooltips. So, rather than needing to repeat the channel definitions when declaring a tooltip, we could derive a tooltip from an existing mark (and possibly allow some overrides, say to suppress certain channels from appearing in the tooltip, or altering how the values are formatted).

As a first cut, I recycled the concept of channel aliases from the earlier PR #798. However, I don’t think this will be sufficient for initializers such as hexbin, because initializers can populate channels that are not declared in _mark_.channels, and thus we can’t create static aliases. That suggests that either we’d need to run the initializer on the tooltip mark (which is a bummer because it is duplicate effort and wouldn’t work with a nondeterministic initializer), or the tooltip should instead have a reference to the mark whose channel values we want to show in the tooltip. I think the latter is the way to go, but it’ll require some more plumbing to figure out how that would work… and also we should retain the ability to render an independent tooltip (attached to itself, in effect).

Getting this working is probably a blocker for #1304 because we shouldn’t land the proposed tooltip mark if we’ll have to redesign it substantially to support shorthand. But I think we’re pretty close to figuring this out.