### PR TITLE
labelArrow option

### DIFF
--- a/docs/features/legends.md
+++ b/docs/features/legends.md
@@ -62,8 +62,8 @@ When an ordinal *color* scale is used redundantly with a *symbol* scale, the *sy
 ```js
 Plot.plot({
   grid: true,
-  x: {label: "Body mass (g) →"},
-  y: {label: "↑ Flipper length (mm)"},
+  x: {label: "Body mass (g)"},
+  y: {label: "Flipper length (mm)"},
   symbol: {legend: true},
   marks: [
     Plot.dot(penguins, {x: "body_mass_g", y: "flipper_length_mm", stroke: "species", symbol: "species"})

--- a/docs/features/scales.md
+++ b/docs/features/scales.md
@@ -935,23 +935,27 @@ For a *band* scale, you can further fine-tune padding:
 
 Align defaults to 0.5 (centered). Band scale padding defaults to 0.1 (10% of available space reserved for separating bands), while point scale padding defaults to 0.5 (the gap between the first point and the edge is half the distance of the gap between points, and likewise for the gap between the last point and the opposite edge). Note that rounding and mark insets (e.g., for bars and rects) also affect separation between adjacent marks.
 
-Plot automatically generates [axis](../marks/axis.md) and optionally [grid](../marks/grid.md) marks for position scales. (For more control, declare these marks explicitly.) You can configure the implicit axes with the following scale options:
+Plot implicitly generates an [axis mark](../marks/axis.md) for position scales if one is not explicitly declared. (For more control, declare the axis mark explicitly.) The following [axis mark options](../marks/axis.md#axis-options) are also available as scale options, applying to the implicit axis:
 
-* **axis** - *top* or *bottom* (or *both*) for *x* and *fx*; *left* or *right* (or *both*) for *y* and *fy*; null to suppress
+* **axis** - the axis **anchor**: *top*, *bottom* (*x* or *fx*); *left*, *right* (*y* or *fy*); *both*; null to suppress
 * **ticks** - the approximate number of ticks to generate, or interval, or array of values
-* **tickSize** - the length of each tick (in pixels; default 6 for *x* and *y*, or 0 for *fx* and *fy*)
 * **tickSpacing** - the approximate number of pixels between ticks (if **ticks** is not specified)
+* **tickSize** - the length of each tick (in pixels; default 6 for *x* and *y*, or 0 for *fx* and *fy*)
 * **tickPadding** - the separation between the tick and its label (in pixels; default 3)
 * **tickFormat** - either a function or specifier string to format tick values; see [Formats](./formats.md)
 * **tickRotate** - whether to rotate tick labels (an angle in degrees clockwise; default 0)
-* **grid** - whether to draw grid lines across the plot for each tick
-* **line** - if true, draw the axis line (only for *x* and *y*)
+* **fontVariant** - the font-variant attribute for ticks; defaults to *tabular-nums* if quantitative
 * **label** - a string to label the axis
 * **labelAnchor** - the label anchor: *top*, *right*, *bottom*, *left*, or *center*
+* **labelArrow** - the label arrow: *auto* (default), *up*, *right*, *down*, *left*, *none*, or true
 * **labelOffset** - the label position offset (in pixels; default depends on margins and orientation)
-* **fontVariant** - the font-variant attribute for ticks; defaults to *tabular-nums* if quantitative
 * **ariaLabel** - a short label representing the axis in the accessibility tree
 * **ariaDescription** - a textual description for the axis
+
+For an implicit [grid mark](../marks/grid.md), use the **grid** option. For an implicit [frame mark](../marks/frame.md) along one edge of the frame, use the **line** option.
+
+* **grid** - whether to draw grid lines across the plot for each tick
+* **line** - if true, draw the axis line (only for *x* and *y*)
 
 Top-level options are also supported as shorthand: **grid** (for *x* and *y* only; see [facets](./facets.md)), **label**, **axis**, **inset**, **round**, **align**, and **padding**. If the **grid** option is true, show a grid using *currentColor*; if specified as a string, show a grid with the specified color; if an approximate number of ticks, an interval, or an array of tick values, show corresponding grid lines.
 

--- a/docs/features/scales.md
+++ b/docs/features/scales.md
@@ -574,7 +574,7 @@ The **transform** scale option allows you to apply a function to all values befo
 Plot.plot({
   y: {
     grid: true,
-    label: `↑ Temperature (°C)`,
+    label: "Temperature (°C)",
     transform: (f) => (f - 32) * (5 / 9) // convert Fahrenheit to Celsius
   },
   marks: [
@@ -624,7 +624,7 @@ Plot.plot({
   },
   y: {
     transform: (d) => d / 1e6,
-    label: "↑ Daily trade volume (millions)"
+    label: "Daily trade volume (millions)"
   },
   marks: [
     Plot.barY(aapl.slice(-40), {x: "Date", y: "Volume"}),
@@ -723,7 +723,7 @@ The **transform** option allows you to apply a function to all values before the
 ```js
 Plot.plot({
   y: {
-    label: "↑ Temperature (°F)",
+    label: "Temperature (°F)",
     transform: (f) => f * 9 / 5 + 32 // convert Celsius to Fahrenheit
   },
   marks: …

--- a/docs/features/transforms.md
+++ b/docs/features/transforms.md
@@ -28,7 +28,7 @@ For example, given a [dataset of highway traffic](https://gist.github.com/chrtze
 ```js
 Plot.plot({
   marginLeft: 120,
-  x: {label: "Vehicles per hour (thousands) →", transform: (x) => x / 1000},
+  x: {label: "Vehicles per hour (thousands)", transform: (x) => x / 1000},
   y: {label: null},
   marks: [
     Plot.ruleX([0]),
@@ -149,7 +149,7 @@ For greater control, you can also implement a custom **transform** function, all
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Unemployment (%)"
+    label: "Unemployment (%)"
   },
   color: {
     domain: [false, true],

--- a/docs/marks/area.md
+++ b/docs/marks/area.md
@@ -67,7 +67,7 @@ When the baseline is not *y* = 0 but instead represents another dimension of dat
 ```js
 Plot.plot({
   y: {
-    label: "↑ Temperature (°F)",
+    label: "Temperature (°F)",
     grid: true
   },
   marks: [
@@ -160,7 +160,7 @@ If a **fill** channel is specified, it is assumed to be ordinal or nominal; data
 Plot.plot({
   y: {
     transform: (d) => d / 1000,
-    label: "↑ Unemployed (thousands)"
+    label: "Unemployed (thousands)"
   },
   marks: [
     Plot.areaY(industries, {x: "date", y: "unemployed", fill: "industry"}),
@@ -181,7 +181,7 @@ Or, as a streamgraph with the **offset** stack transform option:
 Plot.plot({
   y: {
     transform: (d) => d / 1000,
-    label: "↑ Unemployed (thousands)"
+    label: "Unemployed (thousands)"
   },
   marks: [
     Plot.areaY(industries, {x: "date", y: "unemployed", fill: "industry", offset: "wiggle"}),

--- a/docs/marks/arrow.md
+++ b/docs/marks/arrow.md
@@ -23,10 +23,10 @@ Plot.plot({
   inset: 10,
   x: {
     type: "log",
-    label: "Population →"
+    label: "Population"
   },
   y: {
-    label: "↑ Inequality",
+    label: "Inequality",
     ticks: 4
   },
   color: {

--- a/docs/marks/axis.md
+++ b/docs/marks/axis.md
@@ -76,7 +76,7 @@ Plot.plot({
   y: {percent: true},
   marks: [
     Plot.axisX({label: null, lineWidth: 8, marginBottom: 40}),
-    Plot.axisY({label: "↑ Responses (%)"}),
+    Plot.axisY({label: "Responses (%)"}),
     Plot.barY(responses, {x: "name", y: "value"}),
     Plot.ruleY([0])
   ]
@@ -91,7 +91,7 @@ Or, you can use the **textAnchor** option to extend the *y*-axis tick labels to 
 Plot.plot({
   marginTop: 0,
   marginLeft: 4,
-  x: {ticks: 4, label: "Yield (kg) →"},
+  x: {ticks: 4, label: "Yield (kg)"},
   marks: [
     Plot.barX([42, 17, 32], {y: ["🍌 banana", "🍎 apple", "🍐 pear"]}),
     Plot.axisY({textAnchor: "start", fill: "var(--vp-c-bg)", dx: 14})

--- a/docs/marks/axis.md
+++ b/docs/marks/axis.md
@@ -349,19 +349,22 @@ Note that when an axis mark is declared explicitly (via the [**marks** plot opti
 
 In addition to the [standard mark options](../features/marks.md), the axis mark supports the following options:
 
-* **anchor** - the orientation: *top*, *bottom* (*x* or *fx*); *left*, *right* (*y* or *fy*); *both*; null to suppress
+* **anchor** - the axis orientation: *top* or *bottom* for *x* or *fx*; *left* or *right* for *y* or *fy*
 * **tickSize** - the length of the tick vector (in pixels; default 6 for *x* or *y*, or 0 for *fx* or *fy*)
 * **tickPadding** - the separation between the tick vector and its label (in pixels; default 3)
 * **tickFormat** - either a function or specifier string to format tick values; see [Formats](../features/formats.md)
 * **tickRotate** - whether to rotate tick labels (an angle in degrees clockwise; default 0)
-* **fontVariant** - the font-variant attribute for ticks; defaults to tabular-nums for quantitative axes
+* **fontVariant** - the ticks’ font-variant; defaults to *tabular-nums* for quantitative axes
 * **label** - a string to label the axis; defaults to the scale’s label, perhaps with an arrow
 * **labelAnchor** - the label anchor: *top*, *right*, *bottom*, *left*, or *center*
+* **labelArrow** - the label arrow: *auto* (default), *up*, *right*, *down*, *left*, *none*, or true
 * **labelOffset** - the label position offset (in pixels; default depends on margins and orientation)
 * **color** - the color of the ticks and labels (defaults to *currentColor*)
 * **textStroke** - the color of the stroke around tick labels (defaults to *none*)
 * **textStrokeOpacity** - the opacity of the stroke around tick labels
 * **textStrokeWidth** - the thickness of the stroke around tick labels (in pixels)
+
+The **labelArrow** option controls the arrow (↑, →, ↓, or ←) added to the axis label indicating the direction of ascending value; for example, horizontal position *x* typically increases in value going right→, while vertical position *y* typically increases in value going up↑. If *auto* (the default), the arrow will be added only if the scale is quantitative or temporal; if true, the arrow will also apply to ordinal scales, provided the domain is consistently ordered.
 
 As a composite mark, the **stroke** option affects the color of the tick vector, while the **fill** option affects the color the text labels; both default to the **color** option, which defaults to *currentColor*. The **x** and **y** channels, if specified, position the ticks; if not specified, the tick positions depend on the axis **anchor**. The orientation of the tick labels likewise depends on the **anchor**. See the [text mark](./text.md) for details on available options for the tick and axis labels.
 

--- a/docs/marks/bar.md
+++ b/docs/marks/bar.md
@@ -53,7 +53,7 @@ Above, since **y** was specified instead of **y1** and **y2**, the bar spans fro
 ```js
 Plot.plot({
   marginLeft: 60,
-  x: {label: "Frequency →"},
+  x: {label: "Frequency"},
   y: {label: null},
   color: {legend: true},
   marks: [
@@ -201,7 +201,7 @@ Plot.plot({
   marginLeft: 60,
   marginRight: 60,
   label: null,
-  x: {label: "Frequency →"},
+  x: {label: "Frequency"},
   y: {padding: 0},
   marks: [
     Plot.barX(penguins, {fy: "island", y: "sex", x: 1, inset: 0.5}),

--- a/docs/marks/box.md
+++ b/docs/marks/box.md
@@ -65,11 +65,11 @@ Plot.plot({
   marginLeft: 60,
   y: {
     grid: true,
-    label: "↑ Price"
+    label: "Price"
   },
   x: {
     interval: 0.5,
-    label: "Carats →",
+    label: "Carats",
     labelAnchor: "right",
     tickFormat: (x) => x.toFixed(1)
   },
@@ -89,11 +89,11 @@ Plot.plot({
   marginLeft: 60,
   y: {
     grid: true,
-    label: "↑ Price"
+    label: "Price"
   },
   fx: {
     interval: 0.5,
-    label: "Carats →",
+    label: "Carats",
     labelAnchor: "right",
     tickFormat: (x) => x.toFixed(1)
   },

--- a/docs/marks/cell.md
+++ b/docs/marks/cell.md
@@ -95,8 +95,9 @@ Plot.plot({
   x: {
     ticks: simpsons.filter((d) => d.number_in_season === 1).map((d) => d.id),
     tickFormat: (x) => simpsons.find((d) => d.id === x).season,
-    label: "Season →",
-    labelAnchor: "right"
+    label: "Season",
+    labelAnchor: "right",
+    labelArrow: true
   },
   color: {
     type: "linear",

--- a/docs/marks/contour.md
+++ b/docs/marks/contour.md
@@ -91,8 +91,8 @@ We can visualize this small grid directly with a [text mark](./text.md) using th
 ```js
 Plot.plot({
   grid: true,
-  x: {domain: [0, grid.width], label: "column →"},
-  y: {domain: [0, grid.height], label: "↑ row"},
+  x: {domain: [0, grid.width], label: "column"},
+  y: {domain: [0, grid.height], label: "row"},
   marks: [
     Plot.text(grid.values, {
       text: Plot.identity,
@@ -208,8 +208,8 @@ As an alternative to interpolating discrete samples, you can supply values as a 
 ```js
 Plot.plot({
   aspectRatio: 1,
-  x: {tickSpacing: 80, label: "x →"},
-  y: {tickSpacing: 80, label: "↑ y"},
+  x: {tickSpacing: 80, label: "x"},
+  y: {tickSpacing: 80, label: "y"},
   color: {type: "diverging", legend: true, label: "sin(x) cos(y)"},
   marks: [
     Plot.contour({

--- a/docs/marks/dot.md
+++ b/docs/marks/dot.md
@@ -58,8 +58,8 @@ Using a function for **x**, we can instead plot the roughly-linear relationship 
 Plot.plot({
   grid: true,
   inset: 10,
-  x: {label: "Fuel consumption (gallons per 100 miles) →"},
-  y: {label: "↑ Horsepower"},
+  x: {label: "Fuel consumption (gallons per 100 miles)"},
+  y: {label: "Horsepower"},
   marks: [
     Plot.dot(cars, {x: (d) => 100 / d["economy (mpg)"], y: "power (hp)"})
   ]
@@ -75,7 +75,7 @@ Plot.plot({
   y: {
     grid: true,
     tickFormat: "+f",
-    label: "↑ Surface temperature anomaly (°F)"
+    label: "Surface temperature anomaly (°F)"
   },
   color: {
     scheme: "BuRd"
@@ -95,13 +95,13 @@ Dots also support an **r** channel allowing dot size to represent quantitative v
 Plot.plot({
   grid: true,
   x: {
-    label: "Daily change (%) →",
+    label: "Daily change (%)",
     tickFormat: "+f",
     percent: true
   },
   y: {
     type: "log",
-    label: "↑ Daily trading volume"
+    label: "Daily trading volume"
   },
   marks: [
     Plot.ruleX([0]),
@@ -119,8 +119,8 @@ Plot.plot({
   height: 640,
   marginLeft: 60,
   grid: true,
-  x: {label: "Carats →"},
-  y: {label: "↑ Price ($)"},
+  x: {label: "Carats"},
+  y: {label: "Price ($)"},
   r: {range: [0, 20]},
   marks: [
     Plot.dot(diamonds, Plot.bin({r: "count"}, {x: "carat", y: "price", thresholds: 100}))
@@ -166,7 +166,7 @@ Plot.plot({
   grid: true,
   x: {
     axis: "top",
-    label: "Population (%) →",
+    label: "Population (%)",
     percent: true
   },
   color: {
@@ -198,8 +198,8 @@ To improve accessibility, particularly for readers with color vision deficiency,
 ```js
 Plot.plot({
   grid: true,
-  x: {label: "Body mass (g) →"},
-  y: {label: "↑ Flipper length (mm)"},
+  x: {label: "Body mass (g)"},
+  y: {label: "Flipper length (mm)"},
   symbol: {legend: true},
   marks: [
     Plot.dot(penguins, {x: "body_mass_g", y: "flipper_length_mm", stroke: "species", symbol: "species"})
@@ -250,7 +250,7 @@ The dot mark can be combined with the [stack transform](../transforms/stack.md).
 ```js
 Plot.plot({
   aspectRatio: 1,
-  x: {label: "Age (years) →"},
+  x: {label: "Age (years)"},
   y: {
     grid: true,
     label: "← Women · Men →",

--- a/docs/marks/image.md
+++ b/docs/marks/image.md
@@ -21,8 +21,8 @@ The **image mark** draws images centered at the given position in **x** and **y*
 ```js
 Plot.plot({
   inset: 20,
-  x: {label: "First inauguration date →"},
-  y: {grid: true, label: "↑ Net favorability (%)", tickFormat: "+f"},
+  x: {label: "First inauguration date"},
+  y: {grid: true, label: "Net favorability (%)", tickFormat: "+f"},
   marks: [
     Plot.ruleY([0]),
     Plot.image(presidents, {
@@ -44,8 +44,8 @@ With the **r** option, images will be clipped to circles of the given radius. Us
 :::plot defer https://observablehq.com/@observablehq/plot-image-medals
 ```js
 Plot.plot({
-  x: {inset: 20, label: "First inauguration date →"},
-  y: {insetTop: 4, grid: true, label: "↑ Any opinion (%)", tickFormat: "+f"},
+  x: {inset: 20, label: "First inauguration date"},
+  y: {insetTop: 4, grid: true, label: "Any opinion (%)", tickFormat: "+f"},
   marks: [
     Plot.ruleY([0]),
     Plot.image(presidents, {
@@ -95,8 +95,8 @@ The default size of an image is only 16×16 pixels. This may be acceptable if th
 Plot.plot({
   aspectRatio: 1,
   grid: true,
-  x: {label: "Favorable opinion (%) →"},
-  y: {label: "↑ Unfavorable opinion (%)"},
+  x: {label: "Favorable opinion (%)"},
+  y: {label: "Unfavorable opinion (%)"},
   marks: [
     Plot.ruleY([0]),
     Plot.ruleX([0]),

--- a/docs/marks/line.md
+++ b/docs/marks/line.md
@@ -87,10 +87,10 @@ While the *x* scale of a line chart often represents time, this is not required.
 ```js
 Plot.plot({
   x: {
-    label: "Distance from stage start (km) →"
+    label: "Distance from stage start (km)"
   },
   y: {
-    label: "↑ Elevation (m)",
+    label: "Elevation (m)",
     grid: true
   },
   marks: [
@@ -108,8 +108,8 @@ There is no requirement that **y** be dependent on **x**; lines can be used in c
 Plot.plot({
   inset: 10,
   grid: true,
-  x: {label: "Miles driven (per person-year) →"},
-  y: {label: "↑ Cost of gasoline ($ per gallon)"},
+  x: {label: "Miles driven (per person-year)"},
+  y: {label: "Cost of gasoline ($ per gallon)"},
   marks: [
     Plot.line(driving, {x: "miles", y: "gas", curve: "catmull-rom", marker: true}),
     Plot.text(driving, {filter: (d) => d.year % 5 === 0, x: "miles", y: "gas", text: (d) => `${d.year}`, dy: -8})
@@ -125,7 +125,7 @@ To draw multiple lines, use the **z** channel to group [tidy data](https://r4ds.
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Unemployment (%)"
+    label: "Unemployment (%)"
   },
   marks: [
     Plot.ruleY([0]),
@@ -149,7 +149,7 @@ Plot.plot({
   y: {
     type: "log",
     grid: true,
-    label: "↑ Change in price (%)",
+    label: "Change in price (%)",
     tickFormat: ((f) => (x) => f((x - 1) * 100))(d3.format("+d"))
   },
   marks: [
@@ -186,7 +186,7 @@ Plot.plot({
   },
   y: {
     grid: true,
-    label: "↑ Unemployment (%)"
+    label: "Unemployment (%)"
   },
   marks: [
     Plot.ruleY([0]),
@@ -208,7 +208,7 @@ Color encodings can also be used to highlight specific series, such as here to e
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Unemployment (%)"
+    label: "Unemployment (%)"
   },
   color: {
     domain: [false, true],
@@ -237,7 +237,7 @@ As an alternative to **z**, you can render multiple lines using multiple marks. 
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Temperature (°F)"
+    label: "Temperature (°F)"
   },
   marks: [
     Plot.line(sftemp, Plot.windowY(14, {x: "date", y: "low", stroke: "#4e79a7"})),
@@ -286,11 +286,12 @@ While uncommon, you can draw a line with ordinal position values. For example be
 Plot.plot({
   x: {
     domain: stateage.ages, // in age order
-    label: "Age range (years) →",
-    labelAnchor: "right"
+    label: "Age range (years)",
+    labelAnchor: "right",
+    labelArrow: true
   },
   y: {
-    label: "↑ Population (%)",
+    label: "Population (%)",
     percent: true,
     grid: true
   },

--- a/docs/marks/link.md
+++ b/docs/marks/link.md
@@ -31,10 +31,10 @@ Plot.plot({
   inset: 10,
   x: {
     type: "log",
-    label: "Population →"
+    label: "Population"
   },
   y: {
-    label: "↑ Inequality",
+    label: "Inequality",
     ticks: 4
   },
   color: {
@@ -125,12 +125,12 @@ Plot.plot({
   aspectRatio: 1,
   marginRight: 40,
   x: {
-    label: "Median annual income (men, thousands) →",
+    label: "Median annual income (men, thousands)",
     transform: (d) => d / 1000,
     tickSpacing: 60
   },
   y: {
-    label: "↑ Median annual income (women, thousands)",
+    label: "Median annual income (women, thousands)",
     transform: (d) => d / 1000,
     tickSpacing: 60
   },

--- a/docs/marks/raster.md
+++ b/docs/marks/raster.md
@@ -72,8 +72,8 @@ We can visualize this small grid directly with a [text mark](./text.md) using th
 ```js
 Plot.plot({
   grid: true,
-  x: {domain: [0, grid.width], label: "column →"},
-  y: {domain: [0, grid.height], label: "↑ row"},
+  x: {domain: [0, grid.width], label: "column"},
+  y: {domain: [0, grid.height], label: "row"},
   marks: [
     Plot.text(grid.values, {
       text: Plot.identity,

--- a/docs/marks/rect.md
+++ b/docs/marks/rect.md
@@ -146,8 +146,8 @@ Below we recreate an uncommon [chart by Max Roser](https://ourworldindata.org/po
 :::plot defer https://observablehq.com/@observablehq/plot-cumulative-distribution-of-poverty
 ```js
 Plot.plot({
-  x: {label: "Population (millions) →"},
-  y: {percent: true, label: "↑ Proportion living on less than $30 per day (%)"},
+  x: {label: "Population (millions)"},
+  y: {percent: true, label: "Proportion living on less than $30 per day (%)"},
   marks: [
     Plot.rectY(povcalnet, Plot.stackX({
       filter: (d) => ["N", "A"].includes(d.CoverageType),

--- a/docs/marks/rule.md
+++ b/docs/marks/rule.md
@@ -46,7 +46,7 @@ Plot.plot({
   y: {
     type: "log",
     grid: true,
-    label: "↑ Change in price (%)",
+    label: "Change in price (%)",
     tickFormat: ((f) => (d) => f((d - 1) * 100))(d3.format("+d"))
   },
   marks: [
@@ -79,7 +79,7 @@ Rules can also serve as an alternative to an [area mark](./area.md) as in a band
 :::plot defer
 ```js
 Plot.plot({
-  y: {grid: true, label: "↑ Temperature (°C)"},
+  y: {grid: true, label: "Temperature (°C)"},
   color: {scheme: "BuRd"},
   marks: [
     Plot.ruleY([0]),
@@ -96,7 +96,7 @@ In the dense [candlestick chart](https://observablehq.com/@observablehq/observab
 Plot.plot({
   inset: 6,
   label: null,
-  y: {grid: true, label: "↑ Stock price ($)"},
+  y: {grid: true, label: "Stock price ($)"},
   color: {type: "threshold", range: ["#e41a1c", "#4daf4a"]},
   marks: [
     Plot.ruleX(aapl, {x: "Date", y1: "Low", y2: "High"}),

--- a/docs/marks/text.md
+++ b/docs/marks/text.md
@@ -25,7 +25,7 @@ Plot.plot({
   label: null,
   y: {
     grid: true,
-    label: "↑ Frequency (%)",
+    label: "Frequency (%)",
     percent: true
   },
   marks: [
@@ -48,8 +48,8 @@ If there are too many data points, labels may overlap, making them hard to read.
 Plot.plot({
   inset: 10,
   grid: true,
-  x: {label: "Miles driven (per person-year) →"},
-  y: {label: "↑ Cost of gasoline ($ per gallon)"},
+  x: {label: "Miles driven (per person-year)"},
+  y: {label: "Cost of gasoline ($ per gallon)"},
   marks: [
     Plot.line(driving, {x: "miles", y: "gas", curve: "catmull-rom", marker: true}),
     Plot.text(driving, {filter: (d) => d.year % 5 === 0, x: "miles", y: "gas", text: (d) => `${d.year}`, dy: -6, lineAnchor: "bottom"})
@@ -69,7 +69,7 @@ For line charts with multiple series, you may wish to label only the start or en
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Travelers per day (millions)",
+    label: "Travelers per day (millions)",
     transform: (d) => d / 1e6 // convert to millions
   },
   marks: [

--- a/docs/marks/tick.md
+++ b/docs/marks/tick.md
@@ -32,13 +32,13 @@ Ticks are often used to show one-dimensional distributions, as in the “barcode
 Plot.plot({
   x: {
     grid: true,
-    label: "Population (%) →",
+    label: "Population (%)",
     percent: true
   },
   y: {
     domain: stateage.ages, // in age order
     reverse: true,
-    label: "↑ Age (years)",
+    label: "Age (years)",
     labelAnchor: "top"
   },
   marks: [

--- a/docs/transforms/group.md
+++ b/docs/transforms/group.md
@@ -170,7 +170,7 @@ Alternatively, below we use directional arrows (a [link mark](../marks/link.md) 
 Plot.plot({
   marginBottom: 100,
   x: {label: null, tickRotate: 90},
-  y: {grid: true, label: "↑ Frequency"},
+  y: {grid: true, label: "Frequency"},
   color: {type: "categorical", domain: [-1, 1], unknown: "#aaa", transform: Math.sign},
   marks: [
     Plot.ruleY([0]),
@@ -244,7 +244,7 @@ Or, we could group athletes by sport and the number of gold medals 🥇 won. ([M
 Plot.plot({
   marginBottom: 100,
   x: {label: null, tickRotate: 90},
-  y: {label: "↑ gold", labelAnchor: "top", reverse: true},
+  y: {label: "gold", labelAnchor: "top", labelArrow: true, reverse: true},
   color: {type: "sqrt", scheme: "{{$dark ? "turbo" : "YlGnBu"}}"},
   marks: [
     Plot.cell(olympians, Plot.group({fill: "count"}, {x: "sport", y: "gold"}))
@@ -260,7 +260,7 @@ We could instead output **r** and use a [dot mark](../marks/dot.md) whose size a
 Plot.plot({
   marginBottom: 100,
   x: {label: null, tickRotate: 90},
-  y: {type: "point", label: "↑ gold", labelAnchor: "top", reverse: true},
+  y: {type: "point", label: "gold", labelAnchor: "top", labelArrow: true, reverse: true},
   r: {range: [0, 12]},
   marks: [
     Plot.dot(olympians, Plot.group({r: "count"}, {x: "sport", y: "gold"}))
@@ -276,7 +276,7 @@ We can add the **stroke** channel to show overlapping distributions by sex.
 Plot.plot({
   marginBottom: 100,
   x: {label: null, tickRotate: 90},
-  y: {type: "point", label: "↑ gold", labelAnchor: "top", reverse: true},
+  y: {type: "point", label: "gold", labelAnchor: "top", labelArrow: true, reverse: true},
   r: {range: [0, 12]},
   marks: [
     Plot.dot(olympians, Plot.group({r: "count"}, {x: "sport", y: "gold", stroke: "sex"}))

--- a/docs/transforms/interval.md
+++ b/docs/transforms/interval.md
@@ -28,7 +28,7 @@ Plot.plot({
   },
   y: {
     transform: (d) => d / 1e6,
-    label: "↑ Daily trade volume (millions)"
+    label: "Daily trade volume (millions)"
   },
   marks: [
     Plot.barY(aapl.slice(-40), {x: "Date", y: "Volume"}),
@@ -46,7 +46,7 @@ Plot.plot({
   y: {
     grid: true,
     transform: (d) => d / 1e6,
-    label: "↑ Daily trade volume (millions)"
+    label: "Daily trade volume (millions)"
   },
   marks: [
     Plot.rectY(aapl.slice(-40), {x: "Date", interval: "day", y: "Volume"}),
@@ -75,7 +75,7 @@ Plot.plot({
   y: {
     grid: true,
     transform: (d) => d / 1e6,
-    label: "↑ Daily trade volume (millions)"
+    label: "Daily trade volume (millions)"
   },
   marks: [
     Plot.barY(aapl.slice(-40), {x: "Date", y: "Volume", interval: 5e6}),

--- a/docs/transforms/normalize.md
+++ b/docs/transforms/normalize.md
@@ -35,7 +35,7 @@ Plot.plot({
   y: {
     type: "log",
     grid: true,
-    label: "↑ Change in price (%)",
+    label: "Change in price (%)",
     tickFormat: ((f) => (x) => f((x - 1) * 100))(d3.format("+d"))
   },
   marks: [
@@ -78,7 +78,7 @@ Plot.plot({
   grid: true,
   x: {
     axis: "top",
-    label: "Population (%) →",
+    label: "Population (%)",
     percent: true
   },
   color: {

--- a/docs/transforms/sort.md
+++ b/docs/transforms/sort.md
@@ -69,7 +69,7 @@ As another example, in the line chart of unemployment rates below, lines for met
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Unemployment (%)"
+    label: "Unemployment (%)"
   },
   color: {
     domain: [false, true],

--- a/docs/transforms/stack.md
+++ b/docs/transforms/stack.md
@@ -149,7 +149,7 @@ The **order** option controls the order in which the layers are stacked. It defa
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Annual revenue (billions, adj.)",
+    label: "Annual revenue (billions, adj.)",
     transform: (d) => d / 1000 // convert millions to billions
   },
   color: {legend: true},
@@ -179,7 +179,7 @@ The **reverse** option reverses the order of layers. In conjunction with the *ap
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Annual revenue (billions, adj.)",
+    label: "Annual revenue (billions, adj.)",
     transform: (d) => d / 1000 // convert millions to billions
   },
   color: {legend: true},
@@ -202,7 +202,7 @@ The *value* **order** is worth special mention: it sorts each stack by value ind
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Annual revenue (billions, adj.)",
+    label: "Annual revenue (billions, adj.)",
     transform: (d) => d / 1000 // convert millions to billions
   },
   marks: [
@@ -231,7 +231,7 @@ The **offset** option controls the baseline of stacked layers. It defaults to nu
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Annual revenue (billions, adj.)",
+    label: "Annual revenue (billions, adj.)",
     transform: (d) => d / 1000
   },
   marks: [
@@ -251,7 +251,7 @@ The *normalize* **offset** is again worth special mention: it scales stacks to f
 ```js
 Plot.plot({
   y: {
-    label: "↑ Annual revenue (%)",
+    label: "Annual revenue (%)",
     percent: true
   },
   marks: [
@@ -268,7 +268,7 @@ When the provided length (typically **y**) is negative, in conjunction with the 
 ```js
 Plot.plot({
   aspectRatio: 1,
-  x: {label: "Age (years) →"},
+  x: {label: "Age (years)"},
   y: {
     grid: true,
     label: "← Women · Men →",

--- a/docs/transforms/window.md
+++ b/docs/transforms/window.md
@@ -37,7 +37,7 @@ For example, the band chart below shows the daily high and low temperature in Sa
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Temperature (°F)"
+    label: "Temperature (°F)"
   },
   marks: [
     Plot.areaY(sftemp, {x: "date", y1: "low", y2: "high", fillOpacity: 0.3}),
@@ -72,7 +72,7 @@ The **anchor** specifies how to align the rolling window with the data. If *midd
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Temperature (°F)"
+    label: "Temperature (°F)"
   },
   marks: [
     Plot.lineY(sftemp, {x: "date", y: "high", strokeOpacity: 0.3}),
@@ -98,7 +98,7 @@ If **strict** is false (the default), the window size is effectively reduced at 
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Temperature (°F)"
+    label: "Temperature (°F)"
   },
   marks: [
     Plot.lineY(sftemp, {x: "date", y: "low", strokeOpacity: 0.3}),
@@ -117,9 +117,9 @@ The **reduce** option specifies how to compute the output value for the current 
 Plot.plot({
   y: {
     grid: true,
-    label: "↑ Temperature (°F)"
+    label: "Temperature (°F)"
   },
-  marks: [
+marks: [
     Plot.lineY(sftemp, {x: "date", y: "low", strokeOpacity: 0.3}),
     Plot.lineY(sftemp, Plot.windowY({k: 28, reduce: "min"}, {x: "date", y: "low", stroke: "blue"})),
     Plot.lineY(sftemp, Plot.windowY({k: 28, reduce: "max"}, {x: "date", y: "low", stroke: "red"})),

--- a/docs/why-plot.md
+++ b/docs/why-plot.md
@@ -45,8 +45,8 @@ Plot.plot({
   grid: true,
   aspectRatio: 1,
   inset: 10,
-  x: {tickSpacing: 80, label: "Culmen length (mm) →"},
-  y: {tickSpacing: 80, label: "↑ Culmen depth (mm)"},
+  x: {tickSpacing: 80, label: "Culmen length (mm)"},
+  y: {tickSpacing: 80, label: "Culmen depth (mm)"},
   color: {legend: true},
   marks: [
     Plot.frame(),

--- a/src/marks/axis.d.ts
+++ b/src/marks/axis.d.ts
@@ -8,7 +8,7 @@ import type {TickXOptions, TickYOptions} from "./tick.js";
 type GridScaleOptions = Pick<ScaleOptions, "interval" | "ticks" | "tickSpacing">;
 
 /** The subset of scale options for axes. */
-type AxisScaleOptions = Pick<ScaleOptions, "tickSize" | "tickPadding" | "tickFormat" | "tickRotate" | "label" | "labelOffset" | "labelAnchor">; // prettier-ignore
+type AxisScaleOptions = Pick<ScaleOptions, "tickSize" | "tickPadding" | "tickFormat" | "tickRotate" | "label" | "labelOffset" | "labelAnchor" | "labelArrow">; // prettier-ignore
 
 /** Options for the grid marks. */
 export interface GridOptions extends GridScaleOptions {

--- a/src/plot.d.ts
+++ b/src/plot.d.ts
@@ -341,12 +341,12 @@ export interface PlotFacetOptions {
   marginLeft?: number;
 
   /**
-   * default axis grid for fx and fy scales; typically set to true to enable
+   * Default axis grid for fx and fy scales; typically set to true to enable.
    */
   grid?: ScaleOptions["grid"];
 
   /**
-   * default axis label for fx and fy scales; typically set to null to disable
+   * Default axis label for fx and fy scales; typically set to null to disable.
    */
   label?: ScaleOptions["label"];
 }

--- a/src/plot.js
+++ b/src/plot.js
@@ -574,6 +574,7 @@ function axisOptions(
     ariaDescription,
     label = defaults.label,
     labelAnchor,
+    labelArrow = defaults.labelArrow,
     labelOffset
   }
 ) {
@@ -591,6 +592,7 @@ function axisOptions(
     ariaDescription,
     label,
     labelAnchor,
+    labelArrow,
     labelOffset
   };
 }

--- a/src/scales.d.ts
+++ b/src/scales.d.ts
@@ -329,6 +329,15 @@ export interface ScaleDefaults extends InsetOptions {
    * For axes and legends only.
    */
   label?: string | null;
+
+  /**
+   * Whether to apply a directional arrow such as → or ↑ to the scale label. If
+   * *auto* (the default), the presence of the arrow depends on whether the
+   * scale is ordinal.
+   *
+   * For axes only.
+   */
+  labelArrow?: "auto" | "up" | "right" | "down" | "left" | "none" | true | false | null;
 }
 
 /** Options for scales. */

--- a/test/output/axisLabelX.svg
+++ b/test/output/axisLabelX.svg
@@ -41,13 +41,13 @@
     <text transform="translate(614,30)">1.0</text>
   </g>
   <g aria-label="x-axis label" text-anchor="start" transform="translate(-16.5,-26.5)">
-    <text y="0.71em" transform="translate(20,30)">top-left</text>
+    <text y="0.71em" transform="translate(20,30)">top-left →</text>
   </g>
   <g aria-label="x-axis label" transform="translate(0.5,-26.5)">
-    <text y="0.71em" transform="translate(320,30)">top-center</text>
+    <text y="0.71em" transform="translate(320,30)">top-center →</text>
   </g>
   <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,-26.5)">
-    <text y="0.71em" transform="translate(620,30)">top-right</text>
+    <text y="0.71em" transform="translate(620,30)">top-right →</text>
   </g>
   <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
     <path transform="translate(26,370)" d="M0,0L0,6"></path>
@@ -76,12 +76,12 @@
     <text y="0.71em" transform="translate(614,370)">1.0</text>
   </g>
   <g aria-label="x-axis label" text-anchor="start" transform="translate(-16.5,27.5)">
-    <text transform="translate(20,370)">bottom-left</text>
+    <text transform="translate(20,370)">bottom-left →</text>
   </g>
   <g aria-label="x-axis label" transform="translate(0.5,27.5)">
-    <text transform="translate(320,370)">bottom-center</text>
+    <text transform="translate(320,370)">bottom-center →</text>
   </g>
   <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
-    <text transform="translate(620,370)">bottom-right</text>
+    <text transform="translate(620,370)">bottom-right →</text>
   </g>
 </svg>

--- a/test/output/axisLabelY.svg
+++ b/test/output/axisLabelY.svg
@@ -41,13 +41,13 @@
     <text y="0.32em" transform="translate(40,26)">1.0</text>
   </g>
   <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-16.5)">
-    <text y="0.71em" transform="translate(40,20)">left-top</text>
+    <text y="0.71em" transform="translate(40,20)">↑ left-top</text>
   </g>
   <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
-    <text y="0.71em" transform="translate(40,200) rotate(-90)">left-center</text>
+    <text y="0.71em" transform="translate(40,200) rotate(-90)">left-center →</text>
   </g>
   <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,17.5)">
-    <text transform="translate(40,380)">left-bottom</text>
+    <text transform="translate(40,380)">↑ left-bottom</text>
   </g>
   <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(1,0.5)">
     <path transform="translate(600,374)" d="M0,0L6,0"></path>
@@ -76,12 +76,12 @@
     <text y="0.32em" transform="translate(600,26)">1.0</text>
   </g>
   <g aria-label="y-axis label" text-anchor="end" transform="translate(37.5,-16.5)">
-    <text y="0.71em" transform="translate(600,20)">right-top</text>
+    <text y="0.71em" transform="translate(600,20)">right-top ↑</text>
   </g>
   <g aria-label="y-axis label" transform="translate(37.5,0.5)">
-    <text transform="translate(600,200) rotate(-90)">right-center</text>
+    <text transform="translate(600,200) rotate(-90)">right-center →</text>
   </g>
   <g aria-label="y-axis label" text-anchor="end" transform="translate(37.5,17.5)">
-    <text transform="translate(600,380)">right-bottom</text>
+    <text transform="translate(600,380)">right-bottom ↑</text>
   </g>
 </svg>

--- a/test/output/bandClip2.svg
+++ b/test/output/bandClip2.svg
@@ -79,9 +79,6 @@
     <text y="0.71em" transform="translate(430,370)">2022-12-05</text>
     <text y="0.71em" transform="translate(525,370)">2022-12-06</text>
   </g>
-  <g aria-label="x-axis label" transform="translate(0.5,27.5)">
-    <text transform="translate(330,370)">Date</text>
-  </g>
   <g aria-label="rule" stroke="currentColor" transform="translate(0,0.5)">
     <line x1="40" x2="620" y1="370" y2="370"></line>
   </g>

--- a/test/output/boxplotFacetInterval.svg
+++ b/test/output/boxplotFacetInterval.svg
@@ -84,7 +84,7 @@
     </g>
   </g>
   <g aria-label="fy-axis label" transform="translate(-36.5,0.5)">
-    <text y="0.71em" transform="translate(40,135.5) rotate(-90)">height</text>
+    <text y="0.71em" transform="translate(40,135.5) rotate(-90)">height →</text>
   </g>
   <g aria-label="x-axis tick" transform="translate(0.5,0)">
     <g fill="none" stroke="currentColor" transform="translate(0,211)">

--- a/test/output/boxplotFacetNegativeInterval.svg
+++ b/test/output/boxplotFacetNegativeInterval.svg
@@ -84,7 +84,7 @@
     </g>
   </g>
   <g aria-label="fy-axis label" transform="translate(-36.5,0.5)">
-    <text y="0.71em" transform="translate(40,135.5) rotate(-90)">height</text>
+    <text y="0.71em" transform="translate(40,135.5) rotate(-90)">height →</text>
   </g>
   <g aria-label="x-axis tick" transform="translate(0.5,0)">
     <g fill="none" stroke="currentColor" transform="translate(0,211)">

--- a/test/output/downloadsOrdinal.svg
+++ b/test/output/downloadsOrdinal.svg
@@ -140,9 +140,6 @@
     <text y="0.32em" transform="translate(890,370) rotate(-90)">Feb 14</text>
     <text y="0.32em" transform="translate(909,370) rotate(-90)">Feb 15</text>
   </g>
-  <g aria-label="x-axis label" transform="translate(0.5,52.5)">
-    <text transform="translate(490,370)">date</text>
-  </g>
   <g aria-label="bar" fill="#ccc">
     <rect x="54" width="17" y="290.45454545454544" height="79.54545454545456"></rect>
     <rect x="73" width="17" y="20" height="350"></rect>

--- a/test/output/internFacetDate.svg
+++ b/test/output/internFacetDate.svg
@@ -34,7 +34,7 @@
     </g>
   </g>
   <g aria-label="fy-axis label" transform="translate(37.5,0.5)">
-    <text transform="translate(600,445) rotate(-90)">date_of_birth</text>
+    <text transform="translate(600,445) rotate(-90)">← date_of_birth</text>
   </g>
   <g aria-label="y-grid" transform="translate(0,0.5)">
     <g stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0)">

--- a/test/output/intervalAwareBin.svg
+++ b/test/output/intervalAwareBin.svg
@@ -77,7 +77,7 @@
     <text y="0.71em" transform="translate(579,370)">170</text>
   </g>
   <g aria-label="x-axis label" transform="translate(0.5,27.5)">
-    <text transform="translate(330,370)">weight</text>
+    <text transform="translate(330,370)">weight →</text>
   </g>
   <g aria-label="bar">
     <rect x="47" width="34" y="321.96078431372547" height="6.862745098039227" fill="rgb(35, 23, 27)"></rect>

--- a/test/output/intervalAwareGroup.svg
+++ b/test/output/intervalAwareGroup.svg
@@ -67,7 +67,7 @@
     <text y="0.71em" transform="translate(567,370)">2000</text>
   </g>
   <g aria-label="x-axis label" transform="translate(0.5,27.5)">
-    <text transform="translate(330,370)">date_of_birth</text>
+    <text transform="translate(330,370)">date_of_birth →</text>
   </g>
   <g aria-label="bar">
     <rect x="47" width="47" y="369.84485815602835" height="0.15514184397164854"></rect>

--- a/test/output/intervalAwareStack.svg
+++ b/test/output/intervalAwareStack.svg
@@ -64,7 +64,7 @@
     <text y="0.71em" transform="translate(567,370)">2000</text>
   </g>
   <g aria-label="x-axis label" transform="translate(0.5,27.5)">
-    <text transform="translate(330,370)">date_of_birth</text>
+    <text transform="translate(330,370)">date_of_birth →</text>
   </g>
   <g aria-label="bar">
     <rect x="203" width="47" y="369.92242907801415" height="0.07757092198585269"></rect>

--- a/test/output/simpsonsViews.html
+++ b/test/output/simpsonsViews.html
@@ -156,7 +156,7 @@
       <text y="0.71em" transform="translate(589.8297872340427,610)">9.0</text>
     </g>
     <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
-      <text transform="translate(620,610)">IMDB rating →</text>
+      <text transform="translate(620,610)">IMDb rating →</text>
     </g>
     <g aria-label="rule" stroke="currentColor" transform="translate(0,0.5)">
       <line x1="40" x2="620" y1="610" y2="610"></line>

--- a/test/output/sparseCell.svg
+++ b/test/output/sparseCell.svg
@@ -104,7 +104,7 @@
     <text y="0.32em" transform="translate(40,599)">28</text>
   </g>
   <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
-    <text y="0.71em" transform="translate(40,325) rotate(-90)">Season</text>
+    <text y="0.71em" transform="translate(40,325) rotate(-90)">← Season</text>
   </g>
   <g aria-label="x-grid" stroke="currentColor" stroke-opacity="0.1" transform="translate(13,0)">
     <line x1="45" x2="45" y1="30" y2="620"></line>
@@ -179,7 +179,7 @@
     <text transform="translate(591,30)">22</text>
   </g>
   <g aria-label="x-axis label" transform="translate(0.5,-26.5)">
-    <text y="0.71em" transform="translate(330,30)">Episode</text>
+    <text y="0.71em" transform="translate(330,30)">Episode →</text>
   </g>
   <g aria-label="cell">
     <rect x="45" width="25" y="32" height="20" fill="rgb(155, 206, 100)"></rect>

--- a/test/output/textOverflowClip.svg
+++ b/test/output/textOverflowClip.svg
@@ -30,7 +30,7 @@
     <text y="0.71em" transform="translate(446,700)">100</text>
   </g>
   <g aria-label="x-axis label" text-anchor="end" transform="translate(51.5,27.5)">
-    <text transform="translate(446,700)">opinion (%)</text>
+    <text transform="translate(446,700)">opinion (%) →</text>
   </g>
   <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,7.5)">
     <path transform="translate(95,23)" d="M0,0L-6,0"></path>

--- a/test/output/textOverflowEllipsis.svg
+++ b/test/output/textOverflowEllipsis.svg
@@ -30,7 +30,7 @@
     <text y="0.71em" transform="translate(446,700)">100</text>
   </g>
   <g aria-label="x-axis label" text-anchor="end" transform="translate(51.5,27.5)">
-    <text transform="translate(446,700)">opinion (%)</text>
+    <text transform="translate(446,700)">opinion (%) →</text>
   </g>
   <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,7.5)">
     <path transform="translate(95,23)" d="M0,0L-6,0"></path>

--- a/test/output/textOverflowMonospace.svg
+++ b/test/output/textOverflowMonospace.svg
@@ -30,7 +30,7 @@
     <text y="0.71em" transform="translate(446,700)">100</text>
   </g>
   <g aria-label="x-axis label" text-anchor="end" font-family="ui-monospace, monospace" transform="translate(51.5,27.5)">
-    <text transform="translate(446,700)">opinion (%)</text>
+    <text transform="translate(446,700)">opinion (%) →</text>
   </g>
   <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,7.5)">
     <path transform="translate(95,23)" d="M0,0L-6,0"></path>

--- a/test/output/textOverflowNone.svg
+++ b/test/output/textOverflowNone.svg
@@ -30,7 +30,7 @@
     <text y="0.71em" transform="translate(446,1070)">100</text>
   </g>
   <g aria-label="x-axis label" text-anchor="end" transform="translate(51.5,27.5)">
-    <text transform="translate(446,1070)">opinion (%)</text>
+    <text transform="translate(446,1070)">opinion (%) →</text>
   </g>
   <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,11)">
     <path transform="translate(95,29)" d="M0,0L-6,0"></path>

--- a/test/output/tipDotFacets.svg
+++ b/test/output/tipDotFacets.svg
@@ -34,7 +34,7 @@
     </g>
   </g>
   <g aria-label="fy-axis label" transform="translate(37.5,0.5)">
-    <text transform="translate(600,464.5) rotate(-90)">decade of birth</text>
+    <text transform="translate(600,464.5) rotate(-90)">← decade of birth</text>
   </g>
   <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
     <g transform="translate(1,1)">

--- a/test/output/uniformRandomDifference.svg
+++ b/test/output/uniformRandomDifference.svg
@@ -82,7 +82,7 @@
     <text y="0.71em" transform="translate(620,370)">1.0</text>
   </g>
   <g aria-label="x-axis label" transform="translate(0.5,27.5)">
-    <text transform="translate(330,370)">Difference of two uniform random variables</text>
+    <text transform="translate(330,370)">Difference of two uniform random variables →</text>
   </g>
   <g aria-label="rect">
     <rect x="41" y="362.6103646833013" width="13.500000000000014" height="7.389635316698673"></rect>

--- a/test/output/usPresidentFavorabilityDots.svg
+++ b/test/output/usPresidentFavorabilityDots.svg
@@ -53,7 +53,7 @@
     <text y="0.32em" transform="translate(40,54.851485148514854)">+70</text>
   </g>
   <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-16.5)">
-    <text y="0.71em" transform="translate(40,20)">Net favorability (%)</text>
+    <text y="0.71em" transform="translate(40,20)">↑ Net favorability (%)</text>
   </g>
   <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
     <path transform="translate(108.68708351056289,570)" d="M0,0L0,6"></path>
@@ -84,7 +84,7 @@
     <text y="0.71em" transform="translate(906.1789309513682,570)">2020</text>
   </g>
   <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
-    <text transform="translate(940,570)">Date of first inauguration</text>
+    <text transform="translate(940,570)">Date of first inauguration →</text>
   </g>
   <g aria-label="rule" stroke="currentColor" transform="translate(0,0.5)">
     <line x1="40" x2="940" y1="394.4554455445544" y2="394.4554455445544"></line>

--- a/test/output/usRetailSales.svg
+++ b/test/output/usRetailSales.svg
@@ -56,7 +56,7 @@
     <text y="0.32em" transform="translate(40,44.490175521661214)">550</text>
   </g>
   <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-16.5)">
-    <text y="0.71em" transform="translate(40,20)">U.S. retail monthly sales (in billions, seasonally-adjusted)</text>
+    <text y="0.71em" transform="translate(40,20)">↑ U.S. retail monthly sales (in billions, seasonally-adjusted)</text>
   </g>
   <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
     <path transform="translate(100.18557091459951,370)" d="M0,0L0,6"></path>

--- a/test/plots/aapl-candlestick.ts
+++ b/test/plots/aapl-candlestick.ts
@@ -8,7 +8,7 @@ export async function aaplCandlestick() {
     inset: 6,
     grid: true,
     y: {
-      label: "↑ Apple stock price ($)",
+      label: "Apple stock price ($)",
       fontVariant: null
     },
     color: {

--- a/test/plots/aapl-change-volume.ts
+++ b/test/plots/aapl-change-volume.ts
@@ -5,11 +5,11 @@ export async function aaplChangeVolume() {
   const data = await d3.csv<any>("data/aapl.csv", d3.autoType);
   return Plot.plot({
     x: {
-      label: "Daily change (%) →",
+      label: "Daily change (%)",
       tickFormat: "+f"
     },
     y: {
-      label: "↑ Volume (log₁₀)",
+      label: "Volume (log₁₀)",
       transform: Math.log10
     },
     grid: true,

--- a/test/plots/aapl-monthly.ts
+++ b/test/plots/aapl-monthly.ts
@@ -7,7 +7,7 @@ export async function aaplMonthly() {
   return Plot.plot({
     y: {
       transform: (d) => d / 1e6,
-      label: "↑ Daily trade volume (millions)",
+      label: "Daily trade volume (millions)",
       round: true
     },
     marks: [

--- a/test/plots/aapl-volume-rect.ts
+++ b/test/plots/aapl-volume-rect.ts
@@ -7,7 +7,7 @@ export async function aaplVolumeRect() {
     y: {
       grid: true,
       transform: (d) => d / 1e6,
-      label: "↑ Daily trade volume (millions)"
+      label: "Daily trade volume (millions)"
     },
     marks: [
       Plot.rectY(AAPL, {x: "Date", interval: "day", y: "Volume", fill: "#ccc"}),

--- a/test/plots/aapl-volume.ts
+++ b/test/plots/aapl-volume.ts
@@ -6,7 +6,7 @@ export async function aaplVolume() {
   return Plot.plot({
     x: {
       round: true,
-      label: "Trade volume (log₁₀) →"
+      label: "Trade volume (log₁₀)"
     },
     y: {
       grid: true,

--- a/test/plots/athletes-sport-sex.ts
+++ b/test/plots/athletes-sport-sex.ts
@@ -6,7 +6,7 @@ export async function athletesSportSex() {
   return Plot.plot({
     marginLeft: 100,
     x: {
-      label: "Women (%) →",
+      label: "Women (%)",
       domain: [0, 100],
       ticks: 10,
       percent: true,

--- a/test/plots/ballot-status-race.ts
+++ b/test/plots/ballot-status-race.ts
@@ -55,7 +55,7 @@ export async function ballotStatusRace() {
   return Plot.plot({
     x: {
       grid: true,
-      label: "Frequency (%) →"
+      label: "Frequency (%)"
     },
     y: {
       domain: ["ACCEPTED", "REJECTED", "PENDING"],

--- a/test/plots/covid-ihme-projected-deaths.ts
+++ b/test/plots/covid-ihme-projected-deaths.ts
@@ -9,7 +9,7 @@ export async function covidIhmeProjectedDeaths() {
     height: 600,
     y: {
       type: "log",
-      label: "↑ Deaths per day to COVID-19 (projected)",
+      label: "Deaths per day to COVID-19 (projected)",
       tickFormat: ",~f",
       grid: true
     },

--- a/test/plots/d3-survey-2015.ts
+++ b/test/plots/d3-survey-2015.ts
@@ -29,7 +29,7 @@ function bars(groups, title) {
       grid: true,
       axis: "top",
       domain: [0, 100],
-      label: "Frequency (%) →",
+      label: "Frequency (%)",
       transform: (x) => x * 100
     },
     y: {

--- a/test/plots/diamonds-carat-price-dots.ts
+++ b/test/plots/diamonds-carat-price-dots.ts
@@ -8,10 +8,10 @@ export async function diamondsCaratPriceDots() {
     grid: true,
     marginLeft: 44,
     x: {
-      label: "Carats →"
+      label: "Carats"
     },
     y: {
-      label: "↑ Price ($)"
+      label: "Price ($)"
     },
     r: {
       domain: [0, 100],

--- a/test/plots/driving.ts
+++ b/test/plots/driving.ts
@@ -7,10 +7,10 @@ export async function driving() {
     inset: 10,
     grid: true,
     x: {
-      label: "Miles driven (per person-year) →"
+      label: "Miles driven (per person-year)"
     },
     y: {
-      label: "↑ Cost of gasoline ($ per gallon)"
+      label: "Cost of gasoline ($ per gallon)"
     },
     marks: [
       Plot.line(driving, {x: "miles", y: "gas", curve: "catmull-rom", markerMid: "arrow"}),

--- a/test/plots/energy-production.ts
+++ b/test/plots/energy-production.ts
@@ -36,7 +36,7 @@ export async function energyProduction() {
       label: null
     },
     y: {
-      label: "↑ Annual production (quads)"
+      label: "Annual production (quads)"
     },
     color: {
       tickFormat: (t) => types.get(t),

--- a/test/plots/federal-funds.ts
+++ b/test/plots/federal-funds.ts
@@ -6,7 +6,7 @@ export async function federalFunds() {
   return Plot.plot({
     marginLeft: 0, // don’t need left-margin since labels are inset
     x: {label: null, insetLeft: 28}, // reserve space for inset labels
-    y: {label: "↑ Federal funds rate (% per year)"},
+    y: {label: "Federal funds rate (% per year)"},
     marks: [
       Plot.axisY({
         interval: 2, // every 2%

--- a/test/plots/figcaption-html.ts
+++ b/test/plots/figcaption-html.ts
@@ -11,7 +11,7 @@ export async function figcaptionHtml() {
       label: null
     },
     y: {
-      label: "↑ Frequency (%)",
+      label: "Frequency (%)",
       transform: (y) => y * 100,
       grid: true
     },

--- a/test/plots/figcaption.ts
+++ b/test/plots/figcaption.ts
@@ -9,7 +9,7 @@ export async function figcaption() {
       label: null
     },
     y: {
-      label: "↑ Frequency (%)",
+      label: "Frequency (%)",
       transform: (y) => y * 100,
       grid: true
     },

--- a/test/plots/gistemp-anomaly-moving.ts
+++ b/test/plots/gistemp-anomaly-moving.ts
@@ -5,7 +5,7 @@ export async function gistempAnomalyMoving() {
   const data = await d3.csv<any>("data/gistemp.csv", d3.autoType);
   return Plot.plot({
     y: {
-      label: "↑ Temperature anomaly (°C)",
+      label: "Temperature anomaly (°C)",
       tickFormat: "+f",
       grid: true
     },

--- a/test/plots/gistemp-anomaly-transform.ts
+++ b/test/plots/gistemp-anomaly-transform.ts
@@ -6,7 +6,7 @@ export async function gistempAnomalyTransform() {
   const transform = (c) => (c * 9) / 5; // convert (relative) Celsius to Fahrenheit
   return Plot.plot({
     y: {
-      label: "↑ Temperature anomaly (°F)",
+      label: "Temperature anomaly (°F)",
       tickFormat: "+f",
       transform,
       grid: true

--- a/test/plots/gistemp-anomaly.ts
+++ b/test/plots/gistemp-anomaly.ts
@@ -5,7 +5,7 @@ export async function gistempAnomaly() {
   const data = await d3.csv<any>("data/gistemp.csv", d3.autoType);
   return Plot.plot({
     y: {
-      label: "↑ Temperature anomaly (°C)",
+      label: "Temperature anomaly (°C)",
       tickFormat: "+f",
       grid: true
     },

--- a/test/plots/ibm-trading.ts
+++ b/test/plots/ibm-trading.ts
@@ -12,7 +12,7 @@ export async function ibmTrading() {
     },
     y: {
       transform: (d) => d / 1e6,
-      label: "↑ Volume (USD, millions)",
+      label: "Volume (USD, millions)",
       grid: true
     },
     marks: [Plot.barY(ibm, {x: "Date", y: "Volume"})]

--- a/test/plots/letter-frequency-bar.ts
+++ b/test/plots/letter-frequency-bar.ts
@@ -7,7 +7,7 @@ export async function letterFrequencyBar() {
     ariaLabel: "letter-frequency chart",
     ariaDescription: "A horizontal bar chart showing the relative frequency of letters in the English language.",
     x: {
-      label: "Frequency (%) →",
+      label: "Frequency (%)",
       transform: (x) => x * 100,
       grid: true
     },

--- a/test/plots/letter-frequency-column.ts
+++ b/test/plots/letter-frequency-column.ts
@@ -8,7 +8,7 @@ export async function letterFrequencyColumn() {
       label: null
     },
     y: {
-      label: "↑ Frequency (%)",
+      label: "Frequency (%)",
       transform: (y) => y * 100,
       grid: true
     },

--- a/test/plots/long-labels.ts
+++ b/test/plots/long-labels.ts
@@ -16,7 +16,7 @@ Not enough politics\t.12
     marginBottom: 40,
     height: 400,
     x: {label: null},
-    y: {percent: true, label: "↑ Responses (%)"},
+    y: {percent: true, label: "Responses (%)"},
     marks: [
       Plot.axisX({lineWidth: 8}),
       Plot.barY(responses, {x: "name", y: "value"}),

--- a/test/plots/metro-inequality-change.ts
+++ b/test/plots/metro-inequality-change.ts
@@ -8,10 +8,10 @@ export async function metroInequalityChange() {
     inset: 10,
     x: {
       type: "log",
-      label: "Population →"
+      label: "Population"
     },
     y: {
-      label: "↑ Inequality"
+      label: "Inequality"
     },
     color: {
       scheme: "BuRd",

--- a/test/plots/metro-inequality.ts
+++ b/test/plots/metro-inequality.ts
@@ -8,10 +8,10 @@ export async function metroInequality() {
     inset: 10,
     x: {
       type: "log",
-      label: "Population →"
+      label: "Population"
     },
     y: {
-      label: "↑ Inequality"
+      label: "Inequality"
     },
     marks: [Plot.dot(data, {x: "POP_1980", y: "R90_10_1980"})]
   });

--- a/test/plots/metro-unemployment-highlight.ts
+++ b/test/plots/metro-unemployment-highlight.ts
@@ -7,7 +7,7 @@ export async function metroUnemploymentHighlight() {
   return Plot.plot({
     y: {
       grid: true,
-      label: "↑ Unemployment (%)"
+      label: "Unemployment (%)"
     },
     color: {
       domain: [false, true],

--- a/test/plots/metro-unemployment-normalize.ts
+++ b/test/plots/metro-unemployment-normalize.ts
@@ -6,7 +6,7 @@ export async function metroUnemploymentNormalize() {
   return Plot.plot({
     y: {
       type: "log",
-      label: "↑ Change in unemployment (%)",
+      label: "Change in unemployment (%)",
       grid: true,
       tickFormat: (x) => `${x.toPrecision(1)}×`
     },

--- a/test/plots/movies-profit-by-genre.ts
+++ b/test/plots/movies-profit-by-genre.ts
@@ -10,7 +10,7 @@ export async function moviesProfitByGenre() {
     x: {
       grid: true,
       inset: 6,
-      label: "Profit ($M) →",
+      label: "Profit ($M)",
       domain: [d3.min(movies, Profit), 1e3]
     },
     marks: [

--- a/test/plots/music-revenue.ts
+++ b/test/plots/music-revenue.ts
@@ -13,7 +13,7 @@ export async function musicRevenue() {
   return Plot.plot({
     y: {
       grid: true,
-      label: "↑ Annual revenue (billions, adj.)",
+      label: "Annual revenue (billions, adj.)",
       transform: (d) => d / 1000
     },
     marks: [

--- a/test/plots/penguin-mass-sex-species.ts
+++ b/test/plots/penguin-mass-sex-species.ts
@@ -6,7 +6,7 @@ export async function penguinMassSexSpecies() {
   return Plot.plot({
     x: {
       round: true,
-      label: "Body mass (g) →"
+      label: "Body mass (g)"
     },
     facet: {
       data,

--- a/test/plots/penguin-mass-sex.ts
+++ b/test/plots/penguin-mass-sex.ts
@@ -6,7 +6,7 @@ export async function penguinMassSex() {
   return Plot.plot({
     x: {
       round: true,
-      label: "Body mass (g) →"
+      label: "Body mass (g)"
     },
     facet: {
       data,

--- a/test/plots/penguin-mass-species.ts
+++ b/test/plots/penguin-mass-species.ts
@@ -6,7 +6,7 @@ export async function penguinMassSpecies() {
   return Plot.plot({
     x: {
       round: true,
-      label: "Body mass (g) →"
+      label: "Body mass (g)"
     },
     y: {
       grid: true

--- a/test/plots/penguin-mass.ts
+++ b/test/plots/penguin-mass.ts
@@ -6,7 +6,7 @@ export async function penguinMass() {
   return Plot.plot({
     x: {
       round: true,
-      label: "Body mass (g) →"
+      label: "Body mass (g)"
     },
     y: {
       grid: true

--- a/test/plots/penguin-size-symbols.ts
+++ b/test/plots/penguin-size-symbols.ts
@@ -6,10 +6,10 @@ export async function penguinSizeSymbols() {
   return Plot.plot({
     grid: true,
     x: {
-      label: "Body mass (g) →"
+      label: "Body mass (g)"
     },
     y: {
-      label: "↑ Flipper length (mm)"
+      label: "Flipper length (mm)"
     },
     symbol: {
       legend: true

--- a/test/plots/polylinear.ts
+++ b/test/plots/polylinear.ts
@@ -32,7 +32,7 @@ export async function polylinear() {
       domain: times,
       ticks: "day",
       tickFormat: "%d",
-      label: "date →"
+      label: "date"
     },
     color: {
       type: "linear",

--- a/test/plots/seattle-temperature-amplitude.ts
+++ b/test/plots/seattle-temperature-amplitude.ts
@@ -5,8 +5,8 @@ export async function seattleTemperatureAmplitude() {
   const data = await d3.csv<any>("data/seattle-weather.csv", d3.autoType);
   const delta = (d) => d.temp_max - d.temp_min;
   return Plot.plot({
-    x: {label: "Daily low temperature (°F) →", nice: true},
-    y: {label: "↑ Daily temperature variation (Δ°F)", zero: true},
+    x: {label: "Daily low temperature (°F)", nice: true},
+    y: {label: "Daily temperature variation (Δ°F)", zero: true},
     aspectRatio: 1,
     color: {
       type: "cyclical",

--- a/test/plots/seattle-temperature-band.ts
+++ b/test/plots/seattle-temperature-band.ts
@@ -6,7 +6,7 @@ export async function seattleTemperatureBand() {
   return Plot.plot({
     y: {
       grid: true,
-      label: "↑ Temperature (°F)",
+      label: "Temperature (°F)",
       transform: (f) => (f * 9) / 5 + 32 // convert from Celsius
     },
     color: {

--- a/test/plots/sf-temperature-band-area.ts
+++ b/test/plots/sf-temperature-band-area.ts
@@ -6,7 +6,7 @@ export async function sfTemperatureBandArea() {
   return Plot.plot({
     y: {
       grid: true,
-      label: "↑ Daily temperature range (°F)"
+      label: "Daily temperature range (°F)"
     },
     marks: [
       Plot.areaY(

--- a/test/plots/sf-temperature-band.ts
+++ b/test/plots/sf-temperature-band.ts
@@ -6,7 +6,7 @@ export async function sfTemperatureBand() {
   return Plot.plot({
     y: {
       grid: true,
-      label: "↑ Daily temperature range (°F)"
+      label: "Daily temperature range (°F)"
     },
     marks: [
       Plot.areaY(temperatures, {x: "date", y1: "low", y2: "high", curve: "step", fill: "#ccc"}),

--- a/test/plots/simpsons-ratings-dots.ts
+++ b/test/plots/simpsons-ratings-dots.ts
@@ -6,11 +6,12 @@ export async function simpsonsRatingsDots() {
   return Plot.plot({
     x: {
       type: "point",
-      label: "Season →",
-      labelAnchor: "right"
+      label: "Season",
+      labelAnchor: "right",
+      labelArrow: true
     },
     y: {
-      label: "↑ IMDb rating"
+      label: "IMDb rating"
     },
     marks: [
       Plot.ruleX(simpsons, Plot.groupX({y1: "min", y2: "max"}, {x: "season", y: "imdb_rating"})),

--- a/test/plots/simpsons-views.ts
+++ b/test/plots/simpsons-views.ts
@@ -8,10 +8,10 @@ export async function simpsonsViews() {
     grid: true,
     x: {
       inset: 6,
-      label: "IMDB rating →"
+      label: "IMDb rating"
     },
     y: {
-      label: "↑ Viewers (U.S., millions)"
+      label: "Viewers (U.S., millions)"
     },
     color: {
       type: "quantize",

--- a/test/plots/stargazers-binned.ts
+++ b/test/plots/stargazers-binned.ts
@@ -7,7 +7,7 @@ export async function stargazersBinned() {
   return Plot.plot({
     y: {
       grid: true,
-      label: "↑ Stargazers added per week"
+      label: "Stargazers added per week"
     },
     marks: [
       Plot.rectY(

--- a/test/plots/stargazers-hourly-group.ts
+++ b/test/plots/stargazers-hourly-group.ts
@@ -5,7 +5,7 @@ export async function stargazersHourlyGroup() {
   const stargazers = await d3.csv<any>("data/stargazers.csv", d3.autoType);
   return Plot.plot({
     x: {
-      label: "New stargazers per hour →",
+      label: "New stargazers per hour",
       tickFormat: (d) => (d > 10 ? "" : d === 10 ? "10+" : d)
     },
     y: {

--- a/test/plots/stargazers-hourly.ts
+++ b/test/plots/stargazers-hourly.ts
@@ -5,7 +5,7 @@ export async function stargazersHourly() {
   const stargazers = await d3.csv<any>("data/stargazers.csv", d3.autoType);
   return Plot.plot({
     x: {
-      label: "New stargazers per hour →",
+      label: "New stargazers per hour",
       tickFormat: (d) => (d > 10 ? "" : d === 10 ? "10+" : d)
     },
     y: {

--- a/test/plots/stargazers.ts
+++ b/test/plots/stargazers.ts
@@ -7,7 +7,7 @@ export async function stargazers() {
     marginRight: 40,
     y: {
       grid: true,
-      label: "↑ Stargazers"
+      label: "Stargazers"
     },
     marks: [
       Plot.ruleY([0]),

--- a/test/plots/stocks-index.ts
+++ b/test/plots/stocks-index.ts
@@ -19,7 +19,7 @@ export async function stocksIndex() {
     y: {
       type: "log",
       grid: true,
-      label: "↑ Change in price (%)",
+      label: "Change in price (%)",
       tickFormat: formatChange
     },
     marks: [

--- a/test/plots/travelers-covid-drop.ts
+++ b/test/plots/travelers-covid-drop.ts
@@ -8,7 +8,8 @@ export async function travelersCovidDrop() {
     y: {
       grid: true,
       zero: true,
-      label: "↓ Drop in passenger throughput (2020 vs. 2019)",
+      label: "Drop in passenger throughput (2020 vs. 2019)",
+      labelArrow: "down",
       tickFormat: "%"
     },
     marks: [

--- a/test/plots/travelers-year-over-year.ts
+++ b/test/plots/travelers-year-over-year.ts
@@ -7,7 +7,7 @@ export async function travelersYearOverYear() {
     y: {
       grid: true,
       nice: true,
-      label: "↑ Travelers per day (millions)",
+      label: "Travelers per day (millions)",
       transform: (d) => d / 1e6
     },
     marks: [

--- a/test/plots/us-congress-age-color-explicit.ts
+++ b/test/plots/us-congress-age-color-explicit.ts
@@ -7,12 +7,12 @@ export async function usCongressAgeColorExplicit() {
     height: 300,
     x: {
       nice: true,
-      label: "Age →",
+      label: "Age",
       labelAnchor: "right"
     },
     y: {
       grid: true,
-      label: "↑ Frequency"
+      label: "Frequency"
     },
     marks: [
       Plot.dot(

--- a/test/plots/us-congress-age-gender.ts
+++ b/test/plots/us-congress-age-gender.ts
@@ -7,7 +7,7 @@ export async function usCongressAgeGender() {
     height: 300,
     x: {
       nice: true,
-      label: "Age →",
+      label: "Age",
       labelAnchor: "right"
     },
     y: {

--- a/test/plots/us-congress-age-symbol-explicit.ts
+++ b/test/plots/us-congress-age-symbol-explicit.ts
@@ -7,12 +7,12 @@ export async function usCongressAgeSymbolExplicit() {
     height: 300,
     x: {
       nice: true,
-      label: "Age →",
+      label: "Age",
       labelAnchor: "right"
     },
     y: {
       grid: true,
-      label: "↑ Frequency"
+      label: "Frequency"
     },
     marks: [
       Plot.dot(

--- a/test/plots/us-congress-age.ts
+++ b/test/plots/us-congress-age.ts
@@ -7,12 +7,12 @@ export async function usCongressAge() {
     height: 300,
     x: {
       nice: true,
-      label: "Age →",
+      label: "Age",
       labelAnchor: "right"
     },
     y: {
       grid: true,
-      label: "↑ Frequency"
+      label: "Frequency"
     },
     marks: [
       Plot.dot(data, Plot.stackY2({x: (d) => 2021 - d.birth, fill: "currentColor", title: "full_name"})),

--- a/test/plots/us-population-state-age-dots.ts
+++ b/test/plots/us-population-state-age-dots.ts
@@ -11,8 +11,8 @@ export async function usPopulationStateAgeDots() {
     grid: true,
     x: {
       axis: "top",
-      label: "Percent (%) →",
-      transform: (d) => d * 100
+      label: "Percent (%)",
+      percent: true
     },
     y: {
       axis: null

--- a/test/plots/us-population-state-age.ts
+++ b/test/plots/us-population-state-age.ts
@@ -10,8 +10,8 @@ export async function usPopulationStateAge() {
     grid: true,
     x: {
       axis: "top",
-      label: "Percent (%) →",
-      transform: (d) => d * 100
+      label: "Percent (%)",
+      percent: true
     },
     y: {
       domain: ages,

--- a/test/plots/us-presidential-election-2020.ts
+++ b/test/plots/us-presidential-election-2020.ts
@@ -15,7 +15,7 @@ export async function usPresidentialElection2020() {
     },
     y: {
       type: "log",
-      label: "↑ Total number of votes"
+      label: "Total number of votes"
     },
     color: {
       scheme: "BuRd",

--- a/test/plots/us-presidential-forecast-2016.ts
+++ b/test/plots/us-presidential-forecast-2016.ts
@@ -5,7 +5,7 @@ export async function usPresidentialForecast2016() {
   const data = await d3.csv<any>("data/us-presidential-forecast-2016-histogram.csv", d3.autoType);
   return Plot.plot({
     x: {
-      label: "Electoral votes for Hillary Clinton →"
+      label: "Electoral votes for Hillary Clinton"
     },
     y: {
       ticks: 5,

--- a/test/plots/word-length-moby-dick.ts
+++ b/test/plots/word-length-moby-dick.ts
@@ -11,14 +11,8 @@ export async function wordLengthMobyDick() {
     .filter((word) => word); // ignore (now) empty words
 
   return Plot.plot({
-    x: {
-      label: "Word length →",
-      labelAnchor: "right"
-    },
-    y: {
-      grid: true,
-      percent: true
-    },
+    x: {label: "Word length", labelAnchor: "right", labelArrow: true},
+    y: {grid: true, percent: true},
     marks: [Plot.barY(words, Plot.groupX({y: "proportion", title: "mode"}, {x: "length", title: (d) => d}))]
   });
 }


### PR DESCRIPTION
Fixes #510. Supersedes #702.

Plot now applies a directional arrow such as → or ↑ automatically, even if the scale **label** is specified explicitly, as long as the given label does not already include a directional arrow. The arrow can be suppressed by setting the **labelArrow** option to *none*, null, or false. In addition, the arrow can be forced in cases where it would not appear automatically, such as for ordinal scales, by setting the **labelArrow** option to true or one of the four orientations: *up*, *right*, *bottom*, or *left*.

Previously in our repo there were 175 instances of Unicode arrows in specified labels; with this change, there are now only 14 instances! (−92%) The remaining instances are solely for double-ended arrows such as `← Women · Men →`.