### PR TITLE
Add possibility to include a data attribute to text element.

### DIFF
--- a/src/marks/text.d.ts
+++ b/src/marks/text.d.ts
@@ -151,6 +151,13 @@ export interface TextOptions extends MarkOptions, TextStyles {
    * interpreted as a channel.
    */
   rotate?: ChannelValue;
+
+  /**
+   * Add a data attribute to the text node, which could be used for targeting with CSS.
+   * If a string is provided the data attribute key will be "data-text",
+   * for more control provide an array with the attribute name and value, e.g. ["data-name", "my-text"].
+   */
+  dataAttr?: string | [`data-${string}`, string];
 }
 
 /** Options for the textX mark. */

--- a/src/marks/text.js
+++ b/src/marks/text.js
@@ -56,7 +56,8 @@ export class Text extends Mark {
       fontStyle,
       fontVariant,
       fontWeight,
-      rotate
+      rotate,
+      dataAttr
     } = options;
     const [vrotate, crotate] = maybeNumberChannel(rotate, 0);
     const [vfontSize, cfontSize] = maybeFontSizeChannel(fontSize);
@@ -88,11 +89,13 @@ export class Text extends Mark {
     if (!(this.lineWidth >= 0)) throw new Error(`invalid lineWidth: ${lineWidth}`);
     this.splitLines = splitter(this);
     this.clipLine = clipper(this);
+    this.dataAttr = dataAttr;
   }
   render(index, scales, channels, dimensions, context) {
     const {x, y} = scales;
     const {x: X, y: Y, rotate: R, text: T, title: TL, fontSize: FS} = channels;
     const {rotate} = this;
+    const [dataAttrKey, dataAttrValue] = Array.isArray(this.dataAttr) ? this.dataAttr : ["data-text", this.dataAttr];
     const [cx, cy] = applyFrameAnchor(this, dimensions);
     return create("svg:g", context)
       .call(applyIndirectStyles, this, dimensions, context)
@@ -114,6 +117,7 @@ export class Text extends Mark {
           )
           .call(applyAttr, "font-size", FS && ((i) => FS[i]))
           .call(applyChannelStyles, this, channels)
+          .call(applyAttr, dataAttrKey, dataAttrValue)
       )
       .node();
   }


### PR DESCRIPTION
I want to be able to scale text with css to offset text scaling together with the svg.
Ex, svg width=1000 and fontSize=16, if this svg then has a width: 100% with css on it, the text will be super small if the svg container scales down on for ex mobile devices.

With this we can now choose to add a data attribute to the text node which can be selected in css. This enables us to target different text nodes in the svg to apply different styling on different nodes. 

A really nice example is using container query units to offset the scaling text with css only. Then we can just do something like this with the cqi unit.
```
.plotcontainer text[data-name="my-regular-text"] {
    font-size: calc(2rem - 1.85cqi);
}

.plotcontainer text[data-name="my-large-text"] {
    font-size: calc(8rem - 2cqi);
}
```