### PR TITLE
normalizes the calls to valueof to three arguments

### DIFF
--- a/docs/features/transforms.md
+++ b/docs/features/transforms.md
@@ -216,7 +216,7 @@ Plot.valueof(aapl, "Close")
 Given an iterable *data* and some *value* accessor, returns an array (a column) of the specified *type* with the corresponding value of each element of the data. The *value* accessor may be one of the following types:
 
 * a string - corresponding to the field accessor (`(d) => d[value]`)
-* an accessor function - called as *type*.from(*data*, *value*)
+* an accessor function - called on each element as *value*(*element, *index*, *data*)
 * a number, Date, or boolean — resulting in an array uniformly filled with the *value*
 * an object with a **transform** method — called as *value*.transform(*data*)
 * an array of values - returning the same

--- a/src/channel.d.ts
+++ b/src/channel.d.ts
@@ -137,7 +137,7 @@ export type ChannelValue =
   | number // constant
   | boolean // constant
   | null // constant
-  | ((d: any, i: number) => any) // function of data
+  | ((d: any, i: number, values: any[]) => any) // function of data
   | ChannelTransform; // function of data
 
 /**

--- a/src/options.js
+++ b/src/options.js
@@ -35,7 +35,7 @@ function maybeTypedArrayify(data, type) {
 }
 
 function floater(f) {
-  return (d, i) => coerceNumber(f(d, i));
+  return (d, i, v) => coerceNumber(f(d, i, v));
 }
 
 export const singleton = [null]; // for data-less decoration marks, e.g. frame
@@ -127,10 +127,18 @@ export function arrayify(data) {
   return data == null || data instanceof Array || data instanceof TypedArray ? data : Array.from(data);
 }
 
-// An optimization of type.from(values, f): if the given values are already an
-// instanceof the desired array type, the faster values.map method is used.
+// A generalization of values.map(f) with type conversion: if the given values
+// are already an instanceof the desired array type, the faster values.map
+// method is used, otherwise type.from is used. If f accepts a third argument,
+// it receives the values.
 export function map(values, f, type = Array) {
-  return values == null ? values : values instanceof type ? values.map(f) : type.from(values, f);
+  return values == null
+    ? values
+    : values instanceof type
+    ? values.map(f)
+    : f.length === 3
+    ? type.from(values, (d, i) => f(d, i, values))
+    : type.from(values, f);
 }
 
 // An optimization of type.from(values): if the given values are already an

--- a/test/options-test.js
+++ b/test/options-test.js
@@ -122,6 +122,15 @@ it("valueof returns the given array value", () => {
   assert.strictEqual(valueof([], a), a);
 });
 
+it("valueof passes the data as a third argument to function accessors", () => {
+  const a = (d, i, e) => e.length;
+  assert.deepStrictEqual(valueof([1, 2], a, Float64Array), Float64Array.of(2, 2));
+  assert.deepStrictEqual(valueof(Float64Array.of(2, 2), a), [2, 2]);
+  assert.deepStrictEqual(valueof(Float64Array.of(2, 2), a, Uint8Array), Uint8Array.of(2, 2));
+  assert.deepStrictEqual(valueof([1, 2], a, Uint8Array), Uint8Array.of(2, 2));
+  assert.deepStrictEqual(valueof([1, 2], a, Array), [2, 2]);
+});
+
 it("valueof accepts complicated data with the proper accessor", () => {
   const m = [(d) => d, new Promise(() => {})];
   assert.deepStrictEqual(valueof(m, String), ["(d) => d", "[object Promise]"]);


### PR DESCRIPTION
Our types don't guarantee the presence of the third argument to valueof—it depends on whether some type conversion happens, which is an arbitrary implementation choice.

this PR normalizes the calls to valueof to three arguments: *element*, *index*, and *data*

previously *data* was present in some cases (when going through the *arraytype*.map code path) but not others (e.g. when doing type conversion)

Addresses this comment in https://github.com/observablehq/plot/pull/1665#issuecomment-1572742907, guaranteeing that you can use a function filter(d, i, data) { return i < data.length-1 } to select any value but the last.

This seems a bit more robust and I don't expect any performance impact (the wrapper is invoked only when necessary). That said I'm not sure we should do this, or go the other way and ban the third argument—or ignore the issue altogether.