### PR TITLE
fix a corner case where pointer interaction generates two points

### DIFF
--- a/src/interactions/pointer.js
+++ b/src/interactions/pointer.js
@@ -84,8 +84,8 @@ function pointerK(kx, ky, {x, y, px, py, maxRadius = 40, channels, render, ...op
             facetState.set(index.fi, ri);
             f = requestAnimationFrame(() => {
               f = null;
-              for (const r of facetState.values()) {
-                if (r < ri) {
+              for (const [fi, r] of facetState) {
+                if (r < ri || (r === ri && fi < index.fi)) {
                   ii = null;
                   break;
                 }


### PR DESCRIPTION
Because we're checking for strict inequality of the distance to the best facet, it can happen that we display 2 tips if the pointer is exactly at the same distance from two target points in different facets. This fixes this corner case, by retaining only the first point in case of strict equality.

I've seen it happen once, by chance, when I was playing with https://observablehq.com/d/a03f70ae5c5962c4 — so I'm sure it can happen in the wild, but it's difficult to reproduce: you need an environment where the pointer has integer coordinates (this depends on the browser, I think?), and the two targets have integer coordinates (e.g., using the round: true option on x — it's on by default on fx).