### PR TITLE
exclusiveFacets

### DIFF
--- a/src/transforms/stack.js
+++ b/src/transforms/stack.js
@@ -4,6 +4,7 @@ import {withTip} from "../mark.js";
 import {maybeApplyInterval, maybeColumn, maybeZ, maybeZero} from "../options.js";
 import {column, field, mid, one, range, valueof} from "../options.js";
 import {basic} from "./basic.js";
+import {exclusiveFacets} from "./exclusiveFacets.js";
 
 export function stackX(stackOptions = {}, options = {}) {
   if (arguments.length === 1) [stackOptions, options] = mergeOptions(stackOptions);
@@ -84,6 +85,7 @@ function stack(x, y = one, kx, ky, {offset, order, reverse}, options) {
   order = maybeOrder(order, offset, ky);
   return [
     basic(options, (data, facets, plotOptions) => {
+      ({data, facets} = exclusiveFacets(data, facets));
       const X = x == null ? undefined : setX(maybeApplyInterval(valueof(data, x), plotOptions?.[kx]));
       const Y = valueof(data, y, Float64Array);
       const Z = valueof(data, z);


### PR DESCRIPTION
Sketch of minimal solution to #1648.

This needs to pad the data with duplicates, too.

I think we might also read using non-exclusive faceted index, while writing using the exclusive faceted index. Otherwise channels supplied as arrays of values would not work. I’m not sure whether we would do anything about channels that are supplied as arrays of values that are not read by the transform; that feels like a generic issue where transforms can reindex and break the association with data, and maybe if we consider that an issue, Plot should provide a generic mechanism to reindex channel values after transforming data.