### PR TITLE
normalize links in JSDoc comments

### DIFF
--- a/src/format.d.ts
+++ b/src/format.d.ts
@@ -2,11 +2,12 @@
  * Returns a function that formats a given month number (from 0 = January to 11
  * = December) according to the specified *locale* and *format*.
  *
- * @param locale a [BCP 47 language tag](https://tools.ietf.org/html/bcp47);
- * defaults to U.S. English.
- * @param format a [month
- * format](https://tc39.es/ecma402/#datetimeformat-objects): either *2-digit*,
- * *numeric*, *narrow*, *short*, *long*; defaults to *short*.
+ * @param locale a [BCP 47 language tag][1]; defaults to U.S. English.
+ * @param format a [month format][2]: either *2-digit*, *numeric*, *narrow*,
+ * *short*, *long*; defaults to *short*.
+ *
+ * [1]: https://tools.ietf.org/html/bcp47
+ * [2]: https://tc39.es/ecma402/#datetimeformat-objects
  */
 export function formatMonth(
   locale?: string,
@@ -17,11 +18,12 @@ export function formatMonth(
  * Returns a function that formats a given week day number (from 0 = Sunday to 6
  * = Saturday) according to the specified *locale* and *format*.
  *
- * @param locale a [BCP 47 language tag](https://tools.ietf.org/html/bcp47);
- * defaults to U.S. English.
- * @param format a [weekday
- * format](https://tc39.es/ecma402/#datetimeformat-objects): either *narrow*,
- * *short*, or *long*; defaults to *short*.
+ * @param locale a [BCP 47 language tag][1]; defaults to U.S. English.
+ * @param format a [weekday format][2]: either *narrow*, *short*, or *long*;
+ * defaults to *short*.
+ *
+ * [1]: https://tools.ietf.org/html/bcp47
+ * [2]: https://tc39.es/ecma402/#datetimeformat-objects
  */
 export function formatWeekday(locale?: string, format?: "long" | "short" | "narrow"): (i: number) => string;
 

--- a/src/marks/text.d.ts
+++ b/src/marks/text.d.ts
@@ -205,8 +205,8 @@ export interface TextYOptions extends Omit<TextOptions, "x"> {
  *
  * [1]: https://observablehq.com/@mbostock/number-formatting
  * [2]: https://observablehq.com/@mbostock/date-formatting
- * [3]: https://github.com/d3/d3-format
- * [4]: https://github.com/d3/d3-time-format
+ * [3]: https://d3js.org/d3-format
+ * [4]: https://d3js.org/d3-time-format
  */
 export function text(data?: Data, options?: TextOptions): Text;
 

--- a/src/plot.d.ts
+++ b/src/plot.d.ts
@@ -9,11 +9,11 @@ export interface PlotOptions extends ScaleDefaults {
 
   /**
    * The outer width of the plot in pixels, including margins. Defaults to 640.
-   * On Observable, this can be set to the built-in
-   * [width](https://github.com/observablehq/stdlib/blob/main/README.md#width)
-   * for full-width responsive plots. Note: the default style has a max-width of
-   * 100%; the plot will automatically shrink to fit even when a fixed width is
-   * specified.
+   * On Observable, this can be set to the built-in [width][1] for full-width
+   * responsive plots. Note: the default style has a max-width of 100%; the plot
+   * will automatically shrink to fit even when a fixed width is specified.
+   *
+   * [1]: https://github.com/observablehq/stdlib/blob/main/README.md#width
    */
   width?: number;
 
@@ -77,20 +77,15 @@ export interface PlotOptions extends ScaleDefaults {
   /**
    * Custom styles to override Plot’s defaults. Styles may be specified either
    * as a string of inline styles (*e.g.*, `"color: red;"`, in the same fashion
-   * as assigning
-   * [*element*.style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style))
-   * or an object of properties (*e.g.*, `{color: "red"}`, in the same fashion
-   * as assigning [*element*.style
-   * properties](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration)).
-   * Note that unitless numbers ([quirky
-   * lengths](https://www.w3.org/TR/css-values-4/#deprecated-quirky-length))
-   * such as `{padding: 20}` may not supported by some browsers; you should
-   * instead specify a string with units such as `{padding: "20px"}`. By
-   * default, the returned plot has a white background, a max-width of 100%, and
-   * the system-ui font. Plot’s marks and axes default to
-   * [currentColor](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword),
-   * meaning that they will inherit the surrounding content’s color. For
-   * example, a dark theme:
+   * as assigning [*element*.style][1]) or an object of properties (*e.g.*,
+   * `{color: "red"}`, in the same fashion as assigning [*element*.style
+   * properties][2]). Note that unitless numbers ([quirky lengths][3]) such as
+   * `{padding: 20}` may not supported by some browsers; you should instead
+   * specify a string with units such as `{padding: "20px"}`. By default, the
+   * returned plot has a white background, a max-width of 100%, and the
+   * system-ui font. Plot’s marks and axes default to [currentColor][4], meaning
+   * that they will inherit the surrounding content’s color. For example, a dark
+   * theme:
    *
    * ```js
    * Plot.plot({
@@ -98,6 +93,11 @@ export interface PlotOptions extends ScaleDefaults {
    *   marks: …
    * })
    * ```
+   *
+   * [1]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style
+   * [2]: https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration
+   * [3]: https://www.w3.org/TR/css-values-4/#deprecated-quirky-length
+   * [4]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword
    */
   style?: string | Partial<CSSStyleDeclaration> | null;
 
@@ -110,9 +110,9 @@ export interface PlotOptions extends ScaleDefaults {
   /**
    * The figure caption. If present, Plot wraps the generated SVG element in an
    * HTML figure element with a figcaption, returning the figure. To specify an
-   * HTML caption, consider using the [`html` tagged template
-   * literal](http://github.com/observablehq/htl); otherwise, the specified
-   * string represents text that will be escaped as needed.
+   * HTML caption, consider using the [`html` tagged template literal][1];
+   * otherwise, the specified string represents text that will be escaped as
+   * needed.
    *
    * ```js
    * Plot.plot({
@@ -120,29 +120,31 @@ export interface PlotOptions extends ScaleDefaults {
    *   marks: …
    * })
    * ```
+   *
+   * [1]: https://github.com/observablehq/htl
    */
   caption?: string | Node | null;
 
   /**
-   * The [aria-label
-   * attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
-   * on the SVG root.
+   * The [aria-label attribute][1] on the SVG root.
+   *
+   * [1]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
    */
   ariaLabel?: string | null;
 
   /**
-   * The [aria-description
-   * attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description)
-   * on the SVG root.
+   * The [aria-description attribute][1] on the SVG root.
+   *
+   * [1]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description
    */
   ariaDescription?: string | null;
 
   /**
-   * The owner
-   * [Document](https://developer.mozilla.org/en-US/docs/Web/API/Document) used
-   * to create DOM elements. Defaults to window.document, but can be changed to
-   * another document, say when using a virtual DOM library for server-side
-   * rendering in Node.
+   * The owner [Document][1] used to create DOM elements. Defaults to
+   * window.document, but can be changed to another document, say when using a
+   * virtual DOM library for server-side rendering in Node.
+   *
+   * [1]: https://developer.mozilla.org/en-US/docs/Web/API/Document
    */
   document?: Document;
 
@@ -184,10 +186,11 @@ export interface PlotOptions extends ScaleDefaults {
    * first quartile of values has a radius of 3 pixels, but no value has a
    * radius greater than 30 pixels.
    *
-   * Plot does not currently implement a radius legend; see
-   * [#236](https://github.com/observablehq/plot/issues/236). We recommend
-   * either implementing one manually or labeling points so that values can be
-   * read directly from the plot.
+   * Plot does not currently implement a radius legend; see [#236][1]. We
+   * recommend either implementing one manually or labeling points so that
+   * values can be read directly from the plot.
+   *
+   * [1]: https://github.com/observablehq/plot/issues/236
    */
   r?: ScaleOptions;
 

--- a/src/scales.d.ts
+++ b/src/scales.d.ts
@@ -579,9 +579,12 @@ export interface ScaleOptions extends ScaleDefaults {
   /**
    * How to format inputs (abstract values) for axis tick labels; one of:
    *
-   * - a [d3-format](https://github.com/d3/d3-format) string for numeric scales
-   * - a [d3-time-format](https://github.com/d3/d3-time-format) string for temporal scales
+   * - a [d3-format][1] string for numeric scales
+   * - a [d3-time-format][2] string for temporal scales
    * - a function passed a tick *value* and *index*, returning a string
+   *
+   * [1]: https://d3js.org/d3-time
+   * [2]: https://d3js.org/d3-time-format
    */
   tickFormat?: string | ((t: any, i: number) => any) | null;
 

--- a/src/transforms/stack.d.ts
+++ b/src/transforms/stack.d.ts
@@ -14,7 +14,7 @@ import type {CompareFunction, Transformed} from "./basic.js";
  * *wiggle* offset is recommended for streamgraphs in conjunction with the
  * *inside-out* order. For more, see [Byron & Wattenberg][1].
  *
- * [1]: http://leebyron.com/streamgraph/
+ * [1]: https://leebyron.com/streamgraph/
  */
 export type StackOffsetName =
   | "center"
@@ -53,7 +53,7 @@ export type StackOffset = StackOffsetName | StackOffsetFunction;
  * The *inside-out* order is recommended for streamgraphs in conjunction with
  * the *wiggle* offset. For more, see [Byron & Wattenberg][1].
  *
- * [1]: http://leebyron.com/streamgraph/
+ * [1]: https://leebyron.com/streamgraph/
  */
 export type StackOrderName = "value" | "x" | "y" | "z" | "sum" | "appearance" | "inside-out";
 

--- a/src/transforms/window.d.ts
+++ b/src/transforms/window.d.ts
@@ -15,9 +15,11 @@ import type {Map} from "./map.js";
  * - *max* - the maximum value
  * - *mean* - the mean (average) value
  * - *median* - the median value
- * - *variance* - the variance per [Welford’s algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm)
+ * - *variance* - the variance per [Welford’s algorithm][1]
  * - *mode* - the mode (most common occurrence)
  * - *pXX* - the percentile value, where XX is a number in [00,99]
+ *
+ * [1]: https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
  */
 export type WindowReducerName =
   | "difference" // specific to window


### PR DESCRIPTION
Normalize to using numbered links everywhere. Change a few http to https. 

Note that this changes the aspect of one element (_locale_), which goes from "paragraph" to "inline" mode:
 
<img width="898" alt="Capture d’écran 2023-08-07 à 16 28 16" src="https://github.com/observablehq/plot/assets/7001/d892e69b-8b26-41a2-8788-7b2997d04afa">

(Also, when the URL is long, we get bad reflows when using option-Q in VS Code.)