### PR TITLE
Refine “high cardinality” warning

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -252,7 +252,7 @@ function groupAesthetics(
 
 export function groupZ(I, Z, z) {
   const G = group(I, (i) => Z[i]);
-  if (z === undefined && G.size > I.length >> 1) {
+  if (z === undefined && G.size > (1 + I.length) >> 1) {
     warn(
       `Warning: the implicit z channel has high cardinality. This may occur when the fill or stroke channel is associated with quantitative data rather than ordinal or categorical data. You can suppress this warning by setting the z option explicitly; if this data represents a single series, set z to null.`
     );

--- a/test/output/pairsArea.svg
+++ b/test/output/pairsArea.svg
@@ -1,0 +1,26 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="140" viewBox="0 0 640 140" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="area" fill="none" stroke-linejoin="round" stroke-linecap="round">
+    <path stroke="rgb(35, 23, 27)" d="M0,103.735L45.643,126.685L45.643,139L0,139Z"></path>
+    <path stroke="rgb(64, 118, 245)" d="M91.286,58.325L136.929,107.898L136.929,139L91.286,139Z"></path>
+    <path stroke="rgb(38, 208, 205)" d="M182.571,86.502L228.214,135.413L228.214,139L182.571,139Z"></path>
+    <path stroke="rgb(95, 252, 115)" d="M273.857,76.493L319.5,122.445L319.5,139L273.857,139Z"></path>
+    <path stroke="rgb(203, 232, 57)" d="M365.143,16.885L410.786,0L410.786,139L365.143,139Z"></path>
+    <path stroke="rgb(255, 155, 33)" d="M456.429,19.765L502.071,69.17L502.071,139L456.429,139Z"></path>
+    <path stroke="rgb(214, 57, 15)" d="M547.714,49.28L593.357,18.612L593.357,139L547.714,139Z"></path>
+    <path stroke="rgb(144, 12, 0)" d="M639,55.643L639,139Z"></path>
+  </g>
+</svg>

--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -168,6 +168,7 @@ export * from "./music-revenue.js";
 export * from "./npm-versions.js";
 export * from "./opacity.js";
 export * from "./ordinal-bar.js";
+export * from "./pairs.js";
 export * from "./penguin-annotated.js";
 export * from "./penguin-culmen-array.js";
 export * from "./penguin-culmen-delaunay-mesh.js";

--- a/test/plots/pairs.ts
+++ b/test/plots/pairs.ts
@@ -1,0 +1,6 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export async function pairsArea() {
+  return Plot.areaY({length: 15}, {y: d3.randomLcg(42), stroke: (d, i) => i >> 1}).plot({axis: null, height: 140});
+}


### PR DESCRIPTION
The intent of this “high cardinality” warning (as specified [here](https://github.com/observablehq/plot/pull/761#issuecomment-1043121845)) is the following: when a mark only¹ makes sense with grouping—currently area, line, linearRegression and density—, we want to warn when the number of groups (G.size) is higher than the smallest possible number of _meaningful_ groups, which is I.length >> 1 (obtained when the groups are pairs).

However when there is an odd number of elements, having 1 element that falls out is to be expected and should not invalidate the chart.

Closes #1667

¹ It's not a hard rule: the areaY mark with a stroke, the lineY mark with a marker, and the density mark tolerate single points. But these are not the default usage.