### PR TITLE
no tip for tip

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -153,7 +153,7 @@ function maybeChannels(channels) {
 }
 
 function maybeTip(tip) {
-  return tip === true ? "xy" : maybeKeyword(tip, "tip", ["x", "y", "xy"]);
+  return tip === true ? "xy" : tip === false ? null : maybeKeyword(tip, "tip", ["x", "y", "xy"]);
 }
 
 export function withTip(options, tip) {

--- a/src/marks/tip.js
+++ b/src/marks/tip.js
@@ -23,6 +23,8 @@ const ignoreChannels = new Set(["geometry", "href", "src", "ariaLabel"]);
 
 export class Tip extends Mark {
   constructor(data, options = {}) {
+    if (options.tip) options = {...options, tip: false};
+    if (options.title === undefined && isIterable(data) && isTextual(data)) options = {...options, title: identity};
     const {
       x,
       y,
@@ -56,7 +58,7 @@ export class Tip extends Mark {
         x2: {value: x2, scale: "x", optional: x1 == null},
         y2: {value: y2, scale: "y", optional: y1 == null}
       },
-      options.title === undefined && isIterable(data) && isTextual(data) ? {...options, title: identity} : options,
+      options,
       defaults
     );
     this.anchor = maybeAnchor(anchor, "anchor");


### PR DESCRIPTION
Fixes #1580. Also fixes `tip: false` which should be the same as `tip: null`.