### PR TITLE
custom tip format

### DIFF
--- a/src/channel.d.ts
+++ b/src/channel.d.ts
@@ -145,7 +145,7 @@ export type ChannelValue =
  * object to override the scale that would normally be associated with the
  * channel.
  */
-export type ChannelValueSpec = ChannelValue | {value: ChannelValue; scale?: Channel["scale"]}; // TODO label
+export type ChannelValueSpec = ChannelValue | {value: ChannelValue; label?: string; scale?: Channel["scale"]};
 
 /**
  * In some contexts, when specifying a mark channel’s value, you can provide a

--- a/src/channel.js
+++ b/src/channel.js
@@ -5,13 +5,13 @@ import {registry} from "./scales/index.js";
 import {isSymbol, maybeSymbol} from "./symbol.js";
 import {maybeReduce} from "./transforms/group.js";
 
-export function createChannel(data, {scale, type, value, filter, hint}, name) {
+export function createChannel(data, {scale, type, value, filter, hint, label = labelof(value)}, name) {
   if (hint === undefined && typeof value?.transform === "function") hint = value.hint;
   return inferChannelScale(name, {
     scale,
     type,
     value: valueof(data, value),
-    label: labelof(value),
+    label,
     filter,
     hint
   });

--- a/src/mark.d.ts
+++ b/src/mark.d.ts
@@ -1,6 +1,7 @@
 import type {Channel, ChannelDomainSort, ChannelValue, ChannelValues, ChannelValueSpec} from "./channel.js";
 import type {Context} from "./context.js";
 import type {Dimensions} from "./dimensions.js";
+import type {TipOptions} from "./marks/tip.js";
 import type {plot} from "./plot.js";
 import type {ScaleFunctions} from "./scales.js";
 import type {InitializerFunction, SortOrder, TransformFunction} from "./transforms/basic.js";
@@ -22,6 +23,9 @@ export type FrameAnchor =
   | "bottom"
   | "bottom-left"
   | "left";
+
+/** The pointer mode for the tip; corresponds to pointerX, pointerY, and pointer. */
+export type TipPointer = "x" | "y" | "xy";
 
 /**
  * A mark’s data; one of:
@@ -275,8 +279,8 @@ export interface MarkOptions {
    */
   title?: ChannelValue;
 
-  /** Whether to generate a tooltip for this mark. */
-  tip?: boolean | "x" | "y" | "xy";
+  /** Whether to generate a tooltip for this mark, and any tip options. */
+  tip?: boolean | TipPointer | (TipOptions & {pointer?: TipPointer});
 
   /**
    * How to clip the mark; one of:

--- a/src/mark.js
+++ b/src/mark.js
@@ -2,7 +2,7 @@ import {channelDomain, createChannels, valueObject} from "./channel.js";
 import {defined} from "./defined.js";
 import {maybeFacetAnchor} from "./facet.js";
 import {maybeNamed, maybeValue} from "./options.js";
-import {arrayify, isDomainSort, isOptions, keyword, range, singleton} from "./options.js";
+import {arrayify, isDomainSort, isObject, isOptions, keyword, range, singleton} from "./options.js";
 import {project} from "./projection.js";
 import {maybeClip, styles} from "./style.js";
 import {basic, initializer} from "./transforms/basic.js";
@@ -167,6 +167,10 @@ function maybeTip(tip) {
     : tip; // tip options object
 }
 
-export function withTip(options, tip) {
-  return options?.tip === true ? {...options, tip} : options;
+export function withTip(options, pointer) {
+  return options?.tip === true
+    ? {...options, tip: pointer}
+    : isObject(options?.tip) && options.tip.pointer === undefined
+    ? {...options, tip: {...options.tip, pointer}}
+    : options;
 }

--- a/src/mark.js
+++ b/src/mark.js
@@ -1,7 +1,7 @@
 import {channelDomain, createChannels, valueObject} from "./channel.js";
 import {defined} from "./defined.js";
 import {maybeFacetAnchor} from "./facet.js";
-import {maybeKeyword, maybeNamed, maybeValue} from "./options.js";
+import {maybeNamed, maybeValue} from "./options.js";
 import {arrayify, isDomainSort, isOptions, keyword, range, singleton} from "./options.js";
 import {project} from "./projection.js";
 import {maybeClip, styles} from "./style.js";
@@ -150,7 +150,7 @@ export function composeRender(r1, r2) {
 function maybeChannels(channels) {
   return Object.fromEntries(
     Object.entries(maybeNamed(channels)).map(([name, channel]) => {
-      channel = maybeValue(channel);
+      channel = typeof channel === "string" ? {value: channel, label: name} : maybeValue(channel); // for shorthand extra channels, use name as label
       if (channel.filter === undefined && channel.scale == null) channel = {...channel, filter: null};
       return [name, channel];
     })
@@ -158,7 +158,13 @@ function maybeChannels(channels) {
 }
 
 function maybeTip(tip) {
-  return tip === true ? "xy" : tip === false ? null : maybeKeyword(tip, "tip", ["x", "y", "xy"]);
+  return tip === true
+    ? "xy"
+    : tip === false || tip == null
+    ? null
+    : typeof tip === "string"
+    ? keyword(tip, "tip", ["x", "y", "xy"])
+    : tip; // tip options object
 }
 
 export function withTip(options, tip) {

--- a/src/marks/tip.d.ts
+++ b/src/marks/tip.d.ts
@@ -1,4 +1,4 @@
-import type {ChannelValueSpec} from "../channel.js";
+import type {ChannelName, ChannelValueSpec} from "../channel.js";
 import type {Data, FrameAnchor, MarkOptions, RenderableMark} from "../mark.js";
 import type {TextStyles} from "./text.js";
 
@@ -61,6 +61,13 @@ export interface TipOptions extends MarkOptions, TextStyles {
    * the right of the anchor position.
    */
   anchor?: FrameAnchor;
