### PR TITLE
Auto: error on underspecified reduce

### DIFF
--- a/src/marks/auto.js
+++ b/src/marks/auto.js
@@ -15,6 +15,11 @@ import {ruleX, ruleY} from "./rule.js";
 export function autoSpec(data, options) {
   options = normalizeOptions(options);
 
+  for (const channel of ["x", "y", "color", "size"]) {
+    if (isUnderspecifiedReduce(options[channel]))
+      throw new Error(`setting ${channel} reducer to "${options[channel].reduce}" requires setting ${channel} field`);
+  }
+
   // Greedily materialize columns for type inference; we’ll need them anyway to
   // plot! Note that we don’t apply any type inference to the fx and fy
   // channels, if present; these are always ordinal (at least for now).
@@ -338,6 +343,10 @@ function isReducer(reduce) {
       return true;
   }
   return false;
+}
+
+function isUnderspecifiedReduce({value, reduce}) {
+  return value === undefined && reduce !== undefined && reduce !== "count";
 }
 
 function isHighCardinality(value) {


### PR DESCRIPTION
Watching people use the chart cell, they often set a reducer without understanding what it’s reducing. Min _of what_, max _of what_, mean _of what_? Setting most reducers without a field is incoherent; even if it produces something, it’ll be misleading. But people often don’t realize they have to do something else, because they see some output, and scratch their heads trying to interpret it.

Since it’s easy to statically tell if a configuration is invalid like this, this PR throws an error in those cases. Demo: https://observablehq.com/d/932dd87a4c129e16

<img width="845" alt="image" src="https://github.com/observablehq/plot/assets/841829/2fc0e42b-7146-48cc-a6f9-914f0bcfa5fd">

I tried to think of a more plain-English way to say this. We could do something like `Error: ${channel} is "${reducer}" of what? reducer requires ${channel} field`. People don’t know the word “reducer”, but they know the prepositional relationship expressed in “mean” _of_ “height”. It’s gotta be _of_ something.

Broken out from https://github.com/observablehq/plot/pull/1424.