### PR TITLE
avoid repetition of format options

### DIFF
--- a/src/format.d.ts
+++ b/src/format.d.ts
@@ -2,11 +2,11 @@
  * Returns a function that formats a given month number (from 0 = January to 11
  * = December) according to the specified *locale* and *format*.
  *
- * @param locale a [BCP 47 language tag][1]; defaults to U.S. English.
- * @param format a [month format][2]; defaults to *short*.
- *
  * [1]: https://tools.ietf.org/html/bcp47
  * [2]: https://tc39.es/ecma402/#datetimeformat-objects
+ *
+ * @param locale - a [BCP 47 language tag][1]; defaults to U.S. English.
+ * @param format - a [month format][2]; defaults to *short*.
  */
 export function formatMonth(
   locale?: string,
@@ -17,11 +17,11 @@ export function formatMonth(
  * Returns a function that formats a given week day number (from 0 = Sunday to 6
  * = Saturday) according to the specified *locale* and *format*.
  *
- * @param locale a [BCP 47 language tag][1]; defaults to U.S. English.
- * @param format a [weekday format][2]; defaults to *short*.
- *
  * [1]: https://tools.ietf.org/html/bcp47
  * [2]: https://tc39.es/ecma402/#datetimeformat-objects
+ *
+ * @param locale a [BCP 47 language tag][1]; defaults to U.S. English.
+ * @param format a [weekday format][2]; defaults to *short*.
  */
 export function formatWeekday(locale?: string, format?: "long" | "short" | "narrow"): (i: number) => string;
 

--- a/src/format.d.ts
+++ b/src/format.d.ts
@@ -3,8 +3,7 @@
  * = December) according to the specified *locale* and *format*.
  *
  * @param locale a [BCP 47 language tag][1]; defaults to U.S. English.
- * @param format a [month format][2]: either *2-digit*, *numeric*, *narrow*,
- * *short*, *long*; defaults to *short*.
+ * @param format a [month format][2]; defaults to *short*.
  *
  * [1]: https://tools.ietf.org/html/bcp47
  * [2]: https://tc39.es/ecma402/#datetimeformat-objects
@@ -19,8 +18,7 @@ export function formatMonth(
  * = Saturday) according to the specified *locale* and *format*.
  *
  * @param locale a [BCP 47 language tag][1]; defaults to U.S. English.
- * @param format a [weekday format][2]: either *narrow*, *short*, or *long*;
- * defaults to *short*.
+ * @param format a [weekday format][2]; defaults to *short*.
  *
  * [1]: https://tools.ietf.org/html/bcp47
  * [2]: https://tc39.es/ecma402/#datetimeformat-objects


### PR DESCRIPTION
(as suggested by https://github.com/observablehq/plot/pull/1794#discussion_r1287786741; note that the second line is still in the ugly "paragraph" mode in VSCode, even though it's shorter that the first line 🤷

<img width="730" alt="Capture d’écran 2023-08-09 à 10 01 10" src="https://github.com/observablehq/plot/assets/7001/f1cdb700-ad72-41e7-ab2b-1a4177289226">