+
+  /**
+   * How channel values are formatted for display. If a format is a string, it
+   * is interpreted as a (UTC) time format for temporal channels, and otherwise
+   * a number format.
+   */
+  format?: {[name in ChannelName]?: string | ((d: any, i: number) => string)};
 }
 
 /**

--- a/src/marks/tip.d.ts
+++ b/src/marks/tip.d.ts
@@ -67,7 +67,7 @@ export interface TipOptions extends MarkOptions, TextStyles {
    * is interpreted as a (UTC) time format for temporal channels, and otherwise
    * a number format.
    */
-  format?: {[name in ChannelName]?: string | ((d: any, i: number) => string)};
+  format?: {[name in ChannelName]?: boolean | string | ((d: any, i: number) => string)};
 }
 
 /**

--- a/src/marks/tip.js
+++ b/src/marks/tip.js
@@ -350,14 +350,10 @@ function getSourceChannels({channels}, scales) {
       const value = sources[key]?.value ?? scales[key]?.domain() ?? [];
       this.format[key] = (isTemporal(value) ? utcFormat : numberFormat)(format);
     } else if (format === undefined || format === true) {
-      // Borrow the scale’s tick format for facet channels; this is
-      // generally better than the default (and safe for ordinal scales).
-      if (key === "fx" || key === "fy") {
-        const scale = scales[key];
-        this.format[key] = inferTickFormat(scale, scale.domain());
-      } else {
-        this.format[key] = formatDefault;
-      }
+      // For ordinal scales, the inferred tick format can be more concise, such
+      // as only showing the year for yearly data.
+      const scale = scales[key];
+      this.format[key] = scale?.bandwidth ? inferTickFormat(scale, scale.domain()) : formatDefault;
     }
   }
 

--- a/src/plot.js
+++ b/src/plot.js
@@ -532,7 +532,10 @@ function inferTips(marks) {
       p = /^x$/i.test(p) ? pointerX : /^y$/i.test(p) ? pointerY : pointer; // TODO validate?
       tipOptions = p(derive(mark, tipOptions));
       tipOptions.title = null; // prevent implicit title for primitive data
-      tips.push(tip(mark.data, tipOptions));
+      const t = tip(mark.data, tipOptions);
+      t.facet = mark.facet; // inherit facet settings
+      t.facetAnchor = mark.facetAnchor; // inherit facet settings
+      tips.push(t);
     }
   }
   return tips;

--- a/src/plot.js
+++ b/src/plot.js
@@ -239,7 +239,6 @@ export function plot(options = {}) {
   // Compute value objects, applying scales and projection as needed.
   for (const [mark, state] of stateByMark) {
     state.values = mark.scale(state.channels, scales, context);
-    state.values.data = state.data; // expose transformed data for advanced usage
   }
 
   const {width, height} = dimensions;

--- a/src/time.js
+++ b/src/time.js
@@ -193,6 +193,23 @@ export function generalizeTimeInterval(interval, n) {
 
 function formatTimeInterval(name, type, anchor) {
   const format = type === "time" ? timeFormat : utcFormat;
+  // For tips and legends, use a format that doesn’t require context.
+  if (anchor == null) {
+    return format(
+      name === "year"
+        ? "%Y"
+        : name === "month"
+        ? "%Y-%m"
+        : name === "day"
+        ? "%Y-%m-%d"
+        : name === "hour" || name === "minute"
+        ? "%Y-%m-%dT%H:%M"
+        : name === "second"
+        ? "%Y-%m-%dT%H:%M:%S"
+        : "%Y-%m-%dT%H:%M:%S.%L"
+    );
+  }
+  // Otherwise, assume that this is for axis ticks.
   const template = getTimeTemplate(anchor);
   switch (name) {
     case "millisecond":

--- a/test/output/tipFormatChannels.svg
+++ b/test/output/tipFormatChannels.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">Name</tspan> Bob</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">Value</tspan> 1</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatFacet.svg
+++ b/test/output/tipFormatFacet.svg
@@ -1,0 +1,54 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
+    <g transform="translate(1,0)">
+      <text transform="translate(162,30)">a</text>
+    </g>
+    <g transform="translate(316,0)">
+      <text transform="translate(162,30)">b</text>
+    </g>
+  </g>
+  <g aria-label="x-axis tick" transform="translate(0.5,0)">
+    <g fill="none" stroke="currentColor" transform="translate(1,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+    <g fill="none" stroke="currentColor" transform="translate(316,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(0.5,9.5)">
+    <g font-variant="tabular-nums" transform="translate(1,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(316,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+  </g>
+  <g aria-label="tip" transform="translate(0.5,0.5)">
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(1,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> a</tspan></text>
+      </g>
+    </g>
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(316,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> b</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatFacetFalse.svg
+++ b/test/output/tipFormatFacetFalse.svg
@@ -1,0 +1,54 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
+    <g transform="translate(1,0)">
+      <text transform="translate(162,30)">a</text>
+    </g>
+    <g transform="translate(316,0)">
+      <text transform="translate(162,30)">b</text>
+    </g>
+  </g>
+  <g aria-label="x-axis tick" transform="translate(0.5,0)">
+    <g fill="none" stroke="currentColor" transform="translate(1,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+    <g fill="none" stroke="currentColor" transform="translate(316,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(0.5,9.5)">
+    <g font-variant="tabular-nums" transform="translate(1,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(316,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+  </g>
+  <g aria-label="tip" transform="translate(0.5,0.5)">
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(1,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
+      </g>
+    </g>
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(316,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatFacetFormat.svg
+++ b/test/output/tipFormatFacetFormat.svg
@@ -1,0 +1,54 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
+    <g transform="translate(1,0)">
+      <text transform="translate(162,30)"><tspan x="0" y="-1em">Jan</tspan><tspan x="0" dy="1em">1</tspan></text>
+    </g>
+    <g transform="translate(316,0)">
+      <text transform="translate(162,30)">2</text>
+    </g>
+  </g>
+  <g aria-label="x-axis tick" transform="translate(0.5,0)">
+    <g fill="none" stroke="currentColor" transform="translate(1,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+    <g fill="none" stroke="currentColor" transform="translate(316,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(0.5,9.5)">
+    <g font-variant="tabular-nums" transform="translate(1,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(316,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+  </g>
+  <g aria-label="tip" transform="translate(0.5,0.5)">
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(1,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> Jan 1</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
+      </g>
+    </g>
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(316,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> Jan 2</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatFacetFormatDefaultDay.svg
+++ b/test/output/tipFormatFacetFormatDefaultDay.svg
@@ -1,0 +1,54 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
+    <g transform="translate(1,0)">
+      <text transform="translate(162,30)"><tspan x="0" y="-1em">Jan</tspan><tspan x="0" dy="1em">1</tspan></text>
+    </g>
+    <g transform="translate(316,0)">
+      <text transform="translate(162,30)">2</text>
+    </g>
+  </g>
+  <g aria-label="x-axis tick" transform="translate(0.5,0)">
+    <g fill="none" stroke="currentColor" transform="translate(1,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+    <g fill="none" stroke="currentColor" transform="translate(316,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(0.5,9.5)">
+    <g font-variant="tabular-nums" transform="translate(1,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(316,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+  </g>
+  <g aria-label="tip" transform="translate(0.5,0.5)">
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(1,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2001-01-01</tspan></text>
+      </g>
+    </g>
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(316,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2001-01-02</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatFacetFormatDefaultHour.svg
+++ b/test/output/tipFormatFacetFormatDefaultHour.svg
@@ -15,10 +15,10 @@
   </style>
   <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
     <g transform="translate(1,0)">
-      <text transform="translate(162,30)"><tspan x="0" y="-1em">Jan 1</tspan><tspan x="0" dy="1em">8 PM</tspan></text>
+      <text transform="translate(162,30)"><tspan x="0" y="-1em">Jan 1</tspan><tspan x="0" dy="1em">12 PM</tspan></text>
     </g>
     <g transform="translate(316,0)">
-      <text transform="translate(162,30)">9 PM</text>
+      <text transform="translate(162,30)">1 PM</text>
     </g>
   </g>
   <g aria-label="x-axis tick" transform="translate(0.5,0)">
@@ -41,13 +41,13 @@
     <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(1,0)">
       <g transform="translate(162,80)">
         <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
-        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2001-01-01T20:00</tspan></text>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2001-01-01T12:00</tspan></text>
       </g>
     </g>
     <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(316,0)">
       <g transform="translate(162,80)">
         <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
-        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2001-01-01T21:00</tspan></text>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2001-01-01T13:00</tspan></text>
       </g>
     </g>
   </g>

--- a/test/output/tipFormatFacetFormatDefaultHour.svg
+++ b/test/output/tipFormatFacetFormatDefaultHour.svg
@@ -1,0 +1,54 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
+    <g transform="translate(1,0)">
+      <text transform="translate(162,30)"><tspan x="0" y="-1em">Jan 1</tspan><tspan x="0" dy="1em">8 PM</tspan></text>
+    </g>
+    <g transform="translate(316,0)">
+      <text transform="translate(162,30)">9 PM</text>
+    </g>
+  </g>
+  <g aria-label="x-axis tick" transform="translate(0.5,0)">
+    <g fill="none" stroke="currentColor" transform="translate(1,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+    <g fill="none" stroke="currentColor" transform="translate(316,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(0.5,9.5)">
+    <g font-variant="tabular-nums" transform="translate(1,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(316,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+  </g>
+  <g aria-label="tip" transform="translate(0.5,0.5)">
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(1,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2001-01-01T20:00</tspan></text>
+      </g>
+    </g>
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(316,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2001-01-01T21:00</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatFacetFormatDefaultYear.svg
+++ b/test/output/tipFormatFacetFormatDefaultYear.svg
@@ -1,0 +1,54 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
+    <g transform="translate(1,0)">
+      <text transform="translate(162,30)">2001</text>
+    </g>
+    <g transform="translate(316,0)">
+      <text transform="translate(162,30)">2002</text>
+    </g>
+  </g>
+  <g aria-label="x-axis tick" transform="translate(0.5,0)">
+    <g fill="none" stroke="currentColor" transform="translate(1,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+    <g fill="none" stroke="currentColor" transform="translate(316,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(0.5,9.5)">
+    <g font-variant="tabular-nums" transform="translate(1,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(316,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+  </g>
+  <g aria-label="tip" transform="translate(0.5,0.5)">
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(1,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2001</tspan></text>
+      </g>
+    </g>
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(316,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fx</tspan> 2002</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatFacetLabel.svg
+++ b/test/output/tipFormatFacetLabel.svg
@@ -1,0 +1,57 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
+    <g transform="translate(1,0)">
+      <text transform="translate(162,30)">2001</text>
+    </g>
+    <g transform="translate(316,0)">
+      <text transform="translate(162,30)">2002</text>
+    </g>
+  </g>
+  <g aria-label="fx-axis label" transform="translate(0.5,-26.5)">
+    <text y="0.71em" transform="translate(320.5,30)">Year</text>
+  </g>
+  <g aria-label="x-axis tick" transform="translate(0.5,0)">
+    <g fill="none" stroke="currentColor" transform="translate(1,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+    <g fill="none" stroke="currentColor" transform="translate(316,0)">
+      <path transform="translate(162,80)" d="M0,0L0,6"></path>
+    </g>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(0.5,9.5)">
+    <g font-variant="tabular-nums" transform="translate(1,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(316,0)">
+      <text y="0.71em" transform="translate(162,80)">0</text>
+    </g>
+  </g>
+  <g aria-label="tip" transform="translate(0.5,0.5)">
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(1,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">Year</tspan> 2001</tspan></text>
+      </g>
+    </g>
+    <g fill="white" stroke="currentColor" text-anchor="start" visibility="hidden" transform="translate(316,0)">
+      <g transform="translate(162,80)">
+        <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+        <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">Year</tspan> 2002</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatFunction.svg
+++ b/test/output/tipFormatFunction.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0.00</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatNull.svg
+++ b/test/output/tipFormatNull.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">Value</tspan> 1</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPaired.svg
+++ b/test/output/tipFormatPaired.svg
@@ -1,0 +1,48 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(20,60)" d="M0,0L0,6"></path>
+    <path transform="translate(80,60)" d="M0,0L0,6"></path>
+    <path transform="translate(140,60)" d="M0,0L0,6"></path>
+    <path transform="translate(200,60)" d="M0,0L0,6"></path>
+    <path transform="translate(260,60)" d="M0,0L0,6"></path>
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+    <path transform="translate(380,60)" d="M0,0L0,6"></path>
+    <path transform="translate(440,60)" d="M0,0L0,6"></path>
+    <path transform="translate(500,60)" d="M0,0L0,6"></path>
+    <path transform="translate(560,60)" d="M0,0L0,6"></path>
+    <path transform="translate(620,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(20,60)">0.0</text>
+    <text y="0.71em" transform="translate(80,60)">0.1</text>
+    <text y="0.71em" transform="translate(140,60)">0.2</text>
+    <text y="0.71em" transform="translate(200,60)">0.3</text>
+    <text y="0.71em" transform="translate(260,60)">0.4</text>
+    <text y="0.71em" transform="translate(320,60)">0.5</text>
+    <text y="0.71em" transform="translate(380,60)">0.6</text>
+    <text y="0.71em" transform="translate(440,60)">0.7</text>
+    <text y="0.71em" transform="translate(500,60)">0.8</text>
+    <text y="0.71em" transform="translate(560,60)">0.9</text>
+    <text y="0.71em" transform="translate(620,60)">1.0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0–1</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPairedFormat.svg
+++ b/test/output/tipFormatPairedFormat.svg
@@ -1,0 +1,48 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(20,60)" d="M0,0L0,6"></path>
+    <path transform="translate(80,60)" d="M0,0L0,6"></path>
+    <path transform="translate(140,60)" d="M0,0L0,6"></path>
+    <path transform="translate(200,60)" d="M0,0L0,6"></path>
+    <path transform="translate(260,60)" d="M0,0L0,6"></path>
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+    <path transform="translate(380,60)" d="M0,0L0,6"></path>
+    <path transform="translate(440,60)" d="M0,0L0,6"></path>
+    <path transform="translate(500,60)" d="M0,0L0,6"></path>
+    <path transform="translate(560,60)" d="M0,0L0,6"></path>
+    <path transform="translate(620,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(20,60)">0.0</text>
+    <text y="0.71em" transform="translate(80,60)">0.1</text>
+    <text y="0.71em" transform="translate(140,60)">0.2</text>
+    <text y="0.71em" transform="translate(200,60)">0.3</text>
+    <text y="0.71em" transform="translate(260,60)">0.4</text>
+    <text y="0.71em" transform="translate(320,60)">0.5</text>
+    <text y="0.71em" transform="translate(380,60)">0.6</text>
+    <text y="0.71em" transform="translate(440,60)">0.7</text>
+    <text y="0.71em" transform="translate(500,60)">0.8</text>
+    <text y="0.71em" transform="translate(560,60)">0.9</text>
+    <text y="0.71em" transform="translate(620,60)">1.0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">low–high</tspan> 0.00–1.00</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPairedLabel.svg
+++ b/test/output/tipFormatPairedLabel.svg
@@ -1,0 +1,48 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(20,60)" d="M0,0L0,6"></path>
+    <path transform="translate(80,60)" d="M0,0L0,6"></path>
+    <path transform="translate(140,60)" d="M0,0L0,6"></path>
+    <path transform="translate(200,60)" d="M0,0L0,6"></path>
+    <path transform="translate(260,60)" d="M0,0L0,6"></path>
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+    <path transform="translate(380,60)" d="M0,0L0,6"></path>
+    <path transform="translate(440,60)" d="M0,0L0,6"></path>
+    <path transform="translate(500,60)" d="M0,0L0,6"></path>
+    <path transform="translate(560,60)" d="M0,0L0,6"></path>
+    <path transform="translate(620,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(20,60)">0.0</text>
+    <text y="0.71em" transform="translate(80,60)">0.1</text>
+    <text y="0.71em" transform="translate(140,60)">0.2</text>
+    <text y="0.71em" transform="translate(200,60)">0.3</text>
+    <text y="0.71em" transform="translate(260,60)">0.4</text>
+    <text y="0.71em" transform="translate(320,60)">0.5</text>
+    <text y="0.71em" transform="translate(380,60)">0.6</text>
+    <text y="0.71em" transform="translate(440,60)">0.7</text>
+    <text y="0.71em" transform="translate(500,60)">0.8</text>
+    <text y="0.71em" transform="translate(560,60)">0.9</text>
+    <text y="0.71em" transform="translate(620,60)">1.0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">low–high</tspan> 0–1</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPairedLabelChannel.svg
+++ b/test/output/tipFormatPairedLabelChannel.svg
@@ -1,0 +1,48 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(20,60)" d="M0,0L0,6"></path>
+    <path transform="translate(80,60)" d="M0,0L0,6"></path>
+    <path transform="translate(140,60)" d="M0,0L0,6"></path>
+    <path transform="translate(200,60)" d="M0,0L0,6"></path>
+    <path transform="translate(260,60)" d="M0,0L0,6"></path>
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+    <path transform="translate(380,60)" d="M0,0L0,6"></path>
+    <path transform="translate(440,60)" d="M0,0L0,6"></path>
+    <path transform="translate(500,60)" d="M0,0L0,6"></path>
+    <path transform="translate(560,60)" d="M0,0L0,6"></path>
+    <path transform="translate(620,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(20,60)">0.0</text>
+    <text y="0.71em" transform="translate(80,60)">0.1</text>
+    <text y="0.71em" transform="translate(140,60)">0.2</text>
+    <text y="0.71em" transform="translate(200,60)">0.3</text>
+    <text y="0.71em" transform="translate(260,60)">0.4</text>
+    <text y="0.71em" transform="translate(320,60)">0.5</text>
+    <text y="0.71em" transform="translate(380,60)">0.6</text>
+    <text y="0.71em" transform="translate(440,60)">0.7</text>
+    <text y="0.71em" transform="translate(500,60)">0.8</text>
+    <text y="0.71em" transform="translate(560,60)">0.9</text>
+    <text y="0.71em" transform="translate(620,60)">1.0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">Low–High</tspan> 0–1</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPairedLabelScale.svg
+++ b/test/output/tipFormatPairedLabelScale.svg
@@ -1,0 +1,51 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(20,60)" d="M0,0L0,6"></path>
+    <path transform="translate(80,60)" d="M0,0L0,6"></path>
+    <path transform="translate(140,60)" d="M0,0L0,6"></path>
+    <path transform="translate(200,60)" d="M0,0L0,6"></path>
+    <path transform="translate(260,60)" d="M0,0L0,6"></path>
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+    <path transform="translate(380,60)" d="M0,0L0,6"></path>
+    <path transform="translate(440,60)" d="M0,0L0,6"></path>
+    <path transform="translate(500,60)" d="M0,0L0,6"></path>
+    <path transform="translate(560,60)" d="M0,0L0,6"></path>
+    <path transform="translate(620,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(20,60)">0.0</text>
+    <text y="0.71em" transform="translate(80,60)">0.1</text>
+    <text y="0.71em" transform="translate(140,60)">0.2</text>
+    <text y="0.71em" transform="translate(200,60)">0.3</text>
+    <text y="0.71em" transform="translate(260,60)">0.4</text>
+    <text y="0.71em" transform="translate(320,60)">0.5</text>
+    <text y="0.71em" transform="translate(380,60)">0.6</text>
+    <text y="0.71em" transform="translate(440,60)">0.7</text>
+    <text y="0.71em" transform="translate(500,60)">0.8</text>
+    <text y="0.71em" transform="translate(560,60)">0.9</text>
+    <text y="0.71em" transform="translate(620,60)">1.0</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,60)">Intensity →</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">Intensity</tspan> 0–1</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPairedPartial.svg
+++ b/test/output/tipFormatPairedPartial.svg
@@ -1,0 +1,48 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(20,60)" d="M0,0L0,6"></path>
+    <path transform="translate(80,60)" d="M0,0L0,6"></path>
+    <path transform="translate(140,60)" d="M0,0L0,6"></path>
+    <path transform="translate(200,60)" d="M0,0L0,6"></path>
+    <path transform="translate(260,60)" d="M0,0L0,6"></path>
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+    <path transform="translate(380,60)" d="M0,0L0,6"></path>
+    <path transform="translate(440,60)" d="M0,0L0,6"></path>
+    <path transform="translate(500,60)" d="M0,0L0,6"></path>
+    <path transform="translate(560,60)" d="M0,0L0,6"></path>
+    <path transform="translate(620,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(20,60)">0.0</text>
+    <text y="0.71em" transform="translate(80,60)">0.1</text>
+    <text y="0.71em" transform="translate(140,60)">0.2</text>
+    <text y="0.71em" transform="translate(200,60)">0.3</text>
+    <text y="0.71em" transform="translate(260,60)">0.4</text>
+    <text y="0.71em" transform="translate(320,60)">0.5</text>
+    <text y="0.71em" transform="translate(380,60)">0.6</text>
+    <text y="0.71em" transform="translate(440,60)">0.7</text>
+    <text y="0.71em" transform="translate(500,60)">0.8</text>
+    <text y="0.71em" transform="translate(560,60)">0.9</text>
+    <text y="0.71em" transform="translate(620,60)">1.0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">high</tspan> 1</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPriority1.svg
+++ b/test/output/tipFormatPriority1.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">a</tspan> A</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">b</tspan> B</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPriority2.svg
+++ b/test/output/tipFormatPriority2.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">b</tspan> B</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">a</tspan> A</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPriorityDefault.svg
+++ b/test/output/tipFormatPriorityDefault.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">a</tspan> A</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">b</tspan> B</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPriorityPaired.svg
+++ b/test/output/tipFormatPriorityPaired.svg
@@ -1,0 +1,48 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(20,60)" d="M0,0L0,6"></path>
+    <path transform="translate(80,60)" d="M0,0L0,6"></path>
+    <path transform="translate(140,60)" d="M0,0L0,6"></path>
+    <path transform="translate(200,60)" d="M0,0L0,6"></path>
+    <path transform="translate(260,60)" d="M0,0L0,6"></path>
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+    <path transform="translate(380,60)" d="M0,0L0,6"></path>
+    <path transform="translate(440,60)" d="M0,0L0,6"></path>
+    <path transform="translate(500,60)" d="M0,0L0,6"></path>
+    <path transform="translate(560,60)" d="M0,0L0,6"></path>
+    <path transform="translate(620,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(20,60)">0.0</text>
+    <text y="0.71em" transform="translate(80,60)">0.1</text>
+    <text y="0.71em" transform="translate(140,60)">0.2</text>
+    <text y="0.71em" transform="translate(200,60)">0.3</text>
+    <text y="0.71em" transform="translate(260,60)">0.4</text>
+    <text y="0.71em" transform="translate(320,60)">0.5</text>
+    <text y="0.71em" transform="translate(380,60)">0.6</text>
+    <text y="0.71em" transform="translate(440,60)">0.7</text>
+    <text y="0.71em" transform="translate(500,60)">0.8</text>
+    <text y="0.71em" transform="translate(560,60)">0.9</text>
+    <text y="0.71em" transform="translate(620,60)">1.0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">low–high</tspan> 0–1</tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">fill</tspan> 0<tspan fill="rgb(149, 251, 81)" style="user-select: none;"> ■</tspan></tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatPriorityPaired2.svg
+++ b/test/output/tipFormatPriorityPaired2.svg
@@ -1,0 +1,48 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(20,60)" d="M0,0L0,6"></path>
+    <path transform="translate(80,60)" d="M0,0L0,6"></path>
+    <path transform="translate(140,60)" d="M0,0L0,6"></path>
+    <path transform="translate(200,60)" d="M0,0L0,6"></path>
+    <path transform="translate(260,60)" d="M0,0L0,6"></path>
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+    <path transform="translate(380,60)" d="M0,0L0,6"></path>
+    <path transform="translate(440,60)" d="M0,0L0,6"></path>
+    <path transform="translate(500,60)" d="M0,0L0,6"></path>
+    <path transform="translate(560,60)" d="M0,0L0,6"></path>
+    <path transform="translate(620,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(20,60)">0.0</text>
+    <text y="0.71em" transform="translate(80,60)">0.1</text>
+    <text y="0.71em" transform="translate(140,60)">0.2</text>
+    <text y="0.71em" transform="translate(200,60)">0.3</text>
+    <text y="0.71em" transform="translate(260,60)">0.4</text>
+    <text y="0.71em" transform="translate(320,60)">0.5</text>
+    <text y="0.71em" transform="translate(380,60)">0.6</text>
+    <text y="0.71em" transform="translate(440,60)">0.7</text>
+    <text y="0.71em" transform="translate(500,60)">0.8</text>
+    <text y="0.71em" transform="translate(560,60)">0.9</text>
+    <text y="0.71em" transform="translate(620,60)">1.0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">fill</tspan> 0<tspan fill="rgb(149, 251, 81)" style="user-select: none;"> ■</tspan></tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">low–high</tspan> 0–1</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatStringDate.svg
+++ b/test/output/tipFormatStringDate.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">2001</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> January 1, 2001</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatStringNumber.svg
+++ b/test/output/tipFormatStringNumber.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0.00</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatTitleExplicit.svg
+++ b/test/output/tipFormatTitleExplicit.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​2010-01-01</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatTitleIgnoreFormat.svg
+++ b/test/output/tipFormatTitleIgnoreFormat.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​0</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatTitlePrimitive.svg
+++ b/test/output/tipFormatTitlePrimitive.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="white" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​hello</tspan><tspan x="0" dy="1em">​world</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -292,6 +292,7 @@ export * from "./text-overflow.js";
 export * from "./this-is-just-to-say.js";
 export * from "./time-axis.js";
 export * from "./tip.js";
+export * from "./tip-format.js";
 export * from "./title.js";
 export * from "./traffic-horizon.js";
 export * from "./travelers-covid-drop.js";

--- a/test/plots/tip-format.ts
+++ b/test/plots/tip-format.ts
@@ -1,0 +1,113 @@
+import * as Plot from "@observablehq/plot";
+
+function tip(
+  data: Plot.Data,
+  {x = 0, frameAnchor = "bottom", anchor = "bottom", ...tipOptions}: Plot.TipOptions = {},
+  {height = 90, ...plotOptions}: Plot.PlotOptions = {}
+) {
+  return Plot.tip(data, {x, frameAnchor, anchor, ...tipOptions}).plot({height, ...plotOptions});
+}
+
+export async function tipFormatChannels() {
+  return tip([{value: 1}], {channels: {Name: ["Bob"], Value: "value"}});
+}
+
+export async function tipFormatFacet() {
+  return tip({length: 2}, {fx: ["a", "b"]}, {height: 110});
+}
+
+export async function tipFormatFacetFalse() {
+  return tip({length: 1}, {facet: false}, {marks: [Plot.ruleX({length: 2}, {fx: ["a", "b"]})], height: 110});
+}
+
+export async function tipFormatFacetFormat() {
+  return tip({length: 2}, {fx: [new Date("2001-01-01"), new Date("2001-01-02")], format: {fx: "%b %-d"}}, {height: 110});
+}
+
+export async function tipFormatFacetFormatDefaultHour() {
+  return tip({length: 2}, {fx: [new Date("2001-01-01T12:00"), new Date("2001-01-01T13:00")]}, {height: 110});
+}
+
+export async function tipFormatFacetFormatDefaultDay() {
+  return tip({length: 2}, {fx: [new Date("2001-01-01"), new Date("2001-01-02")]}, {height: 110});
+}
+
+export async function tipFormatFacetFormatDefaultYear() {
+  return tip({length: 2}, {fx: [new Date("2001-01-01"), new Date("2002-01-01")]}, {height: 110});
+}
+
+export async function tipFormatFacetLabel() {
+  return tip({length: 2}, {fx: [new Date("2001-01-01"), new Date("2002-01-01")]}, {fx: {label: "Year"}, height: 110});
+}
+
+export async function tipFormatFunction() {
+  return tip({length: 1}, {format: {x: (d) => d.toFixed(2)}});
+}
+
+export async function tipFormatNull() {
+  return tip([{value: 1}], {channels: {Value: "value"}, format: {x: null}});
+}
+
+export async function tipFormatPaired() {
+  return tip({length: 1}, {x1: 0, x2: 1});
+}
+
+export async function tipFormatPairedFormat() {
+  return tip([{low: 0, high: 1}], {x1: "low", x2: "high", format: {x: ".2f"}});
+}
+
+export async function tipFormatPairedLabel() {
+  return tip([{low: 0, high: 1}], {x1: "low", x2: "high"});
+}
+
+export async function tipFormatPairedLabelChannel() {
+  return tip({length: 1}, {x1: Object.assign([0], {label: "Low"}), x2: Object.assign([1], {label: "High"})});
+}
+
+export async function tipFormatPairedLabelScale() {
+  return tip({length: 1}, {x1: 0, x2: 1}, {x: {label: "Intensity"}});
+}
+
+export async function tipFormatPairedPartial() {
+  return tip([{low: 0, high: 1}], {x1: "low", x2: "high", format: {x1: null}});
+}
+
+export async function tipFormatPriority1() {
+  return tip({length: 1}, {channels: {a: ["A"], b: ["B"]}, format: {x: true}});
+}
+
+export async function tipFormatPriority2() {
+  return tip({length: 1}, {channels: {a: ["A"], b: ["B"]}, format: {b: true} as any});
+}
+
+export async function tipFormatPriorityDefault() {
+  return tip({length: 1}, {channels: {a: ["A"], b: ["B"]}, format: {}});
+}
+
+export async function tipFormatPriorityPaired() {
+  return tip([{low: 0, high: 1}], {fill: [0], x1: "low", x2: "high", format: {x: true}});
+}
+
+export async function tipFormatPriorityPaired2() {
+  return tip([{low: 0, high: 1}], {fill: [0], x1: "low", x2: "high", format: {fill: true}});
+}
+
+export async function tipFormatStringDate() {
+  return tip({length: 1}, {x: new Date("2001-01-01"), format: {x: "%B %-d, %Y"}});
+}
+
+export async function tipFormatStringNumber() {
+  return tip({length: 1}, {format: {x: ".2f"}});
+}
+
+export async function tipFormatTitleExplicit() {
+  return tip({length: 1}, {title: [new Date("2010-01-01")]});
+}
+
+export async function tipFormatTitleIgnoreFormat() {
+  return tip({length: 1}, {title: [0], format: {title: ".2f"}});
+}
+
+export async function tipFormatTitlePrimitive() {
+  return tip(["hello\nworld"], {x: 0});
+}

--- a/test/plots/tip-format.ts
+++ b/test/plots/tip-format.ts
@@ -21,7 +21,7 @@ export async function tipFormatFacetFalse() {
 }
 
 export async function tipFormatFacetFormat() {
-  return tip({length: 2}, {fx: [new Date("2001-01-01"), new Date("2001-01-02")], format: {fx: "%b %-d"}}, {height: 110});
+  return tip({length: 2}, {fx: [new Date("2001-01-01"), new Date("2001-01-02")], format: {fx: "%b %-d"}}, {height: 110}); // prettier-ignore
 }
 
 export async function tipFormatFacetFormatDefaultHour() {

--- a/test/plots/tip-format.ts
+++ b/test/plots/tip-format.ts
@@ -25,7 +25,7 @@ export async function tipFormatFacetFormat() {
 }
 
 export async function tipFormatFacetFormatDefaultHour() {
-  return tip({length: 2}, {fx: [new Date("2001-01-01T12:00"), new Date("2001-01-01T13:00")]}, {height: 110});
+  return tip({length: 2}, {fx: [new Date("2001-01-01T12:00Z"), new Date("2001-01-01T13:00Z")]}, {height: 110});
 }
 
 export async function tipFormatFacetFormatDefaultDay() {


### PR DESCRIPTION
This implements a new **format** option for the tip mark that specifies how to format values. The option is specified as an object whose property names are channel names and whose values are formats; each format may either be a shorthand string for a number or time format, or a function that takes a channel value and zero-based index and returns the corresponding formatted string.

For example, to customize the number format of the *x* channel:

```js
format: {x: ".2f"}
```

Equivalently:

```js
format: {x: (d) => d.toFixed(2)}
```

To suppress a channel (similar to #1822), set the corresponding format to null:

```js
format: {x: null}
```

As before, if you want the tip to display a paragraph of text, you can use the **title** channel; if you want to add additional name-value pairs to the tip, you can declare extra channels using the **channels** option; if you want to change the label, you can either change the corresponding channel or scale label. This PR improves the **channels** option slightly, allowing the **label** option to be declared alongside a channel #1734, and defaulting the channel label to its name when expressed as a shorthand string (e.g., `channels: {Sport: "sport"}` now uses the label “Sport” instead of “sport”.)

Lastly, the **tip** mark option now supports passing arbitrary options through to the derived tip mark, including the **format** option. The **tip** mark option also now takes a **pointer** option to control which pointer mode is used (_x_, _y_, or _xy_, for pointerX, pointerY, or pointer respectively).

Fixes #1612.
Fixes #1733.
Fixes #1734.