### PR TITLE
implicit categorical color scale

### DIFF
--- a/src/scales.js
+++ b/src/scales.js
@@ -411,7 +411,7 @@ function inferScaleType(key, channels, {type, domain, range, scheme, pivot, proj
   // If the domain or range has more than two values, assume it’s ordinal. You
   // can still use a “piecewise” (or “polylinear”) scale, but you must set the
   // type explicitly.
-  if ((domain || range || []).length > 2) return asOrdinalType(kind, scheme);
+  if ((domain || range || []).length > 2) return asOrdinalType(kind);
 
   // Otherwise, infer the scale type from the data! Prefer the domain, if
   // present, over channels. (The domain and channels should be consistently
@@ -419,29 +419,30 @@ function inferScaleType(key, channels, {type, domain, range, scheme, pivot, proj
   // check the first defined value for expedience and simplicity; we expect
   // that the types are consistent.
   if (domain !== undefined) {
-    if (isOrdinal(domain)) return asOrdinalType(kind, scheme);
+    if (isOrdinal(domain)) return asOrdinalType(kind);
     if (isTemporal(domain)) return "utc";
   } else {
-    // If any channel is ordinal or temporal, it takes priority.
     const values = channels.map(({value}) => value).filter((value) => value !== undefined);
-    if (values.some(isOrdinal)) return asOrdinalType(kind, scheme);
+    if (values.some(isOrdinal)) return asOrdinalType(kind);
     if (values.some(isTemporal)) return "utc";
   }
+
   // For color scales, take a hint from the color scheme and pivot option.
   if (kind === color) {
     if (pivot != null || isDivergingScheme(scheme)) return "diverging";
     if (isCategoricalScheme(scheme)) return "categorical";
   }
+
   return "linear";
 }
 
 // Positional scales default to a point scale instead of an ordinal scale.
-function asOrdinalType(kind, scheme) {
+function asOrdinalType(kind) {
   switch (kind) {
     case position:
       return "point";
     case color:
-      return isCategoricalScheme(scheme) ? "categorical" : ordinalImplicit;
+      return ordinalImplicit;
     default:
       return "ordinal";
   }

--- a/test/output/shorthandCellCategorical.svg
+++ b/test/output/shorthandCellCategorical.svg
@@ -1,0 +1,52 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(27,0)">
+    <path transform="translate(28,30)" d="M0,0L0,6"></path>
+    <path transform="translate(87,30)" d="M0,0L0,6"></path>
+    <path transform="translate(146,30)" d="M0,0L0,6"></path>
+    <path transform="translate(205,30)" d="M0,0L0,6"></path>
+    <path transform="translate(264,30)" d="M0,0L0,6"></path>
+    <path transform="translate(323,30)" d="M0,0L0,6"></path>
+    <path transform="translate(382,30)" d="M0,0L0,6"></path>
+    <path transform="translate(441,30)" d="M0,0L0,6"></path>
+    <path transform="translate(500,30)" d="M0,0L0,6"></path>
+    <path transform="translate(559,30)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(27,9.5)">
+    <text y="0.71em" transform="translate(28,30)">0</text>
+    <text y="0.71em" transform="translate(87,30)">1</text>
+    <text y="0.71em" transform="translate(146,30)">2</text>
+    <text y="0.71em" transform="translate(205,30)">3</text>
+    <text y="0.71em" transform="translate(264,30)">4</text>
+    <text y="0.71em" transform="translate(323,30)">5</text>
+    <text y="0.71em" transform="translate(382,30)">6</text>
+    <text y="0.71em" transform="translate(441,30)">7</text>
+    <text y="0.71em" transform="translate(500,30)">8</text>
+    <text y="0.71em" transform="translate(559,30)">9</text>
+  </g>
+  <g aria-label="cell">
+    <rect x="28" width="53" y="0" height="30" fill="#4e79a7"></rect>
+    <rect x="87" width="53" y="0" height="30" fill="#f28e2c"></rect>
+    <rect x="146" width="53" y="0" height="30" fill="#e15759"></rect>
+    <rect x="205" width="53" y="0" height="30" fill="#76b7b2"></rect>
+    <rect x="264" width="53" y="0" height="30" fill="#59a14f"></rect>
+    <rect x="323" width="53" y="0" height="30" fill="#edc949"></rect>
+    <rect x="382" width="53" y="0" height="30" fill="#af7aa1"></rect>
+    <rect x="441" width="53" y="0" height="30" fill="#ff9da7"></rect>
+    <rect x="500" width="53" y="0" height="30" fill="#9c755f"></rect>
+    <rect x="559" width="53" y="0" height="30" fill="#bab0ab"></rect>
+  </g>
+</svg>

--- a/test/plots/raster-walmart.ts
+++ b/test/plots/raster-walmart.ts
@@ -14,7 +14,7 @@ async function rasterWalmart(options) {
   ]);
   return Plot.plot({
     projection: "albers",
-    color: {type: "linear", scheme: "spectral"},
+    color: {scheme: "spectral"},
     marks: [
       Plot.raster(walmarts, {x: "longitude", y: "latitude", ...options}),
       Plot.geo({type: "Polygon", coordinates: [d3.reverse(outline) as number[][]]}, {fill: "white"}),


### PR DESCRIPTION
Complement to #1567: we do the scheme test _after_ the domain (or values) have been tested. Fixes the regressions with diverging schemes and temporal scales.