### PR TITLE
fix: pointer interaction was not always dispatching the new value

### DIFF
--- a/src/interactions/pointer.js
+++ b/src/interactions/pointer.js
@@ -123,7 +123,10 @@ function pointerK(kx, ky, {x, y, px, py, maxRadius = 40, channels, render, ...op
           g.replaceWith(r);
         }
         state.roots[renderIndex] = g = r;
-        context.dispatchValue(i == null ? null : data[i]);
+
+        // Dispatch the value. When simultaneously exiting this facet and
+        // entering a new one, prioritize the entering facet.
+        if (!(i === null && facetState?.size > 1)) context.dispatchValue(i == null ? null : data[i]);
         return r;
       }
 


### PR DESCRIPTION
When simultaneously exiting a facet and entering a new one, prioritize dispatching the value from the entering facet.

Fixes #1778 

Cc: @yurivish 