### PR TITLE
zoom

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -1,3 +1,4 @@
+import {select} from "d3";
 import {channelDomain, createChannels, valueObject} from "./channel.js";
 import {defined} from "./defined.js";
 import {maybeFacetAnchor} from "./facet.js";
@@ -127,6 +128,24 @@ export class Mark {
     const values = valueObject(channels, scales);
     if (context.projection) this.project(channels, values, context);
     return values;
+  }
+  // On zoom, a mark can do more interesting things than just applying a
+  // transform; for instance, an axis mark might want to adapt its ticks, and a
+  // dot mark might adjust its radius. By default, though, we just zoom the
+  // zoomable SVG elements (ie everything but clipPath?).
+  zoom(node, transform) {
+    let z = select(node).selectAll(".zoomable");
+    if (z.size() === 0) {
+      z = select(node).append("g").classed("zoomable", true);
+      select(node)
+        .selectChildren("circle,g:not(.zoomable),image,line,path,rect,text")
+        .attr("vector-effect", "non-scaling-stroke")
+        .each(function () {
+          z.append(() => this);
+        });
+    }
+    z.attr("transform", transform);
+    return node;
   }
 }
 

--- a/src/marks/dot.js
+++ b/src/marks/dot.js
@@ -1,4 +1,4 @@
-import {pathRound as path, symbolCircle} from "d3";
+import {pathRound as path, select, symbolCircle} from "d3";
 import {create} from "../context.js";
 import {negative, positive} from "../defined.js";
 import {Mark} from "../mark.js";
@@ -127,6 +127,15 @@ export class Dot extends Mark {
           .call(applyChannelStyles, this, channels)
       )
       .node();
+  }
+  zoom(node, transform, values) {
+    const a = 1 / Math.sqrt(transform.k);
+    select(node)
+      .attr("transform", transform)
+      .selectAll("circle")
+      .attr("vector-effect", "non-scaling-stroke")
+      .attr("r", values.r ? (i) => a * values.r[i] : this.r * a);
+    return node;
   }
 }
 

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,4 +1,4 @@
-import {creator, select} from "d3";
+import {creator, select, zoom as zoomer} from "d3";
 import {createChannel, inferChannelScale} from "./channel.js";
 import {createContext} from "./context.js";
 import {createDimensions} from "./dimensions.js";
@@ -20,7 +20,7 @@ import {initializer} from "./transforms/basic.js";
 import {consumeWarnings, warn} from "./warnings.js";
 
 export function plot(options = {}) {
-  const {facet, style, caption, ariaLabel, ariaDescription} = options;
+  const {facet, style, caption, ariaLabel, ariaDescription, zoom} = options;
 
   // className for inline styles
   const className = maybeClassName(options.className);
@@ -272,6 +272,7 @@ export function plot(options = {}) {
     .call(applyInlineStyles, style);
 
   // Render marks.
+  const nodesByMark = new Map();
   for (const mark of marks) {
     const {channels, values, facets: indexes} = stateByMark.get(mark);
 
@@ -285,6 +286,7 @@ export function plot(options = {}) {
       }
       const node = mark.render(index, scales, values, superdimensions, context);
       if (node == null) continue;
+      nodesByMark.set(mark, node);
       svg.appendChild(node);
     }
 
@@ -336,6 +338,25 @@ export function plot(options = {}) {
 
   figure.scale = exposeScales(scaleDescriptors);
   figure.legend = exposeLegends(scaleDescriptors, context, options);
+
+  if (zoom || true) {
+    select(svg).call(
+      zoomer().on("start zoom end", ({transform}) => {
+        // todo also opt-out when a scale is collapsed.
+        if (scales.y?.bandwidth || zoom === "x") {
+          transform.toString = () => `translate(${transform.x},${0})scale(${transform.k},1)`;
+          transform.rescaleY = (y) => y;
+        }
+        if (scales.x?.bandwidth || zoom === "y") {
+          transform.toString = () => `translate(${0},${transform.y})scale(1,${transform.k})`;
+          transform.rescaleX = (x) => x;
+        }
+        for (const [mark, node] of nodesByMark) {
+          if (mark.zoom != null) nodesByMark.set(mark, mark.zoom(node, transform, stateByMark.get(mark).values));
+        }
+      })
+    );
+  }
 
   const w = consumeWarnings();
   if (w > 0) {


### PR DESCRIPTION
**zoom** is a new top-level option, values "xy", "x", "y". (first pass at #1590)

- A mark has a zoom() method, which allows it to act when the chart receives a zoom event.
- The default zoom method puts all the node’s contents into a new *g* and applies the zoom transform to that g.
- The zoom method on the axis marks computes ticks for the rescaled scale. for the tick label it is set to null.
- The zoom method on the dot mark rescales the dots by sqrt(k) instead of k, making it easy to “declutter by zooming”

Things that don't work yet, but I see no blocker:
- [ ] pointing (still points to the unzoomed positions)
- [ ] facets
- [ ] adaptive pointRadius for the geo mark
- [ ] the image mark when applying a zoom:"x" gets squished
- [ ] zoomExtent defaults and more generally, zoom configuration

Things that seem more difficult—maybe not necessary in the first version:
- [ ] zooming categorical scales
- [ ] re-running initializers (say, if we wanted a hexbin that maintains an unzoomed grid)
- [ ] adaptive rendering (say, to change a map's precision during rendering and depending on the scaling factor)


To make tests easier zoom is considered true everywhere ("xy")—this helps to surface all the cases where it doesn't work (or fails in a funny way).

https://github.com/observablehq/plot/assets/7001/c273688c-02ae-4222-b669-d0acbf5b7399


 

