### PR TITLE
Auto mark: isMonotonic return false if points collide

### DIFF
--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -254,7 +254,8 @@ function isMonotonic(values) {
       continue;
     }
     const order = Math.sign(ascending(previous, value));
-    if (!order) continue; // skip zero, NaN
+    if (isNaN(order)) continue; // skip NaN
+    if (order === 0) return false; // fail on collision, e.g. sorted within series
     if (previousOrder !== undefined && order !== previousOrder) return false;
     previous = value;
     previousOrder = order;

--- a/test/plots/autoplot.ts
+++ b/test/plots/autoplot.ts
@@ -264,3 +264,18 @@ export async function autoBarNoReducer() {
   const simpsons = await d3.csv<any>("data/simpsons.csv", d3.autoType);
   return Plot.auto(simpsons, {x: "season", y: "number_in_season", color: "imdb_rating", mark: "bar"}).plot();
 }
+
+export async function autoLineCollision() {
+  const data = [
+    {date: new Date(2020, 0, 1), value: 5, series: 1},
+    {date: new Date(2020, 0, 1), value: 50, series: 2},
+    {date: new Date(2020, 0, 1), value: 500, series: 3},
+    {date: new Date(2020, 0, 2), value: 6, series: 1},
+    {date: new Date(2020, 0, 2), value: 60, series: 2},
+    {date: new Date(2020, 0, 2), value: 600, series: 3},
+    {date: new Date(2020, 0, 3), value: 7, series: 1},
+    {date: new Date(2020, 0, 3), value: 70, series: 2},
+    {date: new Date(2020, 0, 3), value: 700, series: 3}
+  ]
+  return Plot.auto(data, {x: "date", y: "value"}).plot();
+}


### PR DESCRIPTION
Fixes https://github.com/observablehq/plot/issues/1763. Like making it a `> || <` check instead of `>= || <=`. Not sure about this approach but wanted to put something up.