### PR TITLE
auto chose rect

### DIFF
--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -91,10 +91,10 @@ export function autoSpec(data, options) {
       break;
     case "line":
       markImpl =
-        (X && Y) || xReduce || yReduce // same logic as area (see below), but default to line
-          ? yZero || yReduce || (X && isMonotonic(X))
+        (X && Y) || xReduce != null || yReduce != null // same logic as area (see below), but default to line
+          ? yZero || yReduce != null || (X && isMonotonic(X))
             ? lineY
-            : xZero || xReduce || (Y && isMonotonic(Y))
+            : xZero || xReduce != null || (Y && isMonotonic(Y))
             ? lineX
             : line
           : X // 1d line by index
@@ -104,7 +104,7 @@ export function autoSpec(data, options) {
       if (isHighCardinality(C)) Z = null; // TODO only if z not set by user
       break;
     case "area":
-      markImpl = !(yZero || yReduce) && (xZero || xReduce || (Y && isMonotonic(Y))) ? areaX : areaY; // favor areaY if unsure
+      markImpl = !(yZero || yReduce != null) && (xZero || xReduce != null || (Y && isMonotonic(Y))) ? areaX : areaY; // favor areaY if unsure
       colorMode = "fill";
       if (isHighCardinality(C)) Z = null; // TODO only if z not set by user
       break;
@@ -127,9 +127,9 @@ export function autoSpec(data, options) {
         ? barY
         : isOrdinalReduced(yReduce, Y)
         ? barX
-        : xReduce && !yReduce
+        : xReduce != null
         ? rectX
-        : yReduce && !xReduce
+        : yReduce != null
         ? rectY
         : rect;
       colorMode = "fill";

--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -9,7 +9,7 @@ import {cell} from "./cell.js";
 import {dot} from "./dot.js";
 import {frame} from "./frame.js";
 import {line, lineX, lineY} from "./line.js";
-import {rectX, rectY} from "./rect.js";
+import {rect, rectX, rectY} from "./rect.js";
 import {ruleX, ruleY} from "./rule.js";
 
 export function autoSpec(data, options) {
@@ -127,7 +127,11 @@ export function autoSpec(data, options) {
         ? barY
         : isOrdinalReduced(yReduce, Y)
         ? barX
-        : rectY;
+        : xReduce && !yReduce
+        ? rectX
+        : yReduce && !xReduce
+        ? rectY
+        : rect;
       colorMode = "fill";
       break;
     default:
@@ -350,6 +354,7 @@ const impls = {
   ruleY,
   barX,
   barY,
+  rect,
   rectX,
   rectY,
   cell,

--- a/test/marks/auto-test.js
+++ b/test/marks/auto-test.js
@@ -227,7 +227,7 @@ it("Plot.autoSpec makes a faceted heatmap", () => {
     color: {value: null, reduce: "count"},
     size: {value: null, reduce: null},
     mark: "bar",
-    markImpl: "rectY",
+    markImpl: "rect",
     markOptions: {
       fx: undefined,
       fy: "f",


### PR DESCRIPTION
The auto was always choosing rectX or rectY, but sometimes we want rect because it has more appropriate pointing behavior. Ref. https://twitter.com/angiehjort/status/1658474295788724229