### PR TITLE
Auto: given bar, use cell over rect when no reducer

### DIFF
--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -131,7 +131,9 @@ export function autoSpec(data, options) {
         ? rectX
         : yReduce != null
         ? rectY
-        : rect;
+        : colorReduce != null
+        ? rect
+        : cell;
       colorMode = "fill";
       break;
     default:

--- a/test/output/autoBarNoReducer.svg
+++ b/test/output/autoBarNoReducer.svg
@@ -1,0 +1,736 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="560" viewBox="0 0 640 560" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,9.5)">
+    <path transform="translate(40,26)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,46)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,66)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,86)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,106)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,126)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,146)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,166)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,186)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,206)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,226)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,246)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,266)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,286)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,306)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,326)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,346)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,366)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,386)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,406)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,426)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,446)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,466)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,486)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,506)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" transform="translate(-8.5,9.5)">
+    <text y="0.32em" transform="translate(40,26)">1</text>
+    <text y="0.32em" transform="translate(40,46)">2</text>
+    <text y="0.32em" transform="translate(40,66)">3</text>
+    <text y="0.32em" transform="translate(40,86)">4</text>
+    <text y="0.32em" transform="translate(40,106)">5</text>
+    <text y="0.32em" transform="translate(40,126)">6</text>
+    <text y="0.32em" transform="translate(40,146)">7</text>
+    <text y="0.32em" transform="translate(40,166)">8</text>
+    <text y="0.32em" transform="translate(40,186)">9</text>
+    <text y="0.32em" transform="translate(40,206)">10</text>
+    <text y="0.32em" transform="translate(40,226)">11</text>
+    <text y="0.32em" transform="translate(40,246)">12</text>
+    <text y="0.32em" transform="translate(40,266)">13</text>
+    <text y="0.32em" transform="translate(40,286)">14</text>
+    <text y="0.32em" transform="translate(40,306)">15</text>
+    <text y="0.32em" transform="translate(40,326)">16</text>
+    <text y="0.32em" transform="translate(40,346)">17</text>
+    <text y="0.32em" transform="translate(40,366)">18</text>
+    <text y="0.32em" transform="translate(40,386)">19</text>
+    <text y="0.32em" transform="translate(40,406)">20</text>
+    <text y="0.32em" transform="translate(40,426)">21</text>
+    <text y="0.32em" transform="translate(40,446)">22</text>
+    <text y="0.32em" transform="translate(40,466)">23</text>
+    <text y="0.32em" transform="translate(40,486)">24</text>
+    <text y="0.32em" transform="translate(40,506)">25</text>
+  </g>
+  <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
+    <text y="0.71em" transform="translate(40,275) rotate(-90)">number_in_season</text>
+  </g>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(9.5,0)">
+    <path transform="translate(51,530)" d="M0,0L0,6"></path>
+    <path transform="translate(71,530)" d="M0,0L0,6"></path>
+    <path transform="translate(91,530)" d="M0,0L0,6"></path>
+    <path transform="translate(111,530)" d="M0,0L0,6"></path>
+    <path transform="translate(131,530)" d="M0,0L0,6"></path>
+    <path transform="translate(151,530)" d="M0,0L0,6"></path>
+    <path transform="translate(171,530)" d="M0,0L0,6"></path>
+    <path transform="translate(191,530)" d="M0,0L0,6"></path>
+    <path transform="translate(211,530)" d="M0,0L0,6"></path>
+    <path transform="translate(231,530)" d="M0,0L0,6"></path>
+    <path transform="translate(251,530)" d="M0,0L0,6"></path>
+    <path transform="translate(271,530)" d="M0,0L0,6"></path>
+    <path transform="translate(291,530)" d="M0,0L0,6"></path>
+    <path transform="translate(311,530)" d="M0,0L0,6"></path>
+    <path transform="translate(331,530)" d="M0,0L0,6"></path>
+    <path transform="translate(351,530)" d="M0,0L0,6"></path>
+    <path transform="translate(371,530)" d="M0,0L0,6"></path>
+    <path transform="translate(391,530)" d="M0,0L0,6"></path>
+    <path transform="translate(411,530)" d="M0,0L0,6"></path>
+    <path transform="translate(431,530)" d="M0,0L0,6"></path>
+    <path transform="translate(451,530)" d="M0,0L0,6"></path>
+    <path transform="translate(471,530)" d="M0,0L0,6"></path>
+    <path transform="translate(491,530)" d="M0,0L0,6"></path>
+    <path transform="translate(511,530)" d="M0,0L0,6"></path>
+    <path transform="translate(531,530)" d="M0,0L0,6"></path>
+    <path transform="translate(551,530)" d="M0,0L0,6"></path>
+    <path transform="translate(571,530)" d="M0,0L0,6"></path>
+    <path transform="translate(591,530)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(9.5,9.5)">
+    <text y="0.71em" transform="translate(51,530)">1</text>
+    <text y="0.71em" transform="translate(71,530)">2</text>
+    <text y="0.71em" transform="translate(91,530)">3</text>
+    <text y="0.71em" transform="translate(111,530)">4</text>
+    <text y="0.71em" transform="translate(131,530)">5</text>
+    <text y="0.71em" transform="translate(151,530)">6</text>
+    <text y="0.71em" transform="translate(171,530)">7</text>
+    <text y="0.71em" transform="translate(191,530)">8</text>
+    <text y="0.71em" transform="translate(211,530)">9</text>
+    <text y="0.71em" transform="translate(231,530)">10</text>
+    <text y="0.71em" transform="translate(251,530)">11</text>
+    <text y="0.71em" transform="translate(271,530)">12</text>
+    <text y="0.71em" transform="translate(291,530)">13</text>
+    <text y="0.71em" transform="translate(311,530)">14</text>
+    <text y="0.71em" transform="translate(331,530)">15</text>
+    <text y="0.71em" transform="translate(351,530)">16</text>
+    <text y="0.71em" transform="translate(371,530)">17</text>
+    <text y="0.71em" transform="translate(391,530)">18</text>
+    <text y="0.71em" transform="translate(411,530)">19</text>
+    <text y="0.71em" transform="translate(431,530)">20</text>
+    <text y="0.71em" transform="translate(451,530)">21</text>
+    <text y="0.71em" transform="translate(471,530)">22</text>
+    <text y="0.71em" transform="translate(491,530)">23</text>
+    <text y="0.71em" transform="translate(511,530)">24</text>
+    <text y="0.71em" transform="translate(531,530)">25</text>
+    <text y="0.71em" transform="translate(551,530)">26</text>
+    <text y="0.71em" transform="translate(571,530)">27</text>
+    <text y="0.71em" transform="translate(591,530)">28</text>
+  </g>
+  <g aria-label="x-axis label" transform="translate(0.5,27.5)">
+    <text transform="translate(330,530)">season</text>
+  </g>
+  <g aria-label="cell">
+    <rect x="51" width="18" y="206" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="51" width="18" y="246" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="71" width="18" y="26" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="71" width="18" y="86" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="71" width="18" y="126" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="71" width="18" y="166" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="71" width="18" y="206" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="71" width="18" y="266" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="71" width="18" y="306" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="71" width="18" y="346" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="71" width="18" y="386" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="71" width="18" y="446" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="91" width="18" y="46" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="91" width="18" y="86" height="18" fill="rgb(190, 37, 10)"></rect>
+    <rect x="91" width="18" y="126" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="91" width="18" y="186" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="91" width="18" y="226" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="91" width="18" y="266" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="91" width="18" y="326" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="91" width="18" y="366" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="91" width="18" y="406" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="91" width="18" y="466" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="111" width="18" y="26" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="111" width="18" y="126" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="111" width="18" y="206" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="111" width="18" y="266" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="51" width="18" y="146" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="71" width="18" y="226" height="18" fill="rgb(176, 27, 6)"></rect>
+    <rect x="111" width="18" y="426" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="131" width="18" y="26" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="131" width="18" y="66" height="18" fill="rgb(205, 48, 13)"></rect>
+    <rect x="131" width="18" y="126" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="131" width="18" y="166" height="18" fill="rgb(190, 37, 10)"></rect>
+    <rect x="131" width="18" y="226" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="131" width="18" y="246" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="131" width="18" y="286" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="131" width="18" y="346" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="131" width="18" y="426" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="151" width="18" y="26" height="18" fill="rgb(205, 48, 13)"></rect>
+    <rect x="151" width="18" y="86" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="151" width="18" y="166" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="151" width="18" y="226" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="151" width="18" y="266" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="151" width="18" y="306" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="151" width="18" y="346" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="151" width="18" y="406" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="151" width="18" y="446" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="151" width="18" y="486" height="18" fill="rgb(205, 48, 13)"></rect>
+    <rect x="171" width="18" y="46" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="171" width="18" y="86" height="18" fill="rgb(190, 37, 10)"></rect>
+    <rect x="171" width="18" y="126" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="171" width="18" y="226" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="171" width="18" y="246" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="171" width="18" y="306" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="111" width="18" y="166" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="171" width="18" y="426" height="18" fill="rgb(176, 27, 6)"></rect>
+    <rect x="171" width="18" y="466" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="171" width="18" y="506" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="191" width="18" y="86" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="191" width="18" y="146" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="191" width="18" y="206" height="18" fill="rgb(153, 14, 0)"></rect>
+    <rect x="191" width="18" y="226" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="191" width="18" y="286" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="191" width="18" y="306" height="18" fill="rgb(164, 19, 2)"></rect>
+    <rect x="191" width="18" y="366" height="18" fill="rgb(190, 37, 10)"></rect>
+    <rect x="191" width="18" y="406" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="191" width="18" y="446" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="191" width="18" y="506" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="211" width="18" y="46" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="211" width="18" y="126" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="211" width="18" y="166" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="211" width="18" y="226" height="18" fill="rgb(68, 107, 239)"></rect>
+    <rect x="211" width="18" y="266" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="211" width="18" y="366" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="211" width="18" y="406" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="211" width="18" y="446" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="211" width="18" y="506" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="231" width="18" y="46" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="231" width="18" y="86" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="231" width="18" y="186" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="231" width="18" y="226" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="231" width="18" y="326" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="231" width="18" y="386" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="231" width="18" y="426" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="231" width="18" y="466" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="251" width="18" y="66" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="251" width="18" y="106" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="251" width="18" y="146" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="251" width="18" y="246" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="251" width="18" y="286" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="251" width="18" y="326" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="251" width="18" y="386" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="251" width="18" y="426" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="271" width="18" y="26" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="271" width="18" y="66" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="271" width="18" y="126" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="271" width="18" y="206" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="271" width="18" y="266" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="271" width="18" y="306" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="271" width="18" y="346" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="271" width="18" y="406" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="291" width="18" y="26" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="291" width="18" y="66" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="291" width="18" y="106" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="291" width="18" y="206" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="291" width="18" y="246" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="291" width="18" y="306" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="291" width="18" y="346" height="18" fill="rgb(40, 179, 233)"></rect>
+    <rect x="111" width="18" y="226" height="18" fill="rgb(190, 37, 10)"></rect>
+    <rect x="311" width="18" y="66" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="311" width="18" y="126" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="311" width="18" y="166" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="311" width="18" y="206" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="311" width="18" y="306" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="311" width="18" y="346" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="311" width="18" y="406" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="311" width="18" y="446" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="331" width="18" y="46" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="331" width="18" y="106" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="331" width="18" y="146" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="331" width="18" y="186" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="331" width="18" y="266" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="331" width="18" y="306" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="331" width="18" y="366" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="331" width="18" y="406" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="331" width="18" y="446" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="351" width="18" y="66" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="351" width="18" y="106" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="351" width="18" y="146" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="351" width="18" y="206" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="351" width="18" y="246" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="351" width="18" y="286" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="351" width="18" y="346" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="351" width="18" y="386" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="371" width="18" y="26" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="111" width="18" y="326" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="371" width="18" y="146" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="371" width="18" y="186" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="371" width="18" y="246" height="18" fill="rgb(79, 249, 129)"></rect>
+    <rect x="371" width="18" y="286" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="371" width="18" y="326" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="371" width="18" y="406" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="391" width="18" y="26" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="391" width="18" y="66" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="391" width="18" y="106" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="391" width="18" y="146" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="391" width="18" y="186" height="18" fill="rgb(79, 249, 129)"></rect>
+    <rect x="391" width="18" y="246" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="391" width="18" y="286" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="391" width="18" y="326" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="391" width="18" y="386" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="391" width="18" y="426" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="411" width="18" y="46" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="411" width="18" y="126" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="411" width="18" y="166" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="411" width="18" y="206" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="411" width="18" y="266" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="411" width="18" y="306" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="411" width="18" y="346" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="411" width="18" y="386" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="431" width="18" y="46" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="431" width="18" y="86" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="111" width="18" y="366" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="431" width="18" y="266" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="431" width="18" y="366" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="431" width="18" y="406" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="451" width="18" y="26" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="451" width="18" y="146" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="451" width="18" y="186" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="451" width="18" y="226" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="451" width="18" y="286" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="451" width="18" y="326" height="18" fill="rgb(37, 191, 222)"></rect>
+    <rect x="451" width="18" y="426" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="451" width="18" y="466" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="471" width="18" y="46" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="471" width="18" y="106" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="471" width="18" y="166" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="471" width="18" y="186" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="471" width="18" y="246" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="471" width="18" y="286" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="471" width="18" y="326" height="18" fill="rgb(49, 232, 169)"></rect>
+    <rect x="471" width="18" y="366" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="471" width="18" y="426" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="491" width="18" y="26" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="491" width="18" y="66" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="491" width="18" y="106" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="491" width="18" y="166" height="18" fill="rgb(57, 239, 156)"></rect>
+    <rect x="491" width="18" y="206" height="18" fill="rgb(49, 232, 169)"></rect>
+    <rect x="491" width="18" y="246" height="18" fill="rgb(37, 191, 222)"></rect>
+    <rect x="451" width="18" y="126" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="131" width="18" y="206" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="491" width="18" y="366" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="491" width="18" y="406" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="491" width="18" y="446" height="18" fill="rgb(35, 23, 27)"></rect>
+    <rect x="511" width="18" y="106" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="511" width="18" y="166" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="511" width="18" y="206" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="511" width="18" y="246" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="511" width="18" y="286" height="18" fill="rgb(57, 239, 156)"></rect>
+    <rect x="511" width="18" y="346" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="511" width="18" y="386" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="531" width="18" y="26" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="531" width="18" y="86" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="531" width="18" y="126" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="531" width="18" y="166" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="531" width="18" y="226" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="531" width="18" y="266" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="531" width="18" y="306" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="531" width="18" y="346" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="531" width="18" y="406" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="531" width="18" y="446" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="551" width="18" y="46" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="551" width="18" y="106" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="551" width="18" y="146" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="551" width="18" y="206" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="551" width="18" y="246" height="18" fill="rgb(37, 203, 210)"></rect>
+    <rect x="551" width="18" y="366" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="51" width="18" y="186" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="51" width="18" y="226" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="51" width="18" y="266" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="71" width="18" y="46" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="71" width="18" y="66" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="71" width="18" y="106" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="71" width="18" y="146" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="71" width="18" y="186" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="71" width="18" y="246" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="71" width="18" y="286" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="71" width="18" y="326" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="71" width="18" y="406" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="551" width="18" y="426" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="571" width="18" y="46" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="571" width="18" y="126" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="571" width="18" y="186" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="571" width="18" y="226" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="571" width="18" y="286" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="571" width="18" y="326" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="571" width="18" y="386" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="571" width="18" y="426" height="18" fill="rgb(79, 249, 129)"></rect>
+    <rect x="51" width="18" y="26" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="51" width="18" y="46" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="51" width="18" y="86" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="51" width="18" y="126" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="51" width="18" y="166" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="71" width="18" y="426" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="91" width="18" y="26" height="18" fill="rgb(205, 48, 13)"></rect>
+    <rect x="91" width="18" y="66" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="91" width="18" y="106" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="111" width="18" y="386" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="111" width="18" y="286" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="131" width="18" y="106" height="18" fill="rgb(190, 37, 10)"></rect>
+    <rect x="111" width="18" y="246" height="18" fill="rgb(153, 14, 0)"></rect>
+    <rect x="111" width="18" y="306" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="131" width="18" y="186" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="91" width="18" y="386" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="91" width="18" y="146" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="91" width="18" y="166" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="111" width="18" y="146" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="91" width="18" y="246" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="111" width="18" y="346" height="18" fill="rgb(153, 14, 0)"></rect>
+    <rect x="91" width="18" y="286" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="91" width="18" y="446" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="131" width="18" y="86" height="18" fill="rgb(164, 19, 2)"></rect>
+    <rect x="91" width="18" y="306" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="91" width="18" y="346" height="18" fill="rgb(205, 48, 13)"></rect>
+    <rect x="111" width="18" y="406" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="111" width="18" y="86" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="111" width="18" y="446" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="91" width="18" y="426" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="111" width="18" y="46" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="111" width="18" y="106" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="111" width="18" y="186" height="18" fill="rgb(176, 27, 6)"></rect>
+    <rect x="131" width="18" y="266" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="131" width="18" y="326" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="131" width="18" y="366" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="171" width="18" y="186" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="151" width="18" y="206" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="171" width="18" y="386" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="151" width="18" y="286" height="18" fill="rgb(205, 48, 13)"></rect>
+    <rect x="171" width="18" y="66" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="171" width="18" y="286" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="151" width="18" y="326" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="171" width="18" y="146" height="18" fill="rgb(153, 14, 0)"></rect>
+    <rect x="131" width="18" y="446" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="151" width="18" y="46" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="151" width="18" y="366" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="151" width="18" y="386" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="151" width="18" y="66" height="18" fill="rgb(43, 223, 183)"></rect>
+    <rect x="171" width="18" y="106" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="151" width="18" y="426" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="151" width="18" y="106" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="151" width="18" y="146" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="171" width="18" y="26" height="18" fill="rgb(164, 19, 2)"></rect>
+    <rect x="151" width="18" y="466" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="171" width="18" y="346" height="18" fill="rgb(164, 19, 2)"></rect>
+    <rect x="151" width="18" y="186" height="18" fill="rgb(153, 14, 0)"></rect>
+    <rect x="151" width="18" y="246" height="18" fill="rgb(164, 19, 2)"></rect>
+    <rect x="171" width="18" y="206" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="171" width="18" y="266" height="18" fill="rgb(190, 37, 10)"></rect>
+    <rect x="171" width="18" y="326" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="171" width="18" y="166" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="171" width="18" y="446" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="171" width="18" y="486" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="211" width="18" y="66" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="191" width="18" y="266" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="191" width="18" y="26" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="191" width="18" y="326" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="191" width="18" y="66" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="191" width="18" y="106" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="211" width="18" y="486" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="211" width="18" y="426" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="211" width="18" y="186" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="191" width="18" y="426" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="191" width="18" y="126" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="191" width="18" y="346" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="211" width="18" y="306" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="211" width="18" y="106" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="191" width="18" y="386" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="191" width="18" y="166" height="18" fill="rgb(176, 27, 6)"></rect>
+    <rect x="211" width="18" y="386" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="191" width="18" y="486" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="211" width="18" y="26" height="18" fill="rgb(146, 12, 0)"></rect>
+    <rect x="211" width="18" y="206" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="211" width="18" y="466" height="18" fill="rgb(242, 89, 22)"></rect>
+    <rect x="211" width="18" y="286" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="231" width="18" y="26" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="211" width="18" y="246" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="211" width="18" y="346" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="171" width="18" y="366" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="231" width="18" y="106" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="231" width="18" y="146" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="231" width="18" y="166" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="271" width="18" y="86" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="231" width="18" y="246" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="231" width="18" y="346" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="251" width="18" y="126" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="231" width="18" y="366" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="271" width="18" y="246" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="231" width="18" y="206" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="251" width="18" y="86" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="251" width="18" y="406" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="251" width="18" y="46" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="231" width="18" y="406" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="251" width="18" y="346" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="251" width="18" y="26" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="231" width="18" y="446" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="231" width="18" y="266" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="251" width="18" y="166" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="251" width="18" y="206" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="251" width="18" y="226" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="271" width="18" y="226" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="251" width="18" y="266" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="251" width="18" y="446" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="271" width="18" y="146" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="251" width="18" y="306" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="251" width="18" y="366" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="171" width="18" y="406" height="18" fill="rgb(205, 48, 13)"></rect>
+    <rect x="271" width="18" y="326" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="271" width="18" y="386" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="271" width="18" y="426" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="291" width="18" y="366" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="291" width="18" y="386" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="331" width="18" y="66" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="291" width="18" y="46" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="291" width="18" y="326" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="311" width="18" y="86" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="291" width="18" y="226" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="311" width="18" y="286" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="291" width="18" y="86" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="311" width="18" y="46" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="291" width="18" y="126" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="311" width="18" y="106" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="291" width="18" y="286" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="311" width="18" y="186" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="291" width="18" y="146" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="291" width="18" y="186" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="291" width="18" y="406" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="311" width="18" y="386" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="311" width="18" y="146" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="311" width="18" y="226" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="311" width="18" y="366" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="311" width="18" y="426" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="331" width="18" y="26" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="191" width="18" y="246" height="18" fill="rgb(205, 48, 13)"></rect>
+    <rect x="331" width="18" y="126" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="331" width="18" y="166" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="331" width="18" y="206" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="351" width="18" y="46" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="331" width="18" y="426" height="18" fill="rgb(57, 239, 156)"></rect>
+    <rect x="351" width="18" y="366" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="371" width="18" y="126" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="331" width="18" y="246" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="331" width="18" y="286" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="351" width="18" y="166" height="18" fill="rgb(79, 249, 129)"></rect>
+    <rect x="371" width="18" y="46" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="331" width="18" y="326" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="371" width="18" y="66" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="371" width="18" y="86" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="371" width="18" y="206" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="351" width="18" y="86" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="331" width="18" y="346" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="351" width="18" y="306" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="371" width="18" y="166" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="331" width="18" y="386" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="371" width="18" y="226" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="351" width="18" y="226" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="351" width="18" y="406" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="351" width="18" y="26" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="351" width="18" y="126" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="351" width="18" y="186" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="211" width="18" y="326" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="371" width="18" y="386" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="371" width="18" y="426" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="391" width="18" y="366" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="411" width="18" y="106" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="391" width="18" y="306" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="411" width="18" y="326" height="18" fill="rgb(49, 232, 169)"></rect>
+    <rect x="371" width="18" y="446" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="391" width="18" y="206" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="431" width="18" y="66" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="391" width="18" y="86" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="411" width="18" y="226" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="431" width="18" y="166" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="391" width="18" y="126" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="391" width="18" y="166" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="411" width="18" y="146" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="411" width="18" y="406" height="18" fill="rgb(79, 249, 129)"></rect>
+    <rect x="391" width="18" y="446" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="431" width="18" y="106" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="391" width="18" y="266" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="391" width="18" y="226" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="391" width="18" y="346" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="391" width="18" y="406" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="411" width="18" y="286" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="411" width="18" y="246" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="431" width="18" y="146" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="431" width="18" y="26" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="411" width="18" y="366" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="231" width="18" y="66" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="431" width="18" y="206" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="431" width="18" y="246" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="471" width="18" y="26" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="431" width="18" y="386" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="451" width="18" y="446" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="431" width="18" y="346" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="451" width="18" y="206" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="451" width="18" y="46" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="431" width="18" y="326" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="451" width="18" y="366" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="451" width="18" y="66" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="451" width="18" y="406" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="471" width="18" y="306" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="471" width="18" y="266" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="451" width="18" y="266" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="471" width="18" y="126" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="451" width="18" y="166" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="451" width="18" y="246" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="471" width="18" y="346" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="451" width="18" y="106" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="471" width="18" y="406" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="451" width="18" y="306" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="471" width="18" y="146" height="18" fill="rgb(79, 249, 129)"></rect>
+    <rect x="471" width="18" y="386" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="471" width="18" y="206" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="471" width="18" y="66" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="471" width="18" y="226" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="231" width="18" y="286" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="491" width="18" y="46" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="491" width="18" y="86" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="491" width="18" y="226" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="531" width="18" y="206" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="491" width="18" y="426" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="511" width="18" y="86" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="511" width="18" y="186" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="531" width="18" y="66" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="531" width="18" y="146" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="491" width="18" y="386" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="491" width="18" y="126" height="18" fill="rgb(255, 163, 35)"></rect>
+    <rect x="491" width="18" y="266" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="531" width="18" y="186" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="491" width="18" y="306" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="511" width="18" y="306" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="491" width="18" y="346" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="531" width="18" y="46" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="511" width="18" y="366" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="511" width="18" y="226" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="511" width="18" y="26" height="18" fill="rgb(79, 249, 129)"></rect>
+    <rect x="511" width="18" y="126" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="511" width="18" y="46" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="511" width="18" y="146" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="511" width="18" y="266" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="511" width="18" y="406" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="531" width="18" y="106" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="511" width="18" y="446" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="231" width="18" y="306" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="531" width="18" y="286" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="531" width="18" y="386" height="18" fill="rgb(37, 203, 210)"></rect>
+    <rect x="551" width="18" y="166" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="551" width="18" y="266" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="571" width="18" y="106" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="571" width="18" y="206" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="531" width="18" y="426" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="571" width="18" y="26" height="18" fill="rgb(39, 214, 197)"></rect>
+    <rect x="551" width="18" y="406" height="18" fill="rgb(57, 239, 156)"></rect>
+    <rect x="551" width="18" y="346" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="571" width="18" y="146" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="551" width="18" y="226" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="571" width="18" y="266" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="551" width="18" y="386" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="551" width="18" y="326" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="551" width="18" y="26" height="18" fill="rgb(37, 203, 210)"></rect>
+    <rect x="551" width="18" y="66" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="571" width="18" y="246" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="551" width="18" y="186" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="551" width="18" y="86" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="551" width="18" y="286" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="571" width="18" y="346" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="551" width="18" y="446" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="571" width="18" y="306" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="571" width="18" y="166" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="571" width="18" y="66" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="71" width="18" y="366" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="91" width="18" y="206" height="18" fill="rgb(176, 27, 6)"></rect>
+    <rect x="51" width="18" y="106" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="91" width="18" y="486" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="111" width="18" y="66" height="18" fill="rgb(153, 14, 0)"></rect>
+    <rect x="131" width="18" y="46" height="18" fill="rgb(153, 14, 0)"></rect>
+    <rect x="131" width="18" y="146" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="131" width="18" y="306" height="18" fill="rgb(176, 27, 6)"></rect>
+    <rect x="131" width="18" y="386" height="18" fill="rgb(231, 74, 20)"></rect>
+    <rect x="131" width="18" y="406" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="151" width="18" y="126" height="18" fill="rgb(153, 14, 0)"></rect>
+    <rect x="151" width="18" y="506" height="18" fill="rgb(146, 12, 0)"></rect>
+    <rect x="191" width="18" y="46" height="18" fill="rgb(144, 12, 0)"></rect>
+    <rect x="191" width="18" y="186" height="18" fill="rgb(218, 61, 16)"></rect>
+    <rect x="191" width="18" y="466" height="18" fill="rgb(144, 12, 0)"></rect>
+    <rect x="211" width="18" y="86" height="18" fill="rgb(255, 119, 28)"></rect>
+    <rect x="211" width="18" y="146" height="18" fill="rgb(255, 177, 37)"></rect>
+    <rect x="231" width="18" y="126" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="271" width="18" y="166" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="271" width="18" y="186" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="271" width="18" y="366" height="18" fill="rgb(205, 48, 13)"></rect>
+    <rect x="291" width="18" y="446" height="18" fill="rgb(255, 134, 30)"></rect>
+    <rect x="311" width="18" y="26" height="18" fill="rgb(252, 190, 40)"></rect>
+    <rect x="491" width="18" y="186" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="551" width="18" y="126" height="18" fill="rgb(255, 149, 32)"></rect>
+    <rect x="571" width="18" y="86" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="571" width="18" y="406" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="51" width="18" y="66" height="18" fill="rgb(243, 202, 43)"></rect>
+    <rect x="251" width="18" y="186" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="271" width="18" y="46" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="271" width="18" y="106" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="291" width="18" y="266" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="311" width="18" y="326" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="331" width="18" y="226" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="351" width="18" y="266" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="351" width="18" y="326" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="371" width="18" y="266" height="18" fill="rgb(232, 213, 47)"></rect>
+    <rect x="371" width="18" y="306" height="18" fill="rgb(93, 252, 117)"></rect>
+    <rect x="371" width="18" y="366" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="411" width="18" y="66" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="431" width="18" y="126" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="431" width="18" y="426" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="451" width="18" y="86" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="451" width="18" y="346" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="451" width="18" y="386" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="471" width="18" y="86" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="491" width="18" y="146" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="511" width="18" y="326" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="511" width="18" y="426" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="531" width="18" y="326" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="551" width="18" y="306" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="571" width="18" y="366" height="18" fill="rgb(79, 249, 129)"></rect>
+    <rect x="571" width="18" y="446" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="591" width="18" y="26" height="18" fill="rgb(108, 253, 105)"></rect>
+    <rect x="271" width="18" y="286" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="291" width="18" y="166" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="291" width="18" y="426" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="311" width="18" y="246" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="311" width="18" y="266" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="331" width="18" y="86" height="18" fill="rgb(190, 239, 62)"></rect>
+    <rect x="351" width="18" y="426" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="371" width="18" y="106" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="371" width="18" y="346" height="18" fill="rgb(205, 231, 56)"></rect>
+    <rect x="391" width="18" y="46" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="411" width="18" y="26" height="18" fill="rgb(124, 253, 95)"></rect>
+    <rect x="411" width="18" y="86" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="411" width="18" y="186" height="18" fill="rgb(251, 104, 25)"></rect>
+    <rect x="431" width="18" y="186" height="18" fill="rgb(39, 214, 197)"></rect>
+    <rect x="431" width="18" y="226" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="431" width="18" y="286" height="18" fill="rgb(67, 245, 142)"></rect>
+    <rect x="431" width="18" y="306" height="18" fill="rgb(140, 252, 85)"></rect>
+    <rect x="471" width="18" y="446" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="491" width="18" y="286" height="18" fill="rgb(174, 245, 69)"></rect>
+    <rect x="491" width="18" y="326" height="18" fill="rgb(219, 223, 51)"></rect>
+    <rect x="511" width="18" y="66" height="18" fill="rgb(157, 249, 76)"></rect>
+    <rect x="531" width="18" y="246" height="18" fill="rgb(79, 249, 129)"></rect>
+    <rect x="531" width="18" y="366" height="18" fill="rgb(174, 245, 69)"></rect>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(9.5,9.5)"></g>
+</svg>

