### PR TITLE
[WIP] types: data generics for text * sort order fn

### DIFF
--- a/src/mark.d.ts
+++ b/src/mark.d.ts
@@ -63,7 +63,7 @@ export type RenderFunction = (
 export type Markish = RenderableMark | RenderFunction | Markish[] | null | undefined;
 
 /** Shared options for all marks. */
-export interface MarkOptions {
+export interface MarkOptions<T = unknown> {
   /**
    * Applies a transform to filter the mark’s index according to the given
    * channel values; only truthy values are retained. For example, to show only
@@ -120,7 +120,7 @@ export interface MarkOptions {
    *
    * See also the Plot.sort transform.
    */
-  sort?: SortOrder | ChannelDomainSort;
+  sort?: SortOrder<T> | ChannelDomainSort;
 
   /** A custom mark transform. */
   transform?: TransformFunction;

--- a/src/marks/text.d.ts
+++ b/src/marks/text.d.ts
@@ -3,7 +3,7 @@ import type {Interval} from "../interval.js";
 import type {Data, FrameAnchor, MarkOptions, RenderableMark} from "../mark.js";
 
 /** Options for the text mark. */
-export interface TextOptions extends MarkOptions {
+export interface TextOptions<TData = unknown> extends MarkOptions<TData> {
   /**
    * The horizontal position channel specifying the text’s anchor point,
    * typically bound to the *x* scale.
@@ -151,7 +151,7 @@ export interface TextOptions extends MarkOptions {
 }
 
 /** Options for the textX mark. */
-export interface TextXOptions extends Omit<TextOptions, "y"> {
+export interface TextXOptions<TData = unknown> extends Omit<TextOptions<TData>, "y"> {
   /**
    * The vertical position of the text’s anchor point, typically bound to the
    * *y* scale.
@@ -166,7 +166,7 @@ export interface TextXOptions extends Omit<TextOptions, "y"> {
 }
 
 /** Options for the textY mark. */
-export interface TextYOptions extends Omit<TextOptions, "x"> {
+export interface TextYOptions<TData = unknown> extends Omit<TextOptions<TData>, "x"> {
   /**
    * The horizontal position of the text’s anchor point, typically bound to the
    * *x* scale.
@@ -205,7 +205,7 @@ export interface TextYOptions extends Omit<TextOptions, "x"> {
  * [3]: https://github.com/d3/d3-format
  * [4]: https://github.com/d3/d3-time-format
  */
-export function text(data?: Data, options?: TextOptions): Text;
+export function text<TData extends Data>(data?: TData, options?: TextOptions<TData>): Text;
 
 /**
  * Like text, but **x** defaults to the identity function, assuming that *data*
@@ -219,7 +219,7 @@ export function text(data?: Data, options?: TextOptions): Text;
  * If an **interval** is specified, such as *day*, **y** is transformed to the
  * middle of the interval.
  */
-export function textX(data?: Data, options?: TextXOptions): Text;
+export function textX<TData>(data?: TData, options?: TextXOptions<TData>): Text;
 
 /**
  * Like text, but **y** defaults to the identity function, assuming that *data*
@@ -233,7 +233,7 @@ export function textX(data?: Data, options?: TextXOptions): Text;
  * If an **interval** is specified, such as *day*, **x** is transformed to the
  * middle of the interval.
  */
-export function textY(data?: Data, options?: TextYOptions): Text;
+export function textY<TData>(data?: TData, options?: TextYOptions<TData>): Text;
 
 /** The text mark. */
 export class Text extends RenderableMark {}

--- a/src/plot.d.ts
+++ b/src/plot.d.ts
@@ -377,4 +377,5 @@ export interface Plot {
  * corresponding SVG element, or an HTML figure element if a caption or legend
  * is requested.
  */
+
 export function plot(options?: PlotOptions): (SVGSVGElement | HTMLElement) & Plot;

--- a/src/transforms/basic.d.ts
+++ b/src/transforms/basic.d.ts
@@ -60,7 +60,7 @@ export type InitializerFunction = (
  * considered less than *b*, a positive number if *a* is considered greater than
  * *b*, or zero if *a* and *b* are considered equal.
  */
-export type CompareFunction = (a: any, b: any) => number;
+export type CompareFunction<T = unknown> = (a: T, b: T) => number;
 
 /** Mark options with a mark transform. */
 export type Transformed<T> = T & {transform: TransformFunction};
@@ -145,11 +145,11 @@ export function shuffle<T>(options?: T & {seed?: number}): Transformed<T>;
  * - a {value, order} object for sorting given values
  * - a {channel, order} object for sorting the named channel’s values
  */
-export type SortOrder =
-  | CompareFunction
+export type SortOrder<T = unknown> =
+  | CompareFunction<T>
   | ChannelValue
-  | {value?: ChannelValue; order?: CompareFunction | "ascending" | "descending"}
-  | {channel?: ChannelName; order?: CompareFunction | "ascending" | "descending"};
+  | {value?: ChannelValue; order?: CompareFunction<T> | "ascending" | "descending"}
+  | {channel?: ChannelName; order?: CompareFunction<T> | "ascending" | "descending"};
 
 /**
  * Applies a transform to *options* to sort the mark’s index by the specified


### PR DESCRIPTION
This PR is a tiny preview of the much-needed typescript generic upgrades that I would like to see come to the library. The existing types are really thorough when it comes to option discoverability and static value/option analysis, but as soon as you get into anything that relies on user types, it's the wild-wild west again.

I would *really* love to help make the generics of Plot better and have *a lot* of practice and experience in this area from my other OSS projects.

If this is interesting and something you'd be open to handing off, I would happily take it on. I am relatively certain that I would be able to do this across the board with probably few to no breaking changes to the types. So to summarize my pitch:

- Add generics everywhere possible with non-breaking defaults and constraints
- Do not touch any runtime code
- Profit