### PR TITLE
fixes an alignment issue for radio buttons

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -58,6 +58,7 @@
 
 .label-input > label {
   display: inline-flex;
+  align-items: center;
 }
 
 .label-input > input,


### PR DESCRIPTION
the issue was affecting only safari, e.g. on /plot/transforms/window

thanks to @mootari for the fix

before
![](https://github.com/observablehq/plot/assets/7001/a0dcf881-1cee-45a8-baa6-dac9669dc8cb)

after
![](https://github.com/observablehq/plot/assets/7001/f2485959-df28-4c84-b391-150755df2aed)