--- a/test/plots/autoplot.ts
+++ b/test/plots/autoplot.ts
@@ -259,3 +259,8 @@ export async function autoChannels() {
   const athletes = await d3.csv<any>("data/athletes.csv", d3.autoType);
   return Plot.auto(athletes, {x: Plot.valueof(athletes, "height"), y: Plot.valueof(athletes, "sport")}).plot();
 }
+
+export async function autoBarNoReducer() {
+  const simpsons = await d3.csv<any>("data/simpsons.csv", d3.autoType);
+  return Plot.auto(simpsons, {x: "season", y: "number_in_season", color: "imdb_rating", mark: "bar"}).plot()
+}

--- a/test/plots/autoplot.ts
+++ b/test/plots/autoplot.ts
@@ -262,5 +262,5 @@ export async function autoChannels() {
 
 export async function autoBarNoReducer() {
   const simpsons = await d3.csv<any>("data/simpsons.csv", d3.autoType);
-  return Plot.auto(simpsons, {x: "season", y: "number_in_season", color: "imdb_rating", mark: "bar"}).plot()
+  return Plot.auto(simpsons, {x: "season", y: "number_in_season", color: "imdb_rating", mark: "bar"}).plot();
 }


### PR DESCRIPTION
If there's no reducer, the rects will have no extent, so we should treat numbers as ordinal. Fixes https://github.com/observablehq/plot/issues/1672. This lets us get to e.g. the Simpsons ratings heatmap:

<img width="632" alt="image" src="https://github.com/observablehq/plot/assets/841829/47703678-610b-4618-8158-513bb08b70a3">

```js
Plot.auto(simpsons, {x: "season", y: "number_in_season", color: "imdb_rating", mark: "bar"}).plot()
```

This will never be chosen unless `mark: "bar"` is passed, because of `isZeroReducer(xReduce) || isZeroReducer(yReduce) || colorReduce != null ? "bar"` above. 