### PR TITLE
restore inline destructuring

### DIFF
--- a/src/marks/arrow.js
+++ b/src/marks/arrow.js
@@ -176,9 +176,8 @@ function circleCircleIntersect([ax, ay, ar], [bx, by, br], sign) {
   return [ax + (dx * x + dy * y) / d, ay + (dy * x - dx * y) / d];
 }
 
-export function arrow(data, options = {}) {
-  let {x, x1, x2, y, y1, y2, ...remainingOptions} = options;
+export function arrow(data, {x, x1, x2, y, y1, y2, ...options} = {}) {
   [x1, x2] = maybeSameValue(x, x1, x2);
   [y1, y2] = maybeSameValue(y, y1, y2);
-  return new Arrow(data, {...remainingOptions, x1, x2, y1, y2});
+  return new Arrow(data, {...options, x1, x2, y1, y2});
 }

--- a/src/marks/box.js
+++ b/src/marks/box.js
@@ -8,10 +8,11 @@ import {dot} from "./dot.js";
 import {ruleX, ruleY} from "./rule.js";
 import {tickX, tickY} from "./tick.js";
 
-export function boxX(data, options = {}) {
-  // Returns a composite mark for producing a horizontal box plot, applying the
-  // necessary statistical transforms. The boxes are grouped by y, if present.
-  const {
+// Returns a composite mark for producing a horizontal box plot, applying the
+// necessary statistical transforms. The boxes are grouped by y, if present.
+export function boxX(
+  data,
+  {
     x = identity,
     y = null,
     fill = "#ccc",
@@ -20,21 +21,23 @@ export function boxX(data, options = {}) {
     strokeOpacity,
     strokeWidth = 2,
     sort,
-    ...remainingOptions
-  } = options;
+    ...options
+  } = {}
+) {
   const group = y != null ? groupY : groupZ;
   return marks(
-    ruleY(data, group({x1: loqr1, x2: hiqr2}, {x, y, stroke, strokeOpacity, ...remainingOptions})),
-    barX(data, group({x1: "p25", x2: "p75"}, {x, y, fill, fillOpacity, ...remainingOptions})),
-    tickX(data, group({x: "p50"}, {x, y, stroke, strokeOpacity, strokeWidth, sort, ...remainingOptions})),
-    dot(data, map({x: oqr}, {x, y, z: y, stroke, strokeOpacity, ...remainingOptions}))
+    ruleY(data, group({x1: loqr1, x2: hiqr2}, {x, y, stroke, strokeOpacity, ...options})),
+    barX(data, group({x1: "p25", x2: "p75"}, {x, y, fill, fillOpacity, ...options})),
+    tickX(data, group({x: "p50"}, {x, y, stroke, strokeOpacity, strokeWidth, sort, ...options})),
+    dot(data, map({x: oqr}, {x, y, z: y, stroke, strokeOpacity, ...options}))
   );
 }
 
-export function boxY(data, options = {}) {
-  // Returns a composite mark for producing a vertical box plot, applying the
-  // necessary statistical transforms. The boxes are grouped by x, if present.
-  const {
+// Returns a composite mark for producing a vertical box plot, applying the
+// necessary statistical transforms. The boxes are grouped by x, if present.
+export function boxY(
+  data,
+  {
     y = identity,
     x = null,
     fill = "#ccc",
@@ -43,14 +46,15 @@ export function boxY(data, options = {}) {
     strokeOpacity,
     strokeWidth = 2,
     sort,
-    ...remainingOptions
-  } = options;
+    ...options
+  } = {}
+) {
   const group = x != null ? groupX : groupZ;
   return marks(
-    ruleX(data, group({y1: loqr1, y2: hiqr2}, {x, y, stroke, strokeOpacity, ...remainingOptions})),
-    barY(data, group({y1: "p25", y2: "p75"}, {x, y, fill, fillOpacity, ...remainingOptions})),
-    tickY(data, group({y: "p50"}, {x, y, stroke, strokeOpacity, strokeWidth, sort, ...remainingOptions})),
-    dot(data, map({y: oqr}, {x, y, z: x, stroke, strokeOpacity, ...remainingOptions}))
+    ruleX(data, group({y1: loqr1, y2: hiqr2}, {x, y, stroke, strokeOpacity, ...options})),
+    barY(data, group({y1: "p25", y2: "p75"}, {x, y, fill, fillOpacity, ...options})),
+    tickY(data, group({y: "p50"}, {x, y, stroke, strokeOpacity, strokeWidth, sort, ...options})),
+    dot(data, map({y: oqr}, {x, y, z: x, stroke, strokeOpacity, ...options}))
   );
 }
 

--- a/src/marks/cell.js
+++ b/src/marks/cell.js
@@ -24,20 +24,17 @@ export class Cell extends AbstractBar {
   }
 }
 
-export function cell(data, options = {}) {
-  let {x, y, ...remainingOptions} = options;
+export function cell(data, {x, y, ...options} = {}) {
   [x, y] = maybeTuple(x, y);
-  return new Cell(data, {...remainingOptions, x, y});
+  return new Cell(data, {...options, x, y});
 }
 
-export function cellX(data, options = {}) {
-  let {x = indexOf, fill, stroke, ...remainingOptions} = options;
+export function cellX(data, {x = indexOf, fill, stroke, ...options} = {}) {
   if (fill === undefined && maybeColorChannel(stroke)[0] === undefined) fill = identity;
-  return new Cell(data, {...remainingOptions, x, fill, stroke});
+  return new Cell(data, {...options, x, fill, stroke});
 }
 
-export function cellY(data, options = {}) {
-  let {y = indexOf, fill, stroke, ...remainingOptions} = options;
+export function cellY(data, {y = indexOf, fill, stroke, ...options} = {}) {
   if (fill === undefined && maybeColorChannel(stroke)[0] === undefined) fill = identity;
-  return new Cell(data, {...remainingOptions, y, fill, stroke});
+  return new Cell(data, {...options, y, fill, stroke});
 }

--- a/src/marks/density.js
+++ b/src/marks/density.js
@@ -66,10 +66,9 @@ export class Density extends Mark {
   }
 }
 
-export function density(data, options = {}) {
-  let {x, y, ...remainingOptions} = options;
+export function density(data, {x, y, ...options} = {}) {
   [x, y] = maybeTuple(x, y);
-  return new Density(data, {...remainingOptions, x, y});
+  return new Density(data, {...options, x, y});
 }
 
 const dropChannels = new Set(["x", "y", "z", "weight"]);

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -132,20 +132,17 @@ export class Dot extends Mark {
   }
 }
 
-export function dot(data, options = {}) {
-  let {x, y, ...remainingOptions} = options;
+export function dot(data, {x, y, ...options} = {}) {
   if (options.frameAnchor === undefined) [x, y] = maybeTuple(x, y);
-  return new Dot(data, {...remainingOptions, x, y});
+  return new Dot(data, {...options, x, y});
 }
 
-export function dotX(data, options = {}) {
-  const {x = identity, ...remainingOptions} = options;
-  return new Dot(data, maybeIntervalMidY({...remainingOptions, x}));
+export function dotX(data, {x = identity, ...options} = {}) {
+  return new Dot(data, maybeIntervalMidY({...options, x}));
 }
 
-export function dotY(data, options = {}) {
-  const {y = identity, ...remainingOptions} = options;
-  return new Dot(data, maybeIntervalMidX({...remainingOptions, y}));
+export function dotY(data, {y = identity, ...options} = {}) {
+  return new Dot(data, maybeIntervalMidX({...options, y}));
 }
 
 export function circle(data, options) {

--- a/src/marks/image.js
+++ b/src/marks/image.js
@@ -127,8 +127,7 @@ function position(X, W, R, x, w, r) {
     : x - r;
 }
 
-export function image(data, options = {}) {
-  let {x, y, ...remainingOptions} = options;
+export function image(data, {x, y, ...options} = {}) {
   if (options.frameAnchor === undefined) [x, y] = maybeTuple(x, y);
-  return new Image(data, {...remainingOptions, x, y});
+  return new Image(data, {...options, x, y});
 }

--- a/src/marks/line.js
+++ b/src/marks/line.js
@@ -99,18 +99,15 @@ function sphereLine(projection, X, Y) {
   };
 }
 
-export function line(data, options = {}) {
-  let {x, y, ...remainingOptions} = options;
+export function line(data, {x, y, ...options} = {}) {
   [x, y] = maybeTuple(x, y);
-  return new Line(data, {...remainingOptions, x, y});
+  return new Line(data, {...options, x, y});
 }
 
-export function lineX(data, options = {}) {
-  const {x = identity, y = indexOf, ...remainingOptions} = options;
-  return new Line(data, maybeDenseIntervalY({...remainingOptions, x, y}));
+export function lineX(data, {x = identity, y = indexOf, ...options} = {}) {
+  return new Line(data, maybeDenseIntervalY({...options, x, y}));
 }
 
-export function lineY(data, options = {}) {
-  const {x = indexOf, y = identity, ...remainingOptions} = options;
-  return new Line(data, maybeDenseIntervalX({...remainingOptions, x, y}));
+export function lineY(data, {x = indexOf, y = identity, ...options} = {}) {
+  return new Line(data, maybeDenseIntervalX({...options, x, y}));
 }

--- a/src/marks/linearRegression.js
+++ b/src/marks/linearRegression.js
@@ -122,26 +122,18 @@ class LinearRegressionY extends LinearRegression {
   }
 }
 
-export function linearRegressionX(data, options = {}) {
-  const {
-    y = indexOf,
-    x = identity,
-    stroke,
-    fill = isNoneish(stroke) ? "currentColor" : stroke,
-    ...remainingOptions
-  } = options;
-  return new LinearRegressionX(data, maybeDenseIntervalY({...remainingOptions, x, y, fill, stroke}));
+export function linearRegressionX(
+  data,
+  {y = indexOf, x = identity, stroke, fill = isNoneish(stroke) ? "currentColor" : stroke, ...options} = {}
+) {
+  return new LinearRegressionX(data, maybeDenseIntervalY({...options, x, y, fill, stroke}));
 }
 
-export function linearRegressionY(data, options = {}) {
-  const {
-    x = indexOf,
-    y = identity,
-    stroke,
-    fill = isNoneish(stroke) ? "currentColor" : stroke,
-    ...remainingOptions
-  } = options;
-  return new LinearRegressionY(data, maybeDenseIntervalX({...remainingOptions, x, y, fill, stroke}));
+export function linearRegressionY(
+  data,
+  {x = indexOf, y = identity, stroke, fill = isNoneish(stroke) ? "currentColor" : stroke, ...options} = {}
+) {
+  return new LinearRegressionY(data, maybeDenseIntervalX({...options, x, y, fill, stroke}));
 }
 
 function linearRegressionF(I, X, Y) {

--- a/src/marks/link.js
+++ b/src/marks/link.js
@@ -86,11 +86,10 @@ function sphereLink(projection, X1, Y1, X2, Y2) {
     });
 }
 
-export function link(data, options = {}) {
-  let {x, x1, x2, y, y1, y2, ...remainingOptions} = options;
+export function link(data, {x, x1, x2, y, y1, y2, ...options} = {}) {
   [x1, x2] = maybeSameValue(x, x1, x2);
   [y1, y2] = maybeSameValue(y, y1, y2);
-  return new Link(data, {...remainingOptions, x1, x2, y1, y2});
+  return new Link(data, {...options, x1, x2, y1, y2});
 }
 
 // If x1 and x2 are specified, return them as {x1, x2}.

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -161,20 +161,17 @@ function applyMultilineText(selection, mark, T, TL) {
   });
 }
 
-export function text(data, options = {}) {
-  let {x, y, ...remainingOptions} = options;
+export function text(data, {x, y, ...options} = {}) {
   if (options.frameAnchor === undefined) [x, y] = maybeTuple(x, y);
-  return new Text(data, {...remainingOptions, x, y});
+  return new Text(data, {...options, x, y});
 }
 
-export function textX(data, options = {}) {
-  const {x = identity, ...remainingOptions} = options;
-  return new Text(data, maybeIntervalMidY({...remainingOptions, x}));
+export function textX(data, {x = identity, ...options} = {}) {
+  return new Text(data, maybeIntervalMidY({...options, x}));
 }
 
-export function textY(data, options = {}) {
-  const {y = identity, ...remainingOptions} = options;
-  return new Text(data, maybeIntervalMidX({...remainingOptions, y}));
+export function textY(data, {y = identity, ...options} = {}) {
+  return new Text(data, maybeIntervalMidX({...options, y}));
 }
 
 export function applyIndirectTextStyles(selection, mark, T) {

--- a/src/marks/tick.js
+++ b/src/marks/tick.js
@@ -100,12 +100,10 @@ export class TickY extends AbstractTick {
   }
 }
 
-export function tickX(data, options = {}) {
-  const {x = identity, ...remainingOptions} = options;
-  return new TickX(data, {...remainingOptions, x});
+export function tickX(data, {x = identity, ...options} = {}) {
+  return new TickX(data, {...options, x});
 }
 
-export function tickY(data, options = {}) {
-  const {y = identity, ...remainingOptions} = options;
-  return new TickY(data, {...remainingOptions, y});
+export function tickY(data, {y = identity, ...options} = {}) {
+  return new TickY(data, {...options, y});
 }

--- a/src/marks/tree.js
+++ b/src/marks/tree.js
@@ -6,8 +6,9 @@ import {dot} from "./dot.js";
 import {link} from "./link.js";
 import {text} from "./text.js";
 
-export function tree(data, options = {}) {
-  let {
+export function tree(
+  data,
+  {
     fill,
     stroke,
     strokeWidth,
@@ -26,9 +27,10 @@ export function tree(data, options = {}) {
     title = "node:path",
     dx,
     dy,
-    ...remainingOptions
-  } = options;
-  if (dx === undefined) dx = maybeTreeAnchor(remainingOptions.treeAnchor).dx;
+    ...options
+  } = {}
+) {
+  if (dx === undefined) dx = maybeTreeAnchor(options.treeAnchor).dx;
   return marks(
     link(
       data,
@@ -43,12 +45,10 @@ export function tree(data, options = {}) {
         strokeMiterlimit,
         strokeDasharray,
         strokeDashoffset,
-        ...remainingOptions
+        ...options
       })
     ),
-    dotDot
-      ? dot(data, treeNode({fill: fill === undefined ? "node:internal" : fill, title, ...remainingOptions}))
-      : null,
+    dotDot ? dot(data, treeNode({fill: fill === undefined ? "node:internal" : fill, title, ...options})) : null,
     textText != null
       ? text(
           data,
@@ -59,7 +59,7 @@ export function tree(data, options = {}) {
             dx,
             dy,
             title,
-            ...remainingOptions
+            ...options
           })
         )
       : null

--- a/src/transforms/bin.js
+++ b/src/transforms/bin.js
@@ -43,22 +43,22 @@ import {
 } from "./group.js";
 import {maybeInsetX, maybeInsetY} from "./inset.js";
 
+// Group on {z, fill, stroke}, then optionally on y, then bin x.
 export function binX(outputs = {y: "count"}, options = {}) {
-  // Group on {z, fill, stroke}, then optionally on y, then bin x.
   [outputs, options] = mergeOptions(outputs, options);
   const {x, y} = options;
   return binn(maybeBinValue(x, options, identity), null, null, y, outputs, maybeInsetX(options));
 }
 
+// Group on {z, fill, stroke}, then optionally on x, then bin y.
 export function binY(outputs = {x: "count"}, options = {}) {
-  // Group on {z, fill, stroke}, then optionally on x, then bin y.
   [outputs, options] = mergeOptions(outputs, options);
   const {x, y} = options;
   return binn(null, maybeBinValue(y, options, identity), x, null, outputs, maybeInsetY(options));
 }
 
+// Group on {z, fill, stroke}, then bin on x and y.
 export function bin(outputs = {fill: "count"}, options = {}) {
-  // Group on {z, fill, stroke}, then bin on x and y.
   [outputs, options] = mergeOptions(outputs, options);
   const {x, y} = maybeBinValueTuple(options);
   return binn(x, y, null, null, outputs, maybeInsetX(maybeInsetY(options)));

--- a/src/transforms/map.js
+++ b/src/transforms/map.js
@@ -2,16 +2,16 @@ import {count, group, rank} from "d3";
 import {column, isObject, maybeInput, maybeZ, take, valueof} from "../options.js";
 import {basic} from "./basic.js";
 
-export function mapX(map, options = {}) {
-  return mapAlias(
-    Object.fromEntries(["x", "x1", "x2"].filter((key) => options[key] != null).map((key) => [key, map])),
+export function mapX(mapper, options = {}) {
+  return map(
+    Object.fromEntries(["x", "x1", "x2"].filter((key) => options[key] != null).map((key) => [key, mapper])),
     options
   );
 }
 
-export function mapY(map, options = {}) {
-  return mapAlias(
-    Object.fromEntries(["y", "y1", "y2"].filter((key) => options[key] != null).map((key) => [key, map])),
+export function mapY(mapper, options = {}) {
+  return map(
+    Object.fromEntries(["y", "y1", "y2"].filter((key) => options[key] != null).map((key) => [key, mapper])),
     options
   );
 }
@@ -39,9 +39,6 @@ export function map(outputs = {}, options = {}) {
     ...Object.fromEntries(channels.map(({key, output}) => [key, output]))
   };
 }
-
-// This is used internally so we can use `map` as an argument name.
-const mapAlias = map;
 
 function maybeMap(map) {
   if (map == null) throw new Error("missing map");

--- a/src/transforms/tree.js
+++ b/src/transforms/tree.js
@@ -3,29 +3,28 @@ import {ascendingDefined} from "../defined.js";
 import {column, identity, isObject, one, valueof} from "../options.js";
 import {basic} from "./basic.js";
 
-export function treeNode(options = {}) {
-  let {
-    path = identity, // the delimited path
-    delimiter, // how the path is separated
-    frameAnchor,
-    treeLayout = tree,
-    treeSort,
-    treeSeparation,
-    treeAnchor,
-    ...remainingOptions
-  } = options;
+export function treeNode({
+  path = identity, // the delimited path
+  delimiter, // how the path is separated
+  frameAnchor,
+  treeLayout = tree,
+  treeSort,
+  treeSeparation,
+  treeAnchor,
+  ...options
+} = {}) {
   treeAnchor = maybeTreeAnchor(treeAnchor);
   treeSort = maybeTreeSort(treeSort);
   if (frameAnchor === undefined) frameAnchor = treeAnchor.frameAnchor;
   const normalize = normalizer(delimiter);
-  const outputs = treeOutputs(remainingOptions, maybeNodeValue);
+  const outputs = treeOutputs(options, maybeNodeValue);
   const [X, setX] = column();
   const [Y, setY] = column();
   return {
     x: X,
     y: Y,
     frameAnchor,
-    ...basic(remainingOptions, (data, facets) => {
+    ...basic(options, (data, facets) => {
       const P = normalize(valueof(data, path));
       const X = setX([]);
       const Y = setY([]);
@@ -56,25 +55,24 @@ export function treeNode(options = {}) {
   };
 }
 
-export function treeLink(options = {}) {
-  let {
-    path = identity, // the delimited path
-    delimiter, // how the path is separated
-    curve = "bump-x",
-    stroke = "#555",
-    strokeWidth = 1.5,
-    strokeOpacity = 0.5,
-    treeLayout = tree,
-    treeSort,
-    treeSeparation,
-    treeAnchor,
-    ...remainingOptions
-  } = options;
+export function treeLink({
+  path = identity, // the delimited path
+  delimiter, // how the path is separated
+  curve = "bump-x",
+  stroke = "#555",
+  strokeWidth = 1.5,
+  strokeOpacity = 0.5,
+  treeLayout = tree,
+  treeSort,
+  treeSeparation,
+  treeAnchor,
+  ...options
+} = {}) {
   treeAnchor = maybeTreeAnchor(treeAnchor);
   treeSort = maybeTreeSort(treeSort);
-  remainingOptions = {curve, stroke, strokeWidth, strokeOpacity, ...remainingOptions};
+  options = {curve, stroke, strokeWidth, strokeOpacity, ...options};
   const normalize = normalizer(delimiter);
-  const outputs = treeOutputs(remainingOptions, maybeLinkValue);
+  const outputs = treeOutputs(options, maybeLinkValue);
   const [X1, setX1] = column();
   const [X2, setX2] = column();
   const [Y1, setY1] = column();
@@ -84,7 +82,7 @@ export function treeLink(options = {}) {
     x2: X2,
     y1: Y1,
     y2: Y2,
-    ...basic(remainingOptions, (data, facets) => {
+    ...basic(options, (data, facets) => {
       const P = normalize(valueof(data, path));
       const X1 = setX1([]);
       const X2 = setX2([]);


### PR DESCRIPTION
This restores function parameter destructuring that was removed in 8065e59af569be9e0c37ec6686e895fa4e9a4471 (#1034); now that we have separate TypeScript declaration files, there’s no obligation that the JavaScript implementation match the public interfaces in TypeScript, so we can write the implementation as we desire.

There are no functional changes here.