### PR TITLE
title, subtitle

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -154,3 +154,5 @@ a.plot-fork:hover {
     display: flex;
   }
 }
+
+h2.plot-h2, h3.plot-h3 { margin: 0; }

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -31,6 +31,23 @@
   z-index: 1;
 }
 
+.vp-doc .plot-figure {
+  margin: 16px 0;
+}
+
+.vp-doc .plot-figure h2,
+.vp-doc .plot-figure h3 {
+  all: unset;
+  display: block;
+}
+
+.vp-doc .plot-figure h2 {
+  line-height: 28px;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
 .vp-doc .plot a:hover {
   text-decoration: initial;
 }
@@ -154,5 +171,3 @@ a.plot-fork:hover {
     display: flex;
   }
 }
-
-h2.plot-h2, h3.plot-h3 { margin: 0; }

--- a/docs/components/PlotRender.js
+++ b/docs/components/PlotRender.js
@@ -212,7 +212,10 @@ export default {
     }
     if (typeof document !== "undefined") {
       const plot = Plot[method](options);
-      const replace = (el) => el.firstChild.replaceWith(plot);
+      const replace = (el) => {
+        while (el.lastChild) el.lastChild.remove();
+        el.append(plot);
+      };
       return withDirectives(h("span", [toHyperScript(plot)]), [[{mounted: replace, updated: replace}]]);
     }
     return h("span", [Plot[method]({...options, document: new Document()}).toHyperScript()]);

--- a/docs/features/plots.md
+++ b/docs/features/plots.md
@@ -250,7 +250,7 @@ When using facets, set the *fx* and *fy* scales’ **round** option to false if 
 
 By default, [plot](#plot) returns an SVG element; however, if the plot includes a title, subtitle, [legend](./legends.md), or caption, plot wraps the SVG element with an HTML figure element. You can also force Plot to generate a figure element by setting the **figure** option <VersionBadge pr="1792" /> to true.
 
-The **title** <VersionBadge pr="1792" />, **subtitle** <VersionBadge pr="1792" />, and **caption** options accept either a string or an HTML element. If given an HTML element, say using the [`html` tagged template literal](http://github.com/observablehq/htl), the title and subtitle are used as-is while the caption is wrapped in a figcaption element; otherwise, the specified text will be escaped and wrapped in an H2, H3, or figcaption, respectively.
+The **title** <VersionBadge pr="1792" />, **subtitle** <VersionBadge pr="1792" />, and **caption** options accept either a string or an HTML element. If given an HTML element, say using the [`html` tagged template literal](http://github.com/observablehq/htl), the title and subtitle are used as-is while the caption is wrapped in a figcaption element; otherwise, the specified text will be escaped and wrapped in an h2, h3, or figcaption, respectively.
 
 :::plot https://observablehq.com/@observablehq/plot-caption
 ```js

--- a/docs/features/plots.md
+++ b/docs/features/plots.md
@@ -255,12 +255,12 @@ The **title** <VersionBadge pr="1792" />, **subtitle** <VersionBadge pr="1792" /
 :::plot https://observablehq.com/@observablehq/plot-caption
 ```js
 Plot.plot({
-  title: "For charts, a title assists interpretation",
-  subtitle: "Tell the reader what’s interesting instead of forcing them to discover it.",
+  title: "For charts, an informative title",
+  subtitle: "Subtitle to follow with additional context",
   caption: "Figure 1. A chart with a title, subtitle, and caption.",
   marks: [
     Plot.frame(),
-    Plot.text(["Hello, world!"], {frameAnchor: "middle"})
+    Plot.text(["Titles, subtitles, captions, and annotations assist inter­pretation by telling the reader what’s interesting. Don’t make the reader work to find what you already know."], {lineWidth: 30, frameAnchor: "middle"})
   ]
 })
 ```

--- a/docs/features/plots.md
+++ b/docs/features/plots.md
@@ -248,9 +248,9 @@ When using facets, set the *fx* and *fy* scales’ **round** option to false if 
 
 ## Other options
 
-By default, [plot](#plot) returns an SVG element; however, if the plot includes a title, subtitle, [legend](./legends.md), or caption, plot wraps the SVG element with an HTML figure element. You can also force Plot to generate a figure element by setting the **figure** option <VersionBadge pr="1792" /> to true.
+By default, [plot](#plot) returns an SVG element; however, if the plot includes a title, subtitle, [legend](./legends.md), or caption, plot wraps the SVG element with an HTML figure element. You can also force Plot to generate a figure element by setting the **figure** option <VersionBadge pr="1761" /> to true.
 
-The **title** <VersionBadge pr="1792" />, **subtitle** <VersionBadge pr="1792" />, and **caption** options accept either a string or an HTML element. If given an HTML element, say using the [`html` tagged template literal](http://github.com/observablehq/htl), the title and subtitle are used as-is while the caption is wrapped in a figcaption element; otherwise, the specified text will be escaped and wrapped in an h2, h3, or figcaption, respectively.
+The **title** & **subtitle** options <VersionBadge pr="1761" /> and the **caption** option accept either a string or an HTML element. If given an HTML element, say using the [`html` tagged template literal](http://github.com/observablehq/htl), the title and subtitle are used as-is while the caption is wrapped in a figcaption element; otherwise, the specified text will be escaped and wrapped in an h2, h3, or figcaption, respectively.
 
 :::plot https://observablehq.com/@observablehq/plot-caption
 ```js

--- a/docs/features/plots.md
+++ b/docs/features/plots.md
@@ -248,15 +248,15 @@ When using facets, set the *fx* and *fy* scales’ **round** option to false if 
 
 ## Other options
 
-Plot.plot returns an HTML figure element that wraps the figure’s title, subtitle, [legends](./legends.md), chart, and caption — or the chart’s SVG element if there is no other element.
+By default, [plot](#plot) returns an SVG element; however, if the plot includes a title, subtitle, [legend](./legends.md), or caption, plot wraps the SVG element with an HTML figure element. You can also force Plot to generate a figure element by setting the **figure** option <VersionBadge pr="1792" /> to true.
 
-The top-level **title** <VersionBadge pr="1792" />, **subtitle** <VersionBadge pr="1792" />, and **caption** options can be used to specify the corresponding elements. These options accept either a string or an HTML element. If specified as an HTML element, say using the [`html` tagged template literal](http://github.com/observablehq/htl), the title and subtitle are used as given, and the caption is wrapped in a figcaption element; otherwise, the specified string represents text that will be escaped as needed and inserted in an element of type H2, H3, and figcaption, respectively.
+The **title** <VersionBadge pr="1792" />, **subtitle** <VersionBadge pr="1792" />, and **caption** options accept either a string or an HTML element. If given an HTML element, say using the [`html` tagged template literal](http://github.com/observablehq/htl), the title and subtitle are used as-is while the caption is wrapped in a figcaption element; otherwise, the specified text will be escaped and wrapped in an H2, H3, or figcaption, respectively.
 
 :::plot https://observablehq.com/@observablehq/plot-caption
 ```js
 Plot.plot({
-  title: "Title",
-  subtitle: "Subtitle",
+  title: "For charts, a title assists interpretation",
+  subtitle: "Tell the reader what’s interesting instead of forcing them to discover it.",
   caption: "Figure 1. A chart with a title, subtitle, and caption.",
   marks: [
     Plot.frame(),

--- a/docs/features/plots.md
+++ b/docs/features/plots.md
@@ -248,12 +248,16 @@ When using facets, set the *fx* and *fy* scales’ **round** option to false if 
 
 ## Other options
 
-If a **caption** is specified, Plot.plot wraps the generated SVG element in an HTML figure element with a figcaption, returning the figure. To specify an HTML caption, the caption can be specified as an HTML element, say using the [`html` tagged template literal](http://github.com/observablehq/htl); otherwise, the specified string represents text that will be escaped as needed.
+Plot.plot returns an HTML figure element that wraps the figure’s title, subtitle, [legends](./legends.md), chart, and caption — or the chart’s SVG element if there is no other element.
+
+The top-level **title** <VersionBadge pr="1792" />, **subtitle** <VersionBadge pr="1792" />, and **caption** options can be used to specify the corresponding elements. These options accept either a string or an HTML element. If specified as an HTML element, say using the [`html` tagged template literal](http://github.com/observablehq/htl), the title and subtitle are used as given, and the caption is wrapped in a figcaption element; otherwise, the specified string represents text that will be escaped as needed and inserted in an element of type H2, H3, and figcaption, respectively.
 
 :::plot https://observablehq.com/@observablehq/plot-caption
 ```js
 Plot.plot({
-  caption: "Figure 1. A chart with a caption.",
+  title: "Title",
+  subtitle: "Subtitle",
+  caption: "Figure 1. A chart with a title, subtitle, and caption.",
   marks: [
     Plot.frame(),
     Plot.text(["Hello, world!"], {frameAnchor: "middle"})

--- a/src/plot.d.ts
+++ b/src/plot.d.ts
@@ -109,10 +109,10 @@ export interface PlotOptions extends ScaleDefaults {
 
   /**
    * The figure title. If present, Plot wraps the generated SVG element in an
-   * HTML figure element with the title in a h2 element, returning the figure. To
-   * specify an HTML title, consider using the [`html` tagged template
-   * literal](http://github.com/observablehq/htl); otherwise, the specified
-   * string represents text that will be escaped as needed.
+   * HTML figure element with the title in a h2 element, returning the figure.
+   * To specify an HTML title, consider using the [`html` tagged template
+   * literal][1]; otherwise, the specified string represents text that will be
+   * escaped as needed.
    *
    * ```js
    * Plot.plot({
@@ -120,6 +120,8 @@ export interface PlotOptions extends ScaleDefaults {
    *   marks: …
    * })
    * ```
+   *
+   * [1]: https://github.com/observablehq/htl
    */
   title?: string | Node | null;
 
@@ -127,8 +129,8 @@ export interface PlotOptions extends ScaleDefaults {
    * The figure subtitle. If present, Plot wraps the generated SVG element in an
    * HTML figure element with the subtitle in a h3 element, returning the
    * figure. To specify an HTML subtitle, consider using the [`html` tagged
-   * template literal](http://github.com/observablehq/htl); otherwise, the
-   * specified string represents text that will be escaped as needed.
+   * template literal][1]; otherwise, the specified string represents text that
+   * will be escaped as needed.
    *
    * ```js
    * Plot.plot({
@@ -136,6 +138,8 @@ export interface PlotOptions extends ScaleDefaults {
    *   marks: …
    * })
    * ```
+   *
+   * [1]: https://github.com/observablehq/htl
    */
   subtitle?: string | Node | null;
 

--- a/src/plot.d.ts
+++ b/src/plot.d.ts
@@ -108,6 +108,38 @@ export interface PlotOptions extends ScaleDefaults {
   className?: string;
 
   /**
+   * The figure title. If present, Plot wraps the generated SVG element in an
+   * HTML figure element with the title in a h2 element, returning the figure. To
+   * specify an HTML title, consider using the [`html` tagged template
+   * literal](http://github.com/observablehq/htl); otherwise, the specified
+   * string represents text that will be escaped as needed.
+   *
+   * ```js
+   * Plot.plot({
+   *   title: html`<h2 class="figure">This is a <i>fancy</i> title`,
+   *   marks: …
+   * })
+   * ```
+   */
+  title?: string | Node | null;
+
+  /**
+   * The figure subtitle. If present, Plot wraps the generated SVG element in an
+   * HTML figure element with the subtitle in a h3 element, returning the
+   * figure. To specify an HTML subtitle, consider using the [`html` tagged
+   * template literal](http://github.com/observablehq/htl); otherwise, the
+   * specified string represents text that will be escaped as needed.
+   *
+   * ```js
+   * Plot.plot({
+   *   subtitle: html`<em>This is a <tt>fancy</tt> subtitle`,
+   *   marks: …
+   * })
+   * ```
+   */
+  subtitle?: string | Node | null;
+
+  /**
    * The figure caption. If present, Plot wraps the generated SVG element in an
    * HTML figure element with a figcaption, returning the figure. To specify an
    * HTML caption, consider using the [`html` tagged template literal][1];

--- a/src/plot.d.ts
+++ b/src/plot.d.ts
@@ -162,6 +162,14 @@ export interface PlotOptions extends ScaleDefaults {
   caption?: string | Node | null;
 
   /**
+   * Whether to wrap the generated SVG element with an HTML figure element. By
+   * default, this is determined by the presence of non-chart elements such as
+   * legends, title, subtitle, and caption; if false, these non-chart element
+   * options are ignored.
+   */
+  figure?: boolean;
+
+  /**
    * The [aria-label attribute][1] on the SVG root.
    *
    * [1]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label

--- a/src/plot.js
+++ b/src/plot.js
@@ -20,7 +20,7 @@ import {initializer} from "./transforms/basic.js";
 import {consumeWarnings, warn} from "./warnings.js";
 
 export function plot(options = {}) {
-  const {facet, style, caption, ariaLabel, ariaDescription} = options;
+  const {facet, style, title, subtitle, caption, ariaLabel, ariaDescription} = options;
 
   // className for inline styles
   const className = maybeClassName(options.className);
@@ -320,17 +320,20 @@ export function plot(options = {}) {
     }
   }
 
-  // Wrap the plot in a figure with a caption, if desired.
+  // Wrap the plot in a figure if there are other elements than the svg.
   const legends = createLegends(scaleDescriptors, context, options);
-  if (caption != null || legends.length > 0) {
+  if (title != null || subtitle != null || caption != null || legends.length > 0) {
     figure = document.createElement("figure");
     figure.style.maxWidth = "initial";
-    for (const legend of legends) figure.appendChild(legend);
-    figure.appendChild(svg);
-    if (caption != null) {
-      const figcaption = document.createElement("figcaption");
-      figcaption.appendChild(caption?.ownerDocument ? caption : document.createTextNode(caption));
-      figure.appendChild(figcaption);
+    for (const e of [[title, "h2"], [subtitle, "h3"], ...legends, svg, [caption, "figcaption"]]) {
+      const [contents, tag] = Array.isArray(e) ? e : [e];
+      if (contents == null) continue;
+      if (tag && (!contents.ownerDocument || tag === "figcaption")) {
+        const c = document.createElement(tag);
+        if (tag === "h2" || tag === "h3") c.className = `${className}-${tag}`;
+        c.appendChild(contents.ownerDocument ? contents : document.createTextNode(contents));
+        figure.appendChild(c);
+      } else figure.appendChild(contents);
     }
   }
 

--- a/src/plot.js
+++ b/src/plot.js
@@ -320,13 +320,15 @@ export function plot(options = {}) {
     }
   }
 
-  // Wrap the plot in a figure if there are other elements than the svg.
+  // Wrap the plot in a figure, if needed.
   const legends = createLegends(scaleDescriptors, context, options);
-  if (title != null || subtitle != null || caption != null || legends.length > 0) {
+  const {figure: figured = title != null || subtitle != null || caption != null || legends.length > 0} = options;
+  if (figured) {
     figure = document.createElement("figure");
-    figure.style.maxWidth = "initial";
-    if (title != null) figure.append(createTitleElement(document, title, "h2", className));
-    if (subtitle != null) figure.append(createTitleElement(document, subtitle, "h3", className));
+    figure.className = `${className}-figure`;
+    figure.style.maxWidth = "initial"; // avoid Observable default style
+    if (title != null) figure.append(createTitleElement(document, title, "h2"));
+    if (subtitle != null) figure.append(createTitleElement(document, subtitle, "h3"));
     figure.append(...legends, svg);
     if (caption != null) figure.append(createFigcaption(document, caption));
   }
@@ -351,10 +353,9 @@ export function plot(options = {}) {
   return figure;
 }
 
-function createTitleElement(document, contents, tag, className) {
+function createTitleElement(document, contents, tag) {
   if (contents.ownerDocument) return contents;
   const e = document.createElement(tag);
-  e.className = `${className}-${tag}`;
   e.append(document.createTextNode(contents));
   return e;
 }

--- a/src/plot.js
+++ b/src/plot.js
@@ -325,10 +325,10 @@ export function plot(options = {}) {
   if (title != null || subtitle != null || caption != null || legends.length > 0) {
     figure = document.createElement("figure");
     figure.style.maxWidth = "initial";
-    if (title != null) figure.appendChild(createTitleElement(title, "h2", className));
-    if (subtitle != null) figure.appendChild(createTitleElement(subtitle, "h3", className));
+    if (title != null) figure.append(createTitleElement(title, "h2", className));
+    if (subtitle != null) figure.append(createTitleElement(subtitle, "h3", className));
     figure.append(...legends, svg);
-    if (caption != null) figure.appendChild(createFigcaption(caption));
+    if (caption != null) figure.append(createFigcaption(caption));
   }
 
   figure.scale = exposeScales(scaleDescriptors);
@@ -355,13 +355,13 @@ function createTitleElement(contents, tag, className) {
   if (contents.ownerDocument) return contents;
   const e = document.createElement(tag);
   e.className = `${className}-${tag}`;
-  e.appendChild(document.createTextNode(contents));
+  e.append(document.createTextNode(contents));
   return e;
 }
 
 function createFigcaption(caption) {
   const e = document.createElement("figcaption");
-  e.appendChild(caption.ownerDocument ? caption : document.createTextNode(caption));
+  e.append(caption.ownerDocument ? caption : document.createTextNode(caption));
   return e;
 }
 

--- a/src/plot.js
+++ b/src/plot.js
@@ -325,16 +325,10 @@ export function plot(options = {}) {
   if (title != null || subtitle != null || caption != null || legends.length > 0) {
     figure = document.createElement("figure");
     figure.style.maxWidth = "initial";
-    for (const e of [[title, "h2"], [subtitle, "h3"], ...legends, svg, [caption, "figcaption"]]) {
-      const [contents, tag] = Array.isArray(e) ? e : [e];
-      if (contents == null) continue;
-      if (tag && (!contents.ownerDocument || tag === "figcaption")) {
-        const c = document.createElement(tag);
-        if (tag === "h2" || tag === "h3") c.className = `${className}-${tag}`;
-        c.appendChild(contents.ownerDocument ? contents : document.createTextNode(contents));
-        figure.appendChild(c);
-      } else figure.appendChild(contents);
-    }
+    if (title != null) figure.appendChild(createTitleElement(title, "h2", className));
+    if (subtitle != null) figure.appendChild(createTitleElement(subtitle, "h3", className));
+    figure.append(...legends, svg);
+    if (caption != null) figure.appendChild(createFigcaption(caption));
   }
 
   figure.scale = exposeScales(scaleDescriptors);
@@ -355,6 +349,20 @@ export function plot(options = {}) {
   }
 
   return figure;
+}
+
+function createTitleElement(contents, tag, className) {
+  if (contents.ownerDocument) return contents;
+  const e = document.createElement(tag);
+  e.className = `${className}-${tag}`;
+  e.appendChild(document.createTextNode(contents));
+  return e;
+}
+
+function createFigcaption(caption) {
+  const e = document.createElement("figcaption");
+  e.appendChild(caption.ownerDocument ? caption : document.createTextNode(caption));
+  return e;
 }
 
 function plotThis({marks = [], ...options} = {}) {

--- a/src/plot.js
+++ b/src/plot.js
@@ -325,10 +325,10 @@ export function plot(options = {}) {
   if (title != null || subtitle != null || caption != null || legends.length > 0) {
     figure = document.createElement("figure");
     figure.style.maxWidth = "initial";
-    if (title != null) figure.append(createTitleElement(title, "h2", className));
-    if (subtitle != null) figure.append(createTitleElement(subtitle, "h3", className));
+    if (title != null) figure.append(createTitleElement(document, title, "h2", className));
+    if (subtitle != null) figure.append(createTitleElement(document, subtitle, "h3", className));
     figure.append(...legends, svg);
-    if (caption != null) figure.append(createFigcaption(caption));
+    if (caption != null) figure.append(createFigcaption(document, caption));
   }
 
   figure.scale = exposeScales(scaleDescriptors);
@@ -351,7 +351,7 @@ export function plot(options = {}) {
   return figure;
 }
 
-function createTitleElement(contents, tag, className) {
+function createTitleElement(document, contents, tag, className) {
   if (contents.ownerDocument) return contents;
   const e = document.createElement(tag);
   e.className = `${className}-${tag}`;
@@ -359,7 +359,7 @@ function createTitleElement(contents, tag, className) {
   return e;
 }
 
-function createFigcaption(caption) {
+function createFigcaption(document, caption) {
   const e = document.createElement("figcaption");
   e.append(caption.ownerDocument ? caption : document.createTextNode(caption));
   return e;

--- a/test/output/athletesSortNationality.html
+++ b/test/output/athletesSortNationality.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/athletesSortNullLimit.html
+++ b/test/output/athletesSortNullLimit.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/bigintOrdinal.html
+++ b/test/output/bigintOrdinal.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/caltrain.html
+++ b/test/output/caltrain.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/carsHexbin.html
+++ b/test/output/carsHexbin.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/carsJitter.html
+++ b/test/output/carsJitter.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/colorPiecewiseLinearDomain.html
+++ b/test/output/colorPiecewiseLinearDomain.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/colorPiecewiseLinearDomainReverse.html
+++ b/test/output/colorPiecewiseLinearDomainReverse.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/colorPiecewiseLinearRange.html
+++ b/test/output/colorPiecewiseLinearRange.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/colorPiecewiseLinearRangeHcl.html
+++ b/test/output/colorPiecewiseLinearRangeHcl.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/colorPiecewiseLinearRangeReverse.html
+++ b/test/output/colorPiecewiseLinearRangeReverse.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/decathlon.html
+++ b/test/output/decathlon.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/dotSort.html
+++ b/test/output/dotSort.html
@@ -1,5 +1,5 @@
 <span>
-  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         .plot {
           display: block;
@@ -28,7 +28,7 @@
     <figcaption>default sort (r desc)</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         .plot {
           display: block;
@@ -57,7 +57,7 @@
     <figcaption>sort by r</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         .plot {
           display: block;
@@ -86,7 +86,7 @@
     <figcaption>null sort</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         .plot {
           display: block;
@@ -115,7 +115,7 @@
     <figcaption>reverse</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         .plot {
           display: block;
@@ -144,7 +144,7 @@
     <figcaption>sort by x</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         .plot {
           display: block;
@@ -173,7 +173,7 @@
     <figcaption>reverse sort by x</figcaption>
   </figure>
   <br>
-  <figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         .plot {
           display: block;

--- a/test/output/energyProduction.html
+++ b/test/output/energyProduction.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/figcaption.html
+++ b/test/output/figcaption.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot {
         display: block;

--- a/test/output/figcaptionHtml.html
+++ b/test/output/figcaptionHtml.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot {
         display: block;

--- a/test/output/frameFillCategorical.html
+++ b/test/output/frameFillCategorical.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/frameFillQuantitative.html
+++ b/test/output/frameFillQuantitative.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/hexbinR.html
+++ b/test/output/hexbinR.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/hexbinSymbol.html
+++ b/test/output/hexbinSymbol.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/hexbinZ.html
+++ b/test/output/hexbinZ.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/likertSurvey.html
+++ b/test/output/likertSurvey.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/penguinDensityFill.html
+++ b/test/output/penguinDensityFill.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/penguinDensityZ.html
+++ b/test/output/penguinDensityZ.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/penguinFacetDodgeIsland.html
+++ b/test/output/penguinFacetDodgeIsland.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/penguinFacetDodgeSymbol.html
+++ b/test/output/penguinFacetDodgeSymbol.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/penguinQuantileUnknown.html
+++ b/test/output/penguinQuantileUnknown.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/penguinSizeSymbols.html
+++ b/test/output/penguinSizeSymbols.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/penguinSpeciesCheysson.html
+++ b/test/output/penguinSpeciesCheysson.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/rasterVapor2.html
+++ b/test/output/rasterVapor2.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/seattleTemperatureAmplitude.html
+++ b/test/output/seattleTemperatureAmplitude.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/simpsonsViews.html
+++ b/test/output/simpsonsViews.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/tipTransform.html
+++ b/test/output/tipTransform.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/title.html
+++ b/test/output/title.html
@@ -1,0 +1,417 @@
+<figure style="max-width: initial;">
+  <h2 class="plot-d6a7b5-h2">A title about penguins</h2>
+  <h3 class="plot-d6a7b5-h3">A subtitle about body_mass_g</h3>
+  <div class="plot-swatches plot-swatches-wrap">
+    <style>
+      .plot-swatches {
+        font-family: system-ui, sans-serif;
+        font-size: 10px;
+        margin-bottom: 0.5em;
+      }
+
+      .plot-swatch>svg {
+        margin-right: 0.5em;
+        overflow: visible;
+      }
+
+      .plot-swatches-wrap {
+        display: flex;
+        align-items: center;
+        min-height: 33px;
+        flex-wrap: wrap;
+      }
+
+      .plot-swatches-wrap .plot-swatch {
+        display: inline-flex;
+        align-items: center;
+        margin-right: 1em;
+      }
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>Adelie</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>Chinstrap</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>Gentoo</span>
+  </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+      .plot {
+        display: block;
+        background: white;
+        height: auto;
+        height: intrinsic;
+        max-width: 100%;
+      }
+
+      .plot text,
+      .plot tspan {
+        white-space: pre;
+      }
+    </style>
+    <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+      <path transform="translate(70,30)" d="M0,0L0,6"></path>
+      <path transform="translate(153.33333333333331,30)" d="M0,0L0,6"></path>
+      <path transform="translate(236.66666666666666,30)" d="M0,0L0,6"></path>
+      <path transform="translate(320,30)" d="M0,0L0,6"></path>
+      <path transform="translate(403.3333333333333,30)" d="M0,0L0,6"></path>
+      <path transform="translate(486.6666666666667,30)" d="M0,0L0,6"></path>
+      <path transform="translate(569.9999999999999,30)" d="M0,0L0,6"></path>
+    </g>
+    <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+      <text y="0.71em" transform="translate(70,30)">3,000</text>
+      <text y="0.71em" transform="translate(153.33333333333331,30)">3,500</text>
+      <text y="0.71em" transform="translate(236.66666666666666,30)">4,000</text>
+      <text y="0.71em" transform="translate(320,30)">4,500</text>
+      <text y="0.71em" transform="translate(403.3333333333333,30)">5,000</text>
+      <text y="0.71em" transform="translate(486.6666666666667,30)">5,500</text>
+      <text y="0.71em" transform="translate(569.9999999999999,30)">6,000</text>
+    </g>
+    <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+      <text transform="translate(620,30)">body_mass_g →</text>
+    </g>
+    <g aria-label="dot" fill="none" stroke-width="1.5" transform="translate(0.5,0.5)">
+      <circle cx="195" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="174.16666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="349.1666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="149.16666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="120" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="320" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="170" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="95" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="120" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="120" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="345" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="95" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="86.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="70" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="140.83333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="65.83333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="245" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="53.33333333333333" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="45" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="195" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="95" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="170" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="245" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="45" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="170" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="170" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="120" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="294.99999999999994" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="53.33333333333333" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="190.83333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="357.5" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="82.50000000000001" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="57.5" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="195" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="99.16666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="365.8333333333333" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="207.5" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="282.5" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="249.16666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="53.33333333333333" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="199.16666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="95" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="215.83333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="115.83333333333333" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="315.83333333333337" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="140.83333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="99.16666666666667" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="232.5" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="149.16666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="78.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="190.83333333333331" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="70" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="149.16666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="195" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3" stroke="#4e79a7"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="157.49999999999997" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="190.83333333333331" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="195" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="199.16666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="245" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="165.83333333333331" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="245" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="120" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="170" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="53.33333333333333" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="120" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="328.3333333333333" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="170" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="220" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="211.66666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="370" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="20" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="320" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="182.5" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="182.5" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="170" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="245" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="245" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="157.49999999999997" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="199.16666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="199.16666666666666" cy="15" r="3" stroke="#f28e2c"></circle>
+      <circle cx="320" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="470" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="328.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="370" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="436.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="428.33333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="345" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="495" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="345" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="545" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="545" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="620" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="370" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="461.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="411.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="420" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="511.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="495" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="445" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="411.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="578.3333333333334" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="428.33333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="470" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="395" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="445" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="294.99999999999994" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="461.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="495" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="386.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="470" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="420" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="453.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="378.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="453.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="386.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="411.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="495" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="453.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="511.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="345" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="536.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="495" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="420" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="436.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="536.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="569.9999999999999" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="561.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="340.8333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="478.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="357.5" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="461.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="503.33333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="453.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="382.5" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="495" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="395" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="470" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="511.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="378.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="436.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="390.83333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="382.5" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="340.8333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="445" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="378.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="503.33333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="399.16666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="357.5" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="332.5" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="561.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="345" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="299.1666666666667" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="545" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="382.5" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="569.9999999999999" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="390.83333333333337" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="378.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="528.3333333333333" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="436.66666666666663" cy="15" r="3" stroke="#e15759"></circle>
+      <circle cx="470" cy="15" r="3" stroke="#e15759"></circle>
+    </g>
+  </svg>
+</figure>

--- a/test/output/title.html
+++ b/test/output/title.html
@@ -1,6 +1,6 @@
-<figure style="max-width: initial;">
-  <h2 class="plot-d6a7b5-h2">A title about penguins</h2>
-  <h3 class="plot-d6a7b5-h3">A subtitle about body_mass_g</h3>
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+  <h2>A title about penguins</h2>
+  <h3>A subtitle about body_mass_g</h3>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/titleHtml.html
+++ b/test/output/titleHtml.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <h2>A <i>fancy</i> title about penguins</h2>
   <em>A <tt>fancy</tt> subtitle</em><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>

--- a/test/output/titleHtml.html
+++ b/test/output/titleHtml.html
@@ -1,0 +1,384 @@
+<figure style="max-width: initial;">
+  <h2>A <i>fancy</i> title about penguins</h2>
+  <em>A <tt>fancy</tt> subtitle</em><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+      .plot {
+        display: block;
+        background: white;
+        height: auto;
+        height: intrinsic;
+        max-width: 100%;
+      }
+
+      .plot text,
+      .plot tspan {
+        white-space: pre;
+      }
+    </style>
+    <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+      <path transform="translate(70,30)" d="M0,0L0,6"></path>
+      <path transform="translate(153.33333333333331,30)" d="M0,0L0,6"></path>
+      <path transform="translate(236.66666666666666,30)" d="M0,0L0,6"></path>
+      <path transform="translate(320,30)" d="M0,0L0,6"></path>
+      <path transform="translate(403.3333333333333,30)" d="M0,0L0,6"></path>
+      <path transform="translate(486.6666666666667,30)" d="M0,0L0,6"></path>
+      <path transform="translate(569.9999999999999,30)" d="M0,0L0,6"></path>
+    </g>
+    <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+      <text y="0.71em" transform="translate(70,30)">3,000</text>
+      <text y="0.71em" transform="translate(153.33333333333331,30)">3,500</text>
+      <text y="0.71em" transform="translate(236.66666666666666,30)">4,000</text>
+      <text y="0.71em" transform="translate(320,30)">4,500</text>
+      <text y="0.71em" transform="translate(403.3333333333333,30)">5,000</text>
+      <text y="0.71em" transform="translate(486.6666666666667,30)">5,500</text>
+      <text y="0.71em" transform="translate(569.9999999999999,30)">6,000</text>
+    </g>
+    <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+      <text transform="translate(620,30)">body_mass_g →</text>
+    </g>
+    <g aria-label="dot" fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(0.5,0.5)">
+      <circle cx="195" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3"></circle>
+      <circle cx="174.16666666666666" cy="15" r="3"></circle>
+      <circle cx="349.1666666666667" cy="15" r="3"></circle>
+      <circle cx="149.16666666666669" cy="15" r="3"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3"></circle>
+      <circle cx="120" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3"></circle>
+      <circle cx="320" cy="15" r="3"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3"></circle>
+      <circle cx="170" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3"></circle>
+      <circle cx="95" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="120" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3"></circle>
+      <circle cx="120" cy="15" r="3"></circle>
+      <circle cx="345" cy="15" r="3"></circle>
+      <circle cx="95" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="86.66666666666666" cy="15" r="3"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3"></circle>
+      <circle cx="70" cy="15" r="3"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3"></circle>
+      <circle cx="140.83333333333334" cy="15" r="3"></circle>
+      <circle cx="65.83333333333334" cy="15" r="3"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3"></circle>
+      <circle cx="245" cy="15" r="3"></circle>
+      <circle cx="53.33333333333333" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="45" cy="15" r="3"></circle>
+      <circle cx="195" cy="15" r="3"></circle>
+      <circle cx="95" cy="15" r="3"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3"></circle>
+      <circle cx="170" cy="15" r="3"></circle>
+      <circle cx="245" cy="15" r="3"></circle>
+      <circle cx="45" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3"></circle>
+      <circle cx="78.33333333333334" cy="15" r="3"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3"></circle>
+      <circle cx="170" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="170" cy="15" r="3"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3"></circle>
+      <circle cx="120" cy="15" r="3"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="294.99999999999994" cy="15" r="3"></circle>
+      <circle cx="53.33333333333333" cy="15" r="3"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3"></circle>
+      <circle cx="190.83333333333331" cy="15" r="3"></circle>
+      <circle cx="357.5" cy="15" r="3"></circle>
+      <circle cx="82.50000000000001" cy="15" r="3"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3"></circle>
+      <circle cx="57.5" cy="15" r="3"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3"></circle>
+      <circle cx="195" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="99.16666666666667" cy="15" r="3"></circle>
+      <circle cx="365.8333333333333" cy="15" r="3"></circle>
+      <circle cx="207.5" cy="15" r="3"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3"></circle>
+      <circle cx="282.5" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="249.16666666666666" cy="15" r="3"></circle>
+      <circle cx="53.33333333333333" cy="15" r="3"></circle>
+      <circle cx="199.16666666666666" cy="15" r="3"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3"></circle>
+      <circle cx="95" cy="15" r="3"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3"></circle>
+      <circle cx="215.83333333333334" cy="15" r="3"></circle>
+      <circle cx="78.33333333333334" cy="15" r="3"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3"></circle>
+      <circle cx="115.83333333333333" cy="15" r="3"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3"></circle>
+      <circle cx="78.33333333333334" cy="15" r="3"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3"></circle>
+      <circle cx="315.83333333333337" cy="15" r="3"></circle>
+      <circle cx="140.83333333333334" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="99.16666666666667" cy="15" r="3"></circle>
+      <circle cx="232.5" cy="15" r="3"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3"></circle>
+      <circle cx="149.16666666666669" cy="15" r="3"></circle>
+      <circle cx="78.33333333333334" cy="15" r="3"></circle>
+      <circle cx="190.83333333333331" cy="15" r="3"></circle>
+      <circle cx="70" cy="15" r="3"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3"></circle>
+      <circle cx="278.33333333333337" cy="15" r="3"></circle>
+      <circle cx="149.16666666666669" cy="15" r="3"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3"></circle>
+      <circle cx="195" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3"></circle>
+      <circle cx="157.49999999999997" cy="15" r="3"></circle>
+      <circle cx="190.83333333333331" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3"></circle>
+      <circle cx="195" cy="15" r="3"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="199.16666666666666" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="245" cy="15" r="3"></circle>
+      <circle cx="165.83333333333331" cy="15" r="3"></circle>
+      <circle cx="245" cy="15" r="3"></circle>
+      <circle cx="120" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3"></circle>
+      <circle cx="170" cy="15" r="3"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3"></circle>
+      <circle cx="53.33333333333333" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="120" cy="15" r="3"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="186.66666666666669" cy="15" r="3"></circle>
+      <circle cx="328.3333333333333" cy="15" r="3"></circle>
+      <circle cx="103.33333333333334" cy="15" r="3"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3"></circle>
+      <circle cx="170" cy="15" r="3"></circle>
+      <circle cx="220" cy="15" r="3"></circle>
+      <circle cx="211.66666666666666" cy="15" r="3"></circle>
+      <circle cx="370" cy="15" r="3"></circle>
+      <circle cx="20" cy="15" r="3"></circle>
+      <circle cx="320" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3"></circle>
+      <circle cx="161.66666666666666" cy="15" r="3"></circle>
+      <circle cx="153.33333333333331" cy="15" r="3"></circle>
+      <circle cx="182.5" cy="15" r="3"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3"></circle>
+      <circle cx="182.5" cy="15" r="3"></circle>
+      <circle cx="124.16666666666666" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="170" cy="15" r="3"></circle>
+      <circle cx="245" cy="15" r="3"></circle>
+      <circle cx="128.33333333333334" cy="15" r="3"></circle>
+      <circle cx="145.00000000000003" cy="15" r="3"></circle>
+      <circle cx="111.66666666666667" cy="15" r="3"></circle>
+      <circle cx="245" cy="15" r="3"></circle>
+      <circle cx="203.33333333333334" cy="15" r="3"></circle>
+      <circle cx="157.49999999999997" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3"></circle>
+      <circle cx="178.33333333333334" cy="15" r="3"></circle>
+      <circle cx="236.66666666666666" cy="15" r="3"></circle>
+      <circle cx="136.66666666666666" cy="15" r="3"></circle>
+      <circle cx="199.16666666666666" cy="15" r="3"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3"></circle>
+      <circle cx="199.16666666666666" cy="15" r="3"></circle>
+      <circle cx="320" cy="15" r="3"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3"></circle>
+      <circle cx="470" cy="15" r="3"></circle>
+      <circle cx="328.3333333333333" cy="15" r="3"></circle>
+      <circle cx="370" cy="15" r="3"></circle>
+      <circle cx="436.66666666666663" cy="15" r="3"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3"></circle>
+      <circle cx="428.33333333333337" cy="15" r="3"></circle>
+      <circle cx="345" cy="15" r="3"></circle>
+      <circle cx="495" cy="15" r="3"></circle>
+      <circle cx="345" cy="15" r="3"></circle>
+      <circle cx="545" cy="15" r="3"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3"></circle>
+      <circle cx="545" cy="15" r="3"></circle>
+      <circle cx="261.6666666666667" cy="15" r="3"></circle>
+      <circle cx="620" cy="15" r="3"></circle>
+      <circle cx="370" cy="15" r="3"></circle>
+      <circle cx="461.6666666666667" cy="15" r="3"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3"></circle>
+      <circle cx="411.6666666666667" cy="15" r="3"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3"></circle>
+      <circle cx="420" cy="15" r="3"></circle>
+      <circle cx="253.33333333333334" cy="15" r="3"></circle>
+      <circle cx="511.66666666666663" cy="15" r="3"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3"></circle>
+      <circle cx="495" cy="15" r="3"></circle>
+      <circle cx="445" cy="15" r="3"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3"></circle>
+      <circle cx="411.6666666666667" cy="15" r="3"></circle>
+      <circle cx="578.3333333333334" cy="15" r="3"></circle>
+      <circle cx="428.33333333333337" cy="15" r="3"></circle>
+      <circle cx="470" cy="15" r="3"></circle>
+      <circle cx="395" cy="15" r="3"></circle>
+      <circle cx="445" cy="15" r="3"></circle>
+      <circle cx="294.99999999999994" cy="15" r="3"></circle>
+      <circle cx="461.6666666666667" cy="15" r="3"></circle>
+      <circle cx="228.33333333333331" cy="15" r="3"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3"></circle>
+      <circle cx="495" cy="15" r="3"></circle>
+      <circle cx="386.6666666666667" cy="15" r="3"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3"></circle>
+      <circle cx="470" cy="15" r="3"></circle>
+      <circle cx="420" cy="15" r="3"></circle>
+      <circle cx="453.3333333333333" cy="15" r="3"></circle>
+      <circle cx="378.3333333333333" cy="15" r="3"></circle>
+      <circle cx="453.3333333333333" cy="15" r="3"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3"></circle>
+      <circle cx="386.6666666666667" cy="15" r="3"></circle>
+      <circle cx="411.6666666666667" cy="15" r="3"></circle>
+      <circle cx="286.66666666666663" cy="15" r="3"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3"></circle>
+      <circle cx="311.66666666666663" cy="15" r="3"></circle>
+      <circle cx="495" cy="15" r="3"></circle>
+      <circle cx="270.00000000000006" cy="15" r="3"></circle>
+      <circle cx="453.3333333333333" cy="15" r="3"></circle>
+      <circle cx="303.3333333333333" cy="15" r="3"></circle>
+      <circle cx="511.66666666666663" cy="15" r="3"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3"></circle>
+      <circle cx="520.0000000000001" cy="15" r="3"></circle>
+      <circle cx="345" cy="15" r="3"></circle>
+      <circle cx="536.6666666666667" cy="15" r="3"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3"></circle>
+      <circle cx="495" cy="15" r="3"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3"></circle>
+      <circle cx="420" cy="15" r="3"></circle>
+      <circle cx="436.66666666666663" cy="15" r="3"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3"></circle>
+      <circle cx="536.6666666666667" cy="15" r="3"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3"></circle>
+      <circle cx="569.9999999999999" cy="15" r="3"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3"></circle>
+      <circle cx="561.6666666666667" cy="15" r="3"></circle>
+      <circle cx="340.8333333333333" cy="15" r="3"></circle>
+      <circle cx="478.3333333333333" cy="15" r="3"></circle>
+      <circle cx="357.5" cy="15" r="3"></circle>
+      <circle cx="461.6666666666667" cy="15" r="3"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3"></circle>
+      <circle cx="503.33333333333337" cy="15" r="3"></circle>
+      <circle cx="336.6666666666667" cy="15" r="3"></circle>
+      <circle cx="453.3333333333333" cy="15" r="3"></circle>
+      <circle cx="382.5" cy="15" r="3"></circle>
+      <circle cx="495" cy="15" r="3"></circle>
+      <circle cx="395" cy="15" r="3"></circle>
+      <circle cx="470" cy="15" r="3"></circle>
+      <circle cx="361.66666666666663" cy="15" r="3"></circle>
+      <circle cx="511.66666666666663" cy="15" r="3"></circle>
+      <circle cx="378.3333333333333" cy="15" r="3"></circle>
+      <circle cx="436.66666666666663" cy="15" r="3"></circle>
+      <circle cx="390.83333333333337" cy="15" r="3"></circle>
+      <circle cx="382.5" cy="15" r="3"></circle>
+      <circle cx="340.8333333333333" cy="15" r="3"></circle>
+      <circle cx="445" cy="15" r="3"></circle>
+      <circle cx="378.3333333333333" cy="15" r="3"></circle>
+      <circle cx="503.33333333333337" cy="15" r="3"></circle>
+      <circle cx="399.16666666666663" cy="15" r="3"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3"></circle>
+      <circle cx="357.5" cy="15" r="3"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3"></circle>
+      <circle cx="353.33333333333337" cy="15" r="3"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3"></circle>
+      <circle cx="332.5" cy="15" r="3"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3"></circle>
+      <circle cx="403.3333333333333" cy="15" r="3"></circle>
+      <circle cx="561.6666666666667" cy="15" r="3"></circle>
+      <circle cx="345" cy="15" r="3"></circle>
+      <circle cx="486.6666666666667" cy="15" r="3"></circle>
+      <circle cx="299.1666666666667" cy="15" r="3"></circle>
+      <circle cx="545" cy="15" r="3"></circle>
+      <circle cx="382.5" cy="15" r="3"></circle>
+      <circle cx="569.9999999999999" cy="15" r="3"></circle>
+      <circle cx="390.83333333333337" cy="15" r="3"></circle>
+      <circle cx="378.3333333333333" cy="15" r="3"></circle>
+      <circle cx="528.3333333333333" cy="15" r="3"></circle>
+      <circle cx="436.66666666666663" cy="15" r="3"></circle>
+      <circle cx="470" cy="15" r="3"></circle>
+    </g>
+  </svg>
+</figure>

--- a/test/output/trafficHorizon.html
+++ b/test/output/trafficHorizon.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       .plot-swatches {

--- a/test/output/usCountyChoropleth.html
+++ b/test/output/usCountyChoropleth.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/walmarts.html
+++ b/test/output/walmarts.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/output/warnMisalignedDivergingDomain.html
+++ b/test/output/warnMisalignedDivergingDomain.html
@@ -1,4 +1,4 @@
-<figure style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       .plot-ramp {
         display: block;

--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -287,6 +287,7 @@ export * from "./text-overflow.js";
 export * from "./this-is-just-to-say.js";
 export * from "./time-axis.js";
 export * from "./tip.js";
+export * from "./title.js";
 export * from "./traffic-horizon.js";
 export * from "./travelers-covid-drop.js";
 export * from "./travelers-year-over-year.js";

--- a/test/plots/title.ts
+++ b/test/plots/title.ts
@@ -1,0 +1,20 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+import {html} from "htl";
+
+export async function title() {
+  const penguins = await d3.csv("data/penguins.csv", d3.autoType);
+  return Plot.dotX(penguins, {x: "body_mass_g", stroke: "species"}).plot({
+    title: "A title about penguins",
+    subtitle: "A subtitle about body_mass_g",
+    color: {legend: true}
+  });
+}
+
+export async function titleHtml() {
+  const penguins = await d3.csv("data/penguins.csv", d3.autoType);
+  return Plot.dotX(penguins, {x: "body_mass_g"}).plot({
+    title: html`<h2>A <i>fancy</i> title about penguins</h2>`,
+    subtitle: html`<em>A <tt>fancy</tt> subtitle</em>`
+  });
+}


### PR DESCRIPTION
Add top-level **title** and **subtitle** options.

Like caption, these options make a figure element. By default the title is considered text, and set in a H2 element. The subtitle in a H3 element. If an HTML node is passed, it is used as is (this differs from caption, where the contents are always wrapped in a figcaption element).

I'd like to add default styles, but better discuss them here before, because changing the styles will modify all the snapshot tests. And, in that case, maybe add `${className}-figure` on the figure element?

Default styles could be something like:
```js
.${className}-h2 {
  margin-top: 0.3em;
  margin-bottom: 0.3em;
}
.${className}-h3 {
  margin-top: 0.3em;
  margin-bottom: 0.3em;
  font-weight: normal;
  font-style: italic;
}
```


Demo: https://observablehq.com/@observablehq/plot-title-1761

closes #92
supersedes #423 