### PR TITLE
box tip aggregate

### DIFF
--- a/src/marks/box.js
+++ b/src/marks/box.js
@@ -109,5 +109,5 @@ function boxStats(values) {
     }
   }
   const report = [q3, q1, mi, hiqr2, loqr1];
-  return values.map((d) => (d < loqr1 || d > hiqr2 ? d : report.pop() ?? NaN));
+  return values.map((d) => (d !== null && (d < loqr1 || d > hiqr2) ? d : report.pop() ?? NaN));
 }

--- a/src/marks/box.js
+++ b/src/marks/box.js
@@ -33,7 +33,7 @@ export function boxX(
     barX(data, group({x1: "p25", x2: "p75"}, {x, y, fill, fillOpacity, ...options})),
     tickX(data, group({x: "p50"}, {x, y, stroke, strokeOpacity, strokeWidth, sort, ...options})),
     dot(data, map({x: oqr}, {x, y, z: y, stroke, strokeOpacity, ...options})),
-    tip && tipmark(data, pointerX(map({x: boxStats}, {x, y, z: y, ...options})))
+    tip && tipmark(data, pointerY(map({x: boxStats}, {x, y, z: y, ...options})))
   );
 }
 
@@ -60,7 +60,7 @@ export function boxY(
     barY(data, group({y1: "p25", y2: "p75"}, {x, y, fill, fillOpacity, ...options})),
     tickY(data, group({y: "p50"}, {x, y, stroke, strokeOpacity, strokeWidth, sort, ...options})),
     dot(data, map({y: oqr}, {x, y, z: x, stroke, strokeOpacity, ...options})),
-    tip && tipmark(data, pointerY(map({y: boxStats}, {x, y, z: x, ...options})))
+    tip && tipmark(data, pointerX(map({y: boxStats}, {x, y, z: x, ...options})))
   );
 }
 

--- a/src/marks/box.js
+++ b/src/marks/box.js
@@ -1,4 +1,4 @@
-import {max, min, quantile} from "d3";
+import {max, min, quantile, quantileSorted} from "d3";
 import {marks} from "../mark.js";
 import {identity} from "../options.js";
 import {groupX, groupY, groupZ} from "../transforms/group.js";
@@ -7,6 +7,8 @@ import {barX, barY} from "./bar.js";
 import {dot} from "./dot.js";
 import {ruleX, ruleY} from "./rule.js";
 import {tickX, tickY} from "./tick.js";
+import {pointerX, pointerY} from "../interactions/pointer.js";
+import {tip as tipmark} from "./tip.js";
 
 // Returns a composite mark for producing a horizontal box plot, applying the
 // necessary statistical transforms. The boxes are grouped by y, if present.
@@ -21,6 +23,7 @@ export function boxX(
     strokeOpacity,
     strokeWidth = 2,
     sort,
+    tip,
     ...options
   } = {}
 ) {
@@ -29,7 +32,8 @@ export function boxX(
     ruleY(data, group({x1: loqr1, x2: hiqr2}, {x, y, stroke, strokeOpacity, ...options})),
     barX(data, group({x1: "p25", x2: "p75"}, {x, y, fill, fillOpacity, ...options})),
     tickX(data, group({x: "p50"}, {x, y, stroke, strokeOpacity, strokeWidth, sort, ...options})),
-    dot(data, map({x: oqr}, {x, y, z: y, stroke, strokeOpacity, ...options}))
+    dot(data, map({x: oqr}, {x, y, z: y, stroke, strokeOpacity, ...options})),
+    tip && tipmark(data, pointerX(map({x: boxStats}, {x, y, z: y, ...options})))
   );
 }
 
@@ -46,6 +50,7 @@ export function boxY(
     strokeOpacity,
     strokeWidth = 2,
     sort,
+    tip,
     ...options
   } = {}
 ) {
@@ -54,7 +59,8 @@ export function boxY(
     ruleX(data, group({y1: loqr1, y2: hiqr2}, {x, y, stroke, strokeOpacity, ...options})),
     barY(data, group({y1: "p25", y2: "p75"}, {x, y, fill, fillOpacity, ...options})),
     tickY(data, group({y: "p50"}, {x, y, stroke, strokeOpacity, strokeWidth, sort, ...options})),
-    dot(data, map({y: oqr}, {x, y, z: x, stroke, strokeOpacity, ...options}))
+    dot(data, map({y: oqr}, {x, y, z: x, stroke, strokeOpacity, ...options})),
+    tip && tipmark(data, pointerY(map({y: boxStats}, {x, y, z: x, ...options})))
   );
 }
 
@@ -81,4 +87,27 @@ function quartile1(values) {
 
 function quartile3(values) {
   return quantile(values, 0.75);
+}
+
+function boxStats(values) {
+  const V = Float64Array.from(
+    (function* (V) {
+      for (let v of V) if (v !== null && !isNaN((v = +v))) yield v;
+    })(values)
+  ).sort();
+  const q1 = quantileSorted(V, 0.25);
+  const mi = quantileSorted(V, 0.5);
+  const q3 = quantileSorted(V, 0.75);
+  const lo = q1 * 2.5 - q3 * 1.5;
+  const loqr1 = V.find((d) => d >= lo);
+  const hi = q3 * 2.5 - q1 * 1.5;
+  let hiqr2;
+  for (let i = V.length - 1; i >= 0; --i) {
+    if (V[i] <= hi) {
+      hiqr2 = V[i];
+      break;
+    }
+  }
+  const report = [q3, q1, mi, hiqr2, loqr1];
+  return values.map((d) => (d < loqr1 || d > hiqr2 ? d : report.pop() ?? NaN));
 }

--- a/test/output/boxplotFacetInterval.svg
+++ b/test/output/boxplotFacetInterval.svg
@@ -596,4 +596,17 @@
       <circle cx="215.25179856115108" cy="29.5" r="3"></circle>
     </g>
   </g>
+  <g aria-label="tip" transform="translate(0.5,0.5)">
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,1)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,22)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,43)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,64)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,85)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,106)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,127)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,148)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,169)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,190)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0,211)"></g>
+  </g>
 </svg>

--- a/test/output/boxplotXInterval.svg
+++ b/test/output/boxplotXInterval.svg
@@ -1,0 +1,493 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="280" viewBox="0 0 640 280" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" fill="none" stroke="currentColor" transform="translate(0,9.5)">
+    <path transform="translate(40,26)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,66)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,106)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,146)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,186)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,226)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,9.5)">
+    <text y="0.32em" transform="translate(40,26)">2.2</text>
+    <text y="0.32em" transform="translate(40,66)">2</text>
+    <text y="0.32em" transform="translate(40,106)">1.8</text>
+    <text y="0.32em" transform="translate(40,146)">1.6</text>
+    <text y="0.32em" transform="translate(40,186)">1.4</text>
+    <text y="0.32em" transform="translate(40,226)">1.2</text>
+  </g>
+  <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
+    <text y="0.71em" transform="translate(40,135) rotate(-90)">height →</text>
+  </g>
+  <g aria-label="x-axis tick" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(77.55395683453237,250)" d="M0,0L0,6"></path>
+    <path transform="translate(161.0071942446043,250)" d="M0,0L0,6"></path>
+    <path transform="translate(244.46043165467623,250)" d="M0,0L0,6"></path>
+    <path transform="translate(327.9136690647482,250)" d="M0,0L0,6"></path>
+    <path transform="translate(411.36690647482015,250)" d="M0,0L0,6"></path>
+    <path transform="translate(494.8201438848921,250)" d="M0,0L0,6"></path>
+    <path transform="translate(578.2733812949641,250)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(77.55395683453237,250)">40</text>
+    <text y="0.71em" transform="translate(161.0071942446043,250)">60</text>
+    <text y="0.71em" transform="translate(244.46043165467623,250)">80</text>
+    <text y="0.71em" transform="translate(327.9136690647482,250)">100</text>
+    <text y="0.71em" transform="translate(411.36690647482015,250)">120</text>
+    <text y="0.71em" transform="translate(494.8201438848921,250)">140</text>
+    <text y="0.71em" transform="translate(578.2733812949641,250)">160</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,250)">weight →</text>
+  </g>
+  <g aria-label="rule" stroke="currentColor" transform="translate(0,9.5)">
+    <line x1="106.76258992805755" x2="106.76258992805755" y1="226" y2="226"></line>
+    <line x1="40" x2="198.5611510791367" y1="206" y2="206"></line>
+    <line x1="48.34532374100719" x2="156.83453237410072" y1="186" y2="186"></line>
+    <line x1="56.690647482014384" x2="202.73381294964025" y1="166" y2="166"></line>
+    <line x1="85.89928057553956" x2="227.76978417266184" y1="146" y2="146"></line>
+    <line x1="102.58992805755395" x2="282.0143884892086" y1="126" y2="126"></line>
+    <line x1="140.14388489208633" x2="340.43165467625903" y1="106" y2="106"></line>
+    <line x1="173.5251798561151" x2="403.0215827338129" y1="86" y2="86"></line>
+    <line x1="231.9424460431655" x2="444.7482014388489" y1="66" y2="66"></line>
+    <line x1="277.841726618705" x2="453.0935251798561" y1="46" y2="46"></line>
+    <line x1="277.841726618705" x2="277.841726618705" y1="26" y2="26"></line>
+  </g>
+  <g aria-label="bar" fill="#ccc">
+    <rect x="106.76258992805755" width="0" y="226" height="18"></rect>
+    <rect x="71.29496402877697" width="66.76258992805757" y="206" height="18"></rect>
+    <rect x="75.46762589928059" width="35.46762589928056" y="186" height="18"></rect>
+    <rect x="110.93525179856115" width="37.553956834532386" y="166" height="18"></rect>
+    <rect x="135.97122302158274" width="37.55395683453236" y="146" height="18"></rect>
+    <rect x="169.3525179856115" width="45.899280575539564" y="126" height="18"></rect>
+    <rect x="215.25179856115108" width="50.07194244604318" y="106" height="18"></rect>
+    <rect x="256.978417266187" width="58.41726618705036" y="86" height="18"></rect>
+    <rect x="302.8776978417266" width="58.41726618705036" y="66" height="18"></rect>
+    <rect x="334.1726618705036" width="56.330935251798564" y="46" height="18"></rect>
+    <rect x="277.841726618705" width="0" y="26" height="18"></rect>
+  </g>
+  <g aria-label="tick" stroke="currentColor" stroke-width="2" transform="translate(0.5,0)">
+    <line x1="106.76258992805755" x2="106.76258992805755" y1="226" y2="244"></line>
+    <line x1="110.93525179856115" x2="110.93525179856115" y1="206" y2="224"></line>
+    <line x1="98.41726618705036" x2="98.41726618705036" y1="186" y2="204"></line>
+    <line x1="127.62589928057554" x2="127.62589928057554" y1="166" y2="184"></line>
+    <line x1="152.66187050359713" x2="152.66187050359713" y1="146" y2="164"></line>
+    <line x1="190.21582733812951" x2="190.21582733812951" y1="126" y2="144"></line>
+    <line x1="236.11510791366908" x2="236.11510791366908" y1="106" y2="124"></line>
+    <line x1="286.1870503597122" x2="286.1870503597122" y1="86" y2="104"></line>
+    <line x1="327.9136690647482" x2="327.9136690647482" y1="66" y2="84"></line>
+    <line x1="377.98561151079144" x2="377.98561151079144" y1="46" y2="64"></line>
+    <line x1="277.841726618705" x2="277.841726618705" y1="26" y2="44"></line>
+  </g>
+  <g aria-label="dot" fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(0.5,9.5)">
+    <circle cx="411.36690647482015" cy="126" r="3"></circle>
+    <circle cx="461.4388489208633" cy="86" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="294.53237410071944" cy="126" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="511.5107913669065" cy="106" r="3"></circle>
+    <circle cx="265.32374100719426" cy="146" r="3"></circle>
+    <circle cx="432.23021582733816" cy="86" r="3"></circle>
+    <circle cx="390.50359712230215" cy="106" r="3"></circle>
+    <circle cx="252.80575539568346" cy="146" r="3"></circle>
+    <circle cx="265.32374100719426" cy="146" r="3"></circle>
+    <circle cx="432.23021582733816" cy="106" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="307.0503597122302" cy="126" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="486.47482014388487" cy="86" r="3"></circle>
+    <circle cx="298.705035971223" cy="126" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="478.1294964028777" cy="86" r="3"></circle>
+    <circle cx="532.3741007194244" cy="106" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="273.66906474820144" cy="146" r="3"></circle>
+    <circle cx="332.0863309352518" cy="126" r="3"></circle>
+    <circle cx="432.23021582733816" cy="86" r="3"></circle>
+    <circle cx="411.36690647482015" cy="126" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="315.3956834532374" cy="126" r="3"></circle>
+    <circle cx="357.1223021582734" cy="106" r="3"></circle>
+    <circle cx="215.25179856115108" cy="166" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="453.0935251798561" cy="66" r="3"></circle>
+    <circle cx="307.0503597122302" cy="126" r="3"></circle>
+    <circle cx="307.0503597122302" cy="126" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="344.60431654676256" cy="106" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="73.38129496402877" cy="106" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="494.8201438848921" cy="106" r="3"></circle>
+    <circle cx="294.53237410071944" cy="126" r="3"></circle>
+    <circle cx="307.0503597122302" cy="126" r="3"></circle>
+    <circle cx="473.9568345323741" cy="86" r="3"></circle>
+    <circle cx="348.7769784172662" cy="126" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="344.60431654676256" cy="106" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="315.3956834532374" cy="126" r="3"></circle>
+    <circle cx="620" cy="86" r="3"></circle>
+    <circle cx="307.0503597122302" cy="126" r="3"></circle>
+    <circle cx="390.50359712230215" cy="106" r="3"></circle>
+    <circle cx="490.6474820143885" cy="66" r="3"></circle>
+    <circle cx="403.0215827338129" cy="126" r="3"></circle>
+    <circle cx="269.49640287769785" cy="166" r="3"></circle>
+    <circle cx="377.98561151079144" cy="126" r="3"></circle>
+    <circle cx="307.0503597122302" cy="126" r="3"></circle>
+    <circle cx="411.36690647482015" cy="106" r="3"></circle>
+    <circle cx="244.46043165467623" cy="146" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="336.25899280575544" cy="126" r="3"></circle>
+    <circle cx="390.50359712230215" cy="106" r="3"></circle>
+    <circle cx="390.50359712230215" cy="106" r="3"></circle>
+    <circle cx="432.23021582733816" cy="106" r="3"></circle>
+    <circle cx="298.705035971223" cy="126" r="3"></circle>
+    <circle cx="361.294964028777" cy="106" r="3"></circle>
+    <circle cx="319.56834532374097" cy="146" r="3"></circle>
+    <circle cx="494.8201438848921" cy="86" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="620" cy="66" r="3"></circle>
+    <circle cx="557.410071942446" cy="66" r="3"></circle>
+    <circle cx="290.35971223021585" cy="146" r="3"></circle>
+    <circle cx="515.68345323741" cy="86" r="3"></circle>
+    <circle cx="578.2733812949641" cy="106" r="3"></circle>
+    <circle cx="432.23021582733816" cy="86" r="3"></circle>
+    <circle cx="348.7769784172662" cy="126" r="3"></circle>
+    <circle cx="323.7410071942446" cy="126" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="494.8201438848921" cy="86" r="3"></circle>
+    <circle cx="432.23021582733816" cy="126" r="3"></circle>
+    <circle cx="411.36690647482015" cy="106" r="3"></circle>
+    <circle cx="432.23021582733816" cy="106" r="3"></circle>
+    <circle cx="298.705035971223" cy="126" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="444.7482014388489" cy="86" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="315.3956834532374" cy="126" r="3"></circle>
+    <circle cx="294.53237410071944" cy="126" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="411.36690647482015" cy="106" r="3"></circle>
+    <circle cx="298.705035971223" cy="126" r="3"></circle>
+    <circle cx="307.0503597122302" cy="126" r="3"></circle>
+    <circle cx="440.57553956834533" cy="106" r="3"></circle>
+    <circle cx="590.7913669064748" cy="106" r="3"></circle>
+    <circle cx="557.410071942446" cy="106" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="432.23021582733816" cy="166" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="298.705035971223" cy="126" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="390.50359712230215" cy="106" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="432.23021582733816" cy="86" r="3"></circle>
+    <circle cx="486.47482014388487" cy="106" r="3"></circle>
+    <circle cx="432.23021582733816" cy="86" r="3"></circle>
+    <circle cx="440.57553956834533" cy="106" r="3"></circle>
+    <circle cx="348.7769784172662" cy="126" r="3"></circle>
+    <circle cx="311.2230215827338" cy="126" r="3"></circle>
+    <circle cx="511.5107913669065" cy="106" r="3"></circle>
+    <circle cx="119.28057553956835" cy="106" r="3"></circle>
+    <circle cx="482.30215827338134" cy="66" r="3"></circle>
+    <circle cx="327.9136690647482" cy="126" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="286.1870503597122" cy="146" r="3"></circle>
+    <circle cx="327.9136690647482" cy="126" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="311.2230215827338" cy="126" r="3"></circle>
+    <circle cx="286.1870503597122" cy="146" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="294.53237410071944" cy="126" r="3"></circle>
+    <circle cx="319.56834532374097" cy="146" r="3"></circle>
+    <circle cx="240.28776978417267" cy="146" r="3"></circle>
+    <circle cx="473.9568345323741" cy="106" r="3"></circle>
+    <circle cx="298.705035971223" cy="146" r="3"></circle>
+    <circle cx="344.60431654676256" cy="126" r="3"></circle>
+    <circle cx="432.23021582733816" cy="86" r="3"></circle>
+    <circle cx="515.68345323741" cy="106" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="407.1942446043165" cy="126" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="432.23021582733816" cy="106" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="478.1294964028777" cy="106" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="599.1366906474819" cy="66" r="3"></circle>
+    <circle cx="511.5107913669065" cy="66" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="411.36690647482015" cy="106" r="3"></circle>
+    <circle cx="256.978417266187" cy="146" r="3"></circle>
+    <circle cx="135.97122302158274" cy="106" r="3"></circle>
+    <circle cx="432.23021582733816" cy="106" r="3"></circle>
+    <circle cx="298.705035971223" cy="146" r="3"></circle>
+    <circle cx="223.59712230215825" cy="166" r="3"></circle>
+    <circle cx="440.57553956834533" cy="126" r="3"></circle>
+    <circle cx="290.35971223021585" cy="126" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="85.89928057553956" cy="126" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="398.8489208633094" cy="106" r="3"></circle>
+    <circle cx="344.60431654676256" cy="106" r="3"></circle>
+    <circle cx="440.57553956834533" cy="106" r="3"></circle>
+    <circle cx="302.8776978417266" cy="146" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="432.23021582733816" cy="86" r="3"></circle>
+    <circle cx="465.6115107913669" cy="106" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="327.9136690647482" cy="126" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="361.294964028777" cy="106" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="348.7769784172662" cy="126" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="390.50359712230215" cy="106" r="3"></circle>
+    <circle cx="361.294964028777" cy="126" r="3"></circle>
+    <circle cx="311.2230215827338" cy="126" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="286.1870503597122" cy="146" r="3"></circle>
+    <circle cx="390.50359712230215" cy="126" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="298.705035971223" cy="146" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="265.32374100719426" cy="146" r="3"></circle>
+    <circle cx="348.7769784172662" cy="146" r="3"></circle>
+    <circle cx="256.978417266187" cy="146" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="352.9496402877698" cy="126" r="3"></circle>
+    <circle cx="265.32374100719426" cy="146" r="3"></circle>
+    <circle cx="390.50359712230215" cy="106" r="3"></circle>
+    <circle cx="486.47482014388487" cy="86" r="3"></circle>
+    <circle cx="390.50359712230215" cy="106" r="3"></circle>
+    <circle cx="394.67625899280574" cy="106" r="3"></circle>
+    <circle cx="298.705035971223" cy="126" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="327.9136690647482" cy="126" r="3"></circle>
+    <circle cx="357.1223021582734" cy="106" r="3"></circle>
+    <circle cx="528.2014388489208" cy="86" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="369.64028776978415" cy="126" r="3"></circle>
+    <circle cx="565.7553956834532" cy="86" r="3"></circle>
+    <circle cx="294.53237410071944" cy="126" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="432.23021582733816" cy="106" r="3"></circle>
+    <circle cx="348.7769784172662" cy="126" r="3"></circle>
+    <circle cx="165.17985611510792" cy="66" r="3"></circle>
+    <circle cx="411.36690647482015" cy="106" r="3"></circle>
+    <circle cx="294.53237410071944" cy="126" r="3"></circle>
+    <circle cx="252.80575539568346" cy="146" r="3"></circle>
+    <circle cx="327.9136690647482" cy="146" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="478.1294964028777" cy="86" r="3"></circle>
+    <circle cx="453.0935251798561" cy="66" r="3"></circle>
+    <circle cx="352.9496402877698" cy="106" r="3"></circle>
+    <circle cx="244.46043165467623" cy="146" r="3"></circle>
+    <circle cx="211.0791366906475" cy="66" r="3"></circle>
+    <circle cx="315.3956834532374" cy="126" r="3"></circle>
+    <circle cx="507.3381294964028" cy="86" r="3"></circle>
+    <circle cx="352.9496402877698" cy="126" r="3"></circle>
+    <circle cx="319.56834532374097" cy="126" r="3"></circle>
+    <circle cx="315.3956834532374" cy="126" r="3"></circle>
+    <circle cx="394.67625899280574" cy="126" r="3"></circle>
+    <circle cx="453.0935251798561" cy="146" r="3"></circle>
+    <circle cx="369.64028776978415" cy="126" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="377.98561151079144" cy="106" r="3"></circle>
+    <circle cx="532.3741007194244" cy="106" r="3"></circle>
+    <circle cx="407.1942446043165" cy="86" r="3"></circle>
+    <circle cx="223.59712230215825" cy="166" r="3"></circle>
+    <circle cx="419.7122302158274" cy="146" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="565.7553956834532" cy="66" r="3"></circle>
+    <circle cx="369.64028776978415" cy="126" r="3"></circle>
+    <circle cx="344.60431654676256" cy="106" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="344.60431654676256" cy="106" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="386.33093525179856" cy="126" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="473.9568345323741" cy="86" r="3"></circle>
+    <circle cx="478.1294964028777" cy="126" r="3"></circle>
+    <circle cx="294.53237410071944" cy="126" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="265.32374100719426" cy="146" r="3"></circle>
+    <circle cx="307.0503597122302" cy="126" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="269.49640287769785" cy="146" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="327.9136690647482" cy="146" r="3"></circle>
+    <circle cx="327.9136690647482" cy="126" r="3"></circle>
+    <circle cx="244.46043165467623" cy="146" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="432.23021582733816" cy="106" r="3"></circle>
+    <circle cx="377.98561151079144" cy="106" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="327.9136690647482" cy="126" r="3"></circle>
+    <circle cx="411.36690647482015" cy="126" r="3"></circle>
+    <circle cx="211.0791366906475" cy="166" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="407.1942446043165" cy="86" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="215.25179856115108" cy="166" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="344.60431654676256" cy="106" r="3"></circle>
+    <circle cx="436.4028776978417" cy="106" r="3"></circle>
+    <circle cx="574.1007194244604" cy="86" r="3"></circle>
+    <circle cx="294.53237410071944" cy="126" r="3"></circle>
+    <circle cx="261.15107913669067" cy="146" r="3"></circle>
+    <circle cx="211.0791366906475" cy="166" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="256.978417266187" cy="146" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="419.7122302158274" cy="106" r="3"></circle>
+    <circle cx="407.1942446043165" cy="126" r="3"></circle>
+    <circle cx="432.23021582733816" cy="126" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="315.3956834532374" cy="126" r="3"></circle>
+    <circle cx="578.2733812949641" cy="66" r="3"></circle>
+    <circle cx="298.705035971223" cy="126" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="265.32374100719426" cy="146" r="3"></circle>
+    <circle cx="361.294964028777" cy="146" r="3"></circle>
+    <circle cx="265.32374100719426" cy="146" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="231.9424460431655" cy="146" r="3"></circle>
+    <circle cx="319.56834532374097" cy="126" r="3"></circle>
+    <circle cx="327.9136690647482" cy="126" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="261.15107913669067" cy="146" r="3"></circle>
+    <circle cx="236.11510791366908" cy="166" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="440.57553956834533" cy="106" r="3"></circle>
+    <circle cx="352.9496402877698" cy="106" r="3"></circle>
+    <circle cx="373.8129496402878" cy="106" r="3"></circle>
+    <circle cx="307.0503597122302" cy="126" r="3"></circle>
+    <circle cx="98.41726618705036" cy="126" r="3"></circle>
+    <circle cx="419.7122302158274" cy="106" r="3"></circle>
+    <circle cx="544.8920863309353" cy="106" r="3"></circle>
+    <circle cx="361.294964028777" cy="106" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="519.8561151079136" cy="106" r="3"></circle>
+    <circle cx="319.56834532374097" cy="126" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="344.60431654676256" cy="106" r="3"></circle>
+    <circle cx="327.9136690647482" cy="126" r="3"></circle>
+    <circle cx="461.4388489208633" cy="106" r="3"></circle>
+    <circle cx="507.3381294964028" cy="126" r="3"></circle>
+    <circle cx="369.64028776978415" cy="146" r="3"></circle>
+    <circle cx="344.60431654676256" cy="126" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="453.0935251798561" cy="106" r="3"></circle>
+    <circle cx="428.0575539568345" cy="146" r="3"></circle>
+    <circle cx="240.28776978417267" cy="146" r="3"></circle>
+    <circle cx="440.57553956834533" cy="106" r="3"></circle>
+    <circle cx="544.8920863309353" cy="86" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="298.705035971223" cy="126" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="215.25179856115108" cy="166" r="3"></circle>
+    <circle cx="444.7482014388489" cy="106" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="315.3956834532374" cy="146" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="361.294964028777" cy="106" r="3"></circle>
+    <circle cx="428.0575539568345" cy="86" r="3"></circle>
+    <circle cx="240.28776978417267" cy="146" r="3"></circle>
+    <circle cx="469.7841726618705" cy="86" r="3"></circle>
+    <circle cx="390.50359712230215" cy="106" r="3"></circle>
+    <circle cx="411.36690647482015" cy="106" r="3"></circle>
+    <circle cx="453.0935251798561" cy="86" r="3"></circle>
+    <circle cx="411.36690647482015" cy="126" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="432.23021582733816" cy="86" r="3"></circle>
+    <circle cx="261.15107913669067" cy="146" r="3"></circle>
+    <circle cx="265.32374100719426" cy="146" r="3"></circle>
+    <circle cx="428.0575539568345" cy="86" r="3"></circle>
+    <circle cx="490.6474820143885" cy="66" r="3"></circle>
+    <circle cx="428.0575539568345" cy="106" r="3"></circle>
+    <circle cx="319.56834532374097" cy="126" r="3"></circle>
+    <circle cx="419.7122302158274" cy="106" r="3"></circle>
+    <circle cx="494.8201438848921" cy="66" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="432.23021582733816" cy="86" r="3"></circle>
+    <circle cx="432.23021582733816" cy="106" r="3"></circle>
+    <circle cx="503.1654676258993" cy="66" r="3"></circle>
+    <circle cx="357.1223021582734" cy="146" r="3"></circle>
+    <circle cx="553.2374100719425" cy="86" r="3"></circle>
+    <circle cx="411.36690647482015" cy="106" r="3"></circle>
+    <circle cx="344.60431654676256" cy="126" r="3"></circle>
+    <circle cx="473.9568345323741" cy="86" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="432.23021582733816" cy="126" r="3"></circle>
+    <circle cx="298.705035971223" cy="126" r="3"></circle>
+    <circle cx="473.9568345323741" cy="66" r="3"></circle>
+    <circle cx="369.64028776978415" cy="106" r="3"></circle>
+    <circle cx="98.41726618705036" cy="106" r="3"></circle>
+    <circle cx="423.884892086331" cy="106" r="3"></circle>
+    <circle cx="265.32374100719426" cy="146" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="286.1870503597122" cy="126" r="3"></circle>
+    <circle cx="373.8129496402878" cy="106" r="3"></circle>
+    <circle cx="444.7482014388489" cy="86" r="3"></circle>
+    <circle cx="302.8776978417266" cy="126" r="3"></circle>
+    <circle cx="348.7769784172662" cy="126" r="3"></circle>
+    <circle cx="386.33093525179856" cy="126" r="3"></circle>
+    <circle cx="494.8201438848921" cy="106" r="3"></circle>
+    <circle cx="411.36690647482015" cy="86" r="3"></circle>
+    <circle cx="261.15107913669067" cy="146" r="3"></circle>
+    <circle cx="411.36690647482015" cy="126" r="3"></circle>
+    <circle cx="369.64028776978415" cy="126" r="3"></circle>
+    <circle cx="277.841726618705" cy="146" r="3"></circle>
+    <circle cx="236.11510791366908" cy="146" r="3"></circle>
+    <circle cx="536.5467625899281" cy="126" r="3"></circle>
+    <circle cx="348.7769784172662" cy="106" r="3"></circle>
+    <circle cx="348.7769784172662" cy="126" r="3"></circle>
+    <circle cx="411.36690647482015" cy="106" r="3"></circle>
+    <circle cx="461.4388489208633" cy="66" r="3"></circle>
+    <circle cx="286.1870503597122" cy="146" r="3"></circle>
+    <circle cx="282.0143884892086" cy="146" r="3"></circle>
+  </g>
+</svg>

--- a/test/output/boxplotY.svg
+++ b/test/output/boxplotY.svg
@@ -1,0 +1,664 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="430" viewBox="0 0 640 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    .plot {
+      display: block;
+      background: white;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    .plot text,
+    .plot tspan {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="fx-grid" transform="translate(0.5,0)">
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(1,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(41,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(81,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(121,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(161,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(201,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(241,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(281,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(321,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(361,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(401,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(441,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(481,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(521,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+    <g stroke="currentColor" stroke-opacity="0.1" transform="translate(561,0)">
+      <line x1="49" x2="49" y1="20" y2="400"></line>
+    </g>
+  </g>
+  <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
+    <g font-variant="tabular-nums" transform="translate(1,0)">
+      <text y="0.71em" transform="translate(49,400)">170</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(41,0)">
+      <text y="0.71em" transform="translate(49,400)">160</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(81,0)">
+      <text y="0.71em" transform="translate(49,400)">150</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(121,0)">
+      <text y="0.71em" transform="translate(49,400)">140</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(161,0)">
+      <text y="0.71em" transform="translate(49,400)">130</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(201,0)">
+      <text y="0.71em" transform="translate(49,400)">120</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(241,0)">
+      <text y="0.71em" transform="translate(49,400)">110</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(281,0)">
+      <text y="0.71em" transform="translate(49,400)">100</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(321,0)">
+      <text y="0.71em" transform="translate(49,400)">90</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(361,0)">
+      <text y="0.71em" transform="translate(49,400)">80</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(401,0)">
+      <text y="0.71em" transform="translate(49,400)">70</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(441,0)">
+      <text y="0.71em" transform="translate(49,400)">60</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(481,0)">
+      <text y="0.71em" transform="translate(49,400)">50</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(521,0)">
+      <text y="0.71em" transform="translate(49,400)">40</text>
+    </g>
+    <g font-variant="tabular-nums" transform="translate(561,0)">
+      <text y="0.71em" transform="translate(49,400)">30</text>
+    </g>
+  </g>
+  <g aria-label="fx-axis label" transform="translate(0.5,27.5)">
+    <text transform="translate(330,400)">← weight</text>
+  </g>
+  <g aria-label="y-axis tick" transform="translate(0,0.5)">
+    <g fill="none" stroke="currentColor" transform="translate(1,0)">
+      <path transform="translate(40,365.79999999999995)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,327.8)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,289.8)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,251.79999999999995)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,213.8)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,175.79999999999998)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,137.80000000000004)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,99.79999999999998)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,61.799999999999955)" d="M0,0L-6,0"></path>
+      <path transform="translate(40,23.79999999999992)" d="M0,0L-6,0"></path>
+    </g>
+  </g>
+  <g aria-label="y-axis tick label" transform="translate(-8.5,0.5)">
+    <g text-anchor="end" font-variant="tabular-nums" transform="translate(1,0)">
+      <text y="0.32em" transform="translate(40,365.79999999999995)">1.3</text>
+      <text y="0.32em" transform="translate(40,327.8)">1.4</text>
+      <text y="0.32em" transform="translate(40,289.8)">1.5</text>
+      <text y="0.32em" transform="translate(40,251.79999999999995)">1.6</text>
+      <text y="0.32em" transform="translate(40,213.8)">1.7</text>
+      <text y="0.32em" transform="translate(40,175.79999999999998)">1.8</text>
+      <text y="0.32em" transform="translate(40,137.80000000000004)">1.9</text>
+      <text y="0.32em" transform="translate(40,99.79999999999998)">2.0</text>
+      <text y="0.32em" transform="translate(40,61.799999999999955)">2.1</text>
+      <text y="0.32em" transform="translate(40,23.79999999999992)">2.2</text>
+    </g>
+  </g>
+  <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-16.5)">
+    <text y="0.71em" transform="translate(41,20)">↑ height</text>
+  </g>
+  <g aria-label="rule" transform="translate(0.5,0)">
+    <g stroke="currentColor" transform="translate(1,0)">
+      <line x1="49" x2="49" y1="130.20000000000002" y2="88.40000000000006"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(41,0)">
+      <line x1="49" x2="49" y1="164.39999999999995" y2="88.40000000000006"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(61,0)">
+      <line x1="49" x2="49" y1="156.79999999999995" y2="84.59999999999997"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(81,0)">
+      <line x1="49" x2="49" y1="194.8" y2="107.4"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(101,0)">
+      <line x1="49" x2="49" y1="164.39999999999995" y2="126.4"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(121,0)">
+      <line x1="49" x2="49" y1="183.39999999999998" y2="84.59999999999997"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(141,0)">
+      <line x1="49" x2="49" y1="190.99999999999997" y2="76.99999999999997"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(161,0)">
+      <line x1="49" x2="49" y1="175.79999999999998" y2="84.59999999999997"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(181,0)">
+      <line x1="49" x2="49" y1="198.6" y2="69.39999999999996"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(201,0)">
+      <line x1="49" x2="49" y1="229.00000000000003" y2="50.40000000000003"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(221,0)">
+      <line x1="49" x2="49" y1="198.6" y2="31.399999999999928"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(241,0)">
+      <line x1="49" x2="49" y1="221.4" y2="42.80000000000002"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(261,0)">
+      <line x1="49" x2="49" y1="225.2" y2="58.000000000000036"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(281,0)">
+      <line x1="49" x2="49" y1="213.8" y2="46.59999999999994"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(301,0)">
+      <line x1="49" x2="49" y1="213.8" y2="61.799999999999955"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(321,0)">
+      <line x1="49" x2="49" y1="213.8" y2="69.39999999999996"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(341,0)">
+      <line x1="49" x2="49" y1="210" y2="88.40000000000006"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(361,0)">
+      <line x1="49" x2="49" y1="217.6" y2="103.6"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(381,0)">
+      <line x1="49" x2="49" y1="221.4" y2="118.8"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(401,0)">
+      <line x1="49" x2="49" y1="247.99999999999994" y2="115"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(421,0)">
+      <line x1="49" x2="49" y1="259.3999999999999" y2="137.80000000000004"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(441,0)">
+      <line x1="49" x2="49" y1="270.79999999999995" y2="149.19999999999993"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(461,0)">
+      <line x1="49" x2="49" y1="286" y2="164.39999999999995"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(481,0)">
+      <line x1="49" x2="49" y1="293.6" y2="179.59999999999997"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(501,0)">
+      <line x1="49" x2="49" y1="308.8" y2="179.59999999999997"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(521,0)">
+      <line x1="49" x2="49" y1="316.4" y2="221.4"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(541,0)">
+      <line x1="49" x2="49" y1="320.2" y2="274.6"></line>
+    </g>
+    <g stroke="currentColor" transform="translate(561,0)">
+      <line x1="49" x2="49" y1="354.3999999999999" y2="308.8"></line>
+    </g>
+  </g>
+  <g aria-label="bar">
+    <g fill="#ccc" transform="translate(1,0)">
+      <rect x="40" width="18" y="98.85" height="20.900000000000077"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(21,0)">
+      <rect x="40" width="18" y="92.19999999999997" height="0"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(41,0)">
+      <rect x="40" width="18" y="120.70000000000006" height="37.99999999999987"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(61,0)">
+      <rect x="40" width="18" y="99.79999999999998" height="30.400000000000034"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(81,0)">
+      <rect x="40" width="18" y="130.20000000000002" height="50.34999999999994"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(101,0)">
+      <rect x="40" width="18" y="138.75" height="23.75"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(121,0)">
+      <rect x="40" width="18" y="118.8" height="37.99999999999996"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(141,0)">
+      <rect x="40" width="18" y="99.79999999999998" height="41.80000000000004"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(161,0)">
+      <rect x="40" width="18" y="115" height="41.799999999999955"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(181,0)">
+      <rect x="40" width="18" y="124.49999999999997" height="41.799999999999955"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(201,0)">
+      <rect x="40" width="18" y="98.85" height="55.09999999999994"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(221,0)">
+      <rect x="40" width="18" y="77.94999999999995" height="70.30000000000003"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(241,0)">
+      <rect x="40" width="18" y="92.19999999999997" height="60.79999999999997"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(261,0)">
+      <rect x="40" width="18" y="92.19999999999997" height="53.20000000000006"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(281,0)">
+      <rect x="40" width="18" y="103.6" height="45.59999999999994"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(301,0)">
+      <rect x="40" width="18" y="115" height="41.799999999999955"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(321,0)">
+      <rect x="40" width="18" y="122.6" height="37.99999999999994"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(341,0)">
+      <rect x="40" width="18" y="134" height="31.349999999999937"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(361,0)">
+      <rect x="40" width="18" y="145.40000000000003" height="30.39999999999995"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(381,0)">
+      <rect x="40" width="18" y="156.79999999999995" height="26.600000000000023"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(401,0)">
+      <rect x="40" width="18" y="164.39999999999995" height="34.200000000000045"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(421,0)">
+      <rect x="40" width="18" y="183.39999999999998" height="30.400000000000034"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(441,0)">
+      <rect x="40" width="18" y="194.8" height="30.399999999999977"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(461,0)">
+      <rect x="40" width="18" y="210" height="30.400000000000034"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(481,0)">
+      <rect x="40" width="18" y="221.4" height="30.39999999999995"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(501,0)">
+      <rect x="40" width="18" y="232.80000000000004" height="37.999999999999915"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(521,0)">
+      <rect x="40" width="18" y="248.94999999999993" height="29.450000000000045"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(541,0)">
+      <rect x="40" width="18" y="277.45" height="28.5"></rect>
+    </g>
+    <g fill="#ccc" transform="translate(561,0)">
+      <rect x="40" width="18" y="314.49999999999994" height="19.950000000000102"></rect>
+    </g>
+  </g>
+  <g aria-label="tick" transform="translate(0,0.5)">
+    <g stroke="currentColor" stroke-width="2" transform="translate(1,0)">
+      <line x1="40" x2="58" y1="109.30000000000004" y2="109.30000000000004"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(21,0)">
+      <line x1="40" x2="58" y1="92.19999999999997" y2="92.19999999999997"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(41,0)">
+      <line x1="40" x2="58" y1="152.99999999999994" y2="152.99999999999994"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(61,0)">
+      <line x1="40" x2="58" y1="111.2" y2="111.2"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(81,0)">
+      <line x1="40" x2="58" y1="156.79999999999995" y2="156.79999999999995"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(101,0)">
+      <line x1="40" x2="58" y1="154.9" y2="154.9"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(121,0)">
+      <line x1="40" x2="58" y1="137.80000000000004" y2="137.80000000000004"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(141,0)">
+      <line x1="40" x2="58" y1="122.6" y2="122.6"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(161,0)">
+      <line x1="40" x2="58" y1="137.80000000000004" y2="137.80000000000004"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(181,0)">
+      <line x1="40" x2="58" y1="152.99999999999994" y2="152.99999999999994"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(201,0)">
+      <line x1="40" x2="58" y1="132.09999999999997" y2="132.09999999999997"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(221,0)">
+      <line x1="40" x2="58" y1="122.6" y2="122.6"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(241,0)">
+      <line x1="40" x2="58" y1="115" y2="115"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(261,0)">
+      <line x1="40" x2="58" y1="115" y2="115"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(281,0)">
+      <line x1="40" x2="58" y1="124.49999999999997" y2="124.49999999999997"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(301,0)">
+      <line x1="40" x2="58" y1="130.20000000000002" y2="130.20000000000002"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(321,0)">
+      <line x1="40" x2="58" y1="137.80000000000004" y2="137.80000000000004"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(341,0)">
+      <line x1="40" x2="58" y1="145.40000000000003" y2="145.40000000000003"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(361,0)">
+      <line x1="40" x2="58" y1="160.59999999999994" y2="160.59999999999994"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(381,0)">
+      <line x1="40" x2="58" y1="168.2" y2="168.2"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(401,0)">
+      <line x1="40" x2="58" y1="183.39999999999998" y2="183.39999999999998"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(421,0)">
+      <line x1="40" x2="58" y1="198.6" y2="198.6"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(441,0)">
+      <line x1="40" x2="58" y1="213.8" y2="213.8"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(461,0)">
+      <line x1="40" x2="58" y1="225.2" y2="225.2"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(481,0)">
+      <line x1="40" x2="58" y1="236.60000000000002" y2="236.60000000000002"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(501,0)">
+      <line x1="40" x2="58" y1="251.79999999999995" y2="251.79999999999995"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(521,0)">
+      <line x1="40" x2="58" y1="263.2" y2="263.2"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(541,0)">
+      <line x1="40" x2="58" y1="295.50000000000006" y2="295.50000000000006"></line>
+    </g>
+    <g stroke="currentColor" stroke-width="2" transform="translate(561,0)">
+      <line x1="40" x2="58" y1="322.1" y2="322.1"></line>
+    </g>
+  </g>
+  <g aria-label="dot" transform="translate(0.5,0.5)">
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(161,0)">
+      <circle cx="49" cy="240.40000000000003" r="3"></circle>
+      <circle cx="49" cy="50.40000000000003" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(181,0)">
+      <circle cx="49" cy="278.4" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(201,0)">
+      <circle cx="49" cy="251.79999999999995" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(261,0)">
+      <circle cx="49" cy="240.40000000000003" r="3"></circle>
+      <circle cx="49" cy="229.00000000000003" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(281,0)">
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(301,0)">
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="240.40000000000003" r="3"></circle>
+      <circle cx="49" cy="35.20000000000002" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(321,0)">
+      <circle cx="49" cy="61.799999999999955" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+      <circle cx="49" cy="217.6" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+      <circle cx="49" cy="244.19999999999993" r="3"></circle>
+      <circle cx="49" cy="217.6" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+      <circle cx="49" cy="65.60000000000004" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(341,0)">
+      <circle cx="49" cy="61.799999999999955" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="213.8" r="3"></circle>
+      <circle cx="49" cy="213.8" r="3"></circle>
+      <circle cx="49" cy="217.6" r="3"></circle>
+      <circle cx="49" cy="80.80000000000005" r="3"></circle>
+      <circle cx="49" cy="259.3999999999999" r="3"></circle>
+      <circle cx="49" cy="213.8" r="3"></circle>
+      <circle cx="49" cy="76.99999999999997" r="3"></circle>
+      <circle cx="49" cy="213.8" r="3"></circle>
+      <circle cx="49" cy="20" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+      <circle cx="49" cy="229.00000000000003" r="3"></circle>
+      <circle cx="49" cy="213.8" r="3"></circle>
+      <circle cx="49" cy="76.99999999999997" r="3"></circle>
+      <circle cx="49" cy="240.40000000000003" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="80.80000000000005" r="3"></circle>
+      <circle cx="49" cy="84.59999999999997" r="3"></circle>
+      <circle cx="49" cy="213.8" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+      <circle cx="49" cy="229.00000000000003" r="3"></circle>
+      <circle cx="49" cy="251.79999999999995" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="236.60000000000002" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(361,0)">
+      <circle cx="49" cy="251.79999999999995" r="3"></circle>
+      <circle cx="49" cy="96.00000000000007" r="3"></circle>
+      <circle cx="49" cy="240.40000000000003" r="3"></circle>
+      <circle cx="49" cy="92.19999999999997" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="99.79999999999998" r="3"></circle>
+      <circle cx="49" cy="99.79999999999998" r="3"></circle>
+      <circle cx="49" cy="240.40000000000003" r="3"></circle>
+      <circle cx="49" cy="96.00000000000007" r="3"></circle>
+      <circle cx="49" cy="244.19999999999993" r="3"></circle>
+      <circle cx="49" cy="99.79999999999998" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="99.79999999999998" r="3"></circle>
+      <circle cx="49" cy="99.79999999999998" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="96.00000000000007" r="3"></circle>
+      <circle cx="49" cy="221.4" r="3"></circle>
+      <circle cx="49" cy="99.79999999999998" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(381,0)">
+      <circle cx="49" cy="107.4" r="3"></circle>
+      <circle cx="49" cy="240.40000000000003" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="236.60000000000002" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="229.00000000000003" r="3"></circle>
+      <circle cx="49" cy="107.4" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="103.6" r="3"></circle>
+      <circle cx="49" cy="115" r="3"></circle>
+      <circle cx="49" cy="92.19999999999997" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="115" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="259.3999999999999" r="3"></circle>
+      <circle cx="49" cy="229.00000000000003" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="240.40000000000003" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="247.99999999999994" r="3"></circle>
+      <circle cx="49" cy="282.2" r="3"></circle>
+      <circle cx="49" cy="111.2" r="3"></circle>
+      <circle cx="49" cy="115" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="236.60000000000002" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="251.79999999999995" r="3"></circle>
+      <circle cx="49" cy="270.79999999999995" r="3"></circle>
+      <circle cx="49" cy="229.00000000000003" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="225.2" r="3"></circle>
+      <circle cx="49" cy="232.80000000000004" r="3"></circle>
+      <circle cx="49" cy="240.40000000000003" r="3"></circle>
+      <circle cx="49" cy="244.19999999999993" r="3"></circle>
+      <circle cx="49" cy="115" r="3"></circle>
+      <circle cx="49" cy="111.2" r="3"></circle>
+      <circle cx="49" cy="251.79999999999995" r="3"></circle>
+      <circle cx="49" cy="96.00000000000007" r="3"></circle>
+      <circle cx="49" cy="229.00000000000003" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(401,0)">
+      <circle cx="49" cy="259.3999999999999" r="3"></circle>
+      <circle cx="49" cy="251.79999999999995" r="3"></circle>
+      <circle cx="49" cy="263.2" r="3"></circle>
+      <circle cx="49" cy="251.79999999999995" r="3"></circle>
+      <circle cx="49" cy="278.4" r="3"></circle>
+      <circle cx="49" cy="111.2" r="3"></circle>
+      <circle cx="49" cy="278.4" r="3"></circle>
+      <circle cx="49" cy="107.4" r="3"></circle>
+      <circle cx="49" cy="80.80000000000005" r="3"></circle>
+      <circle cx="49" cy="259.3999999999999" r="3"></circle>
+      <circle cx="49" cy="289.8" r="3"></circle>
+      <circle cx="49" cy="282.2" r="3"></circle>
+      <circle cx="49" cy="289.8" r="3"></circle>
+      <circle cx="49" cy="274.6" r="3"></circle>
+      <circle cx="49" cy="259.3999999999999" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(421,0)">
+      <circle cx="49" cy="134" r="3"></circle>
+      <circle cx="49" cy="270.79999999999995" r="3"></circle>
+      <circle cx="49" cy="130.20000000000002" r="3"></circle>
+      <circle cx="49" cy="339.19999999999993" r="3"></circle>
+      <circle cx="49" cy="118.8" r="3"></circle>
+      <circle cx="49" cy="134" r="3"></circle>
+      <circle cx="49" cy="278.4" r="3"></circle>
+      <circle cx="49" cy="278.4" r="3"></circle>
+      <circle cx="49" cy="126.4" r="3"></circle>
+      <circle cx="49" cy="130.20000000000002" r="3"></circle>
+      <circle cx="49" cy="130.20000000000002" r="3"></circle>
+      <circle cx="49" cy="282.2" r="3"></circle>
+      <circle cx="49" cy="118.8" r="3"></circle>
+      <circle cx="49" cy="278.4" r="3"></circle>
+      <circle cx="49" cy="263.2" r="3"></circle>
+      <circle cx="49" cy="134" r="3"></circle>
+      <circle cx="49" cy="270.79999999999995" r="3"></circle>
+      <circle cx="49" cy="134" r="3"></circle>
+      <circle cx="49" cy="134" r="3"></circle>
+      <circle cx="49" cy="130.20000000000002" r="3"></circle>
+      <circle cx="49" cy="126.4" r="3"></circle>
+      <circle cx="49" cy="270.79999999999995" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(441,0)">
+      <circle cx="49" cy="137.80000000000004" r="3"></circle>
+      <circle cx="49" cy="134" r="3"></circle>
+      <circle cx="49" cy="282.2" r="3"></circle>
+      <circle cx="49" cy="274.6" r="3"></circle>
+      <circle cx="49" cy="289.8" r="3"></circle>
+      <circle cx="49" cy="115" r="3"></circle>
+      <circle cx="49" cy="88.40000000000006" r="3"></circle>
+      <circle cx="49" cy="278.4" r="3"></circle>
+      <circle cx="49" cy="145.40000000000003" r="3"></circle>
+      <circle cx="49" cy="282.2" r="3"></circle>
+      <circle cx="49" cy="282.2" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(461,0)">
+      <circle cx="49" cy="289.8" r="3"></circle>
+      <circle cx="49" cy="152.99999999999994" r="3"></circle>
+      <circle cx="49" cy="293.6" r="3"></circle>
+      <circle cx="49" cy="152.99999999999994" r="3"></circle>
+      <circle cx="49" cy="156.79999999999995" r="3"></circle>
+      <circle cx="49" cy="312.6" r="3"></circle>
+      <circle cx="49" cy="145.40000000000003" r="3"></circle>
+      <circle cx="49" cy="316.4" r="3"></circle>
+      <circle cx="49" cy="156.79999999999995" r="3"></circle>
+      <circle cx="49" cy="308.8" r="3"></circle>
+      <circle cx="49" cy="289.8" r="3"></circle>
+      <circle cx="49" cy="297.4" r="3"></circle>
+      <circle cx="49" cy="335.4" r="3"></circle>
+      <circle cx="49" cy="289.8" r="3"></circle>
+      <circle cx="49" cy="160.59999999999994" r="3"></circle>
+      <circle cx="49" cy="152.99999999999994" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(481,0)">
+      <circle cx="49" cy="354.3999999999999" r="3"></circle>
+      <circle cx="49" cy="175.79999999999998" r="3"></circle>
+      <circle cx="49" cy="164.39999999999995" r="3"></circle>
+      <circle cx="49" cy="301.2" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(501,0)">
+      <circle cx="49" cy="400" r="3"></circle>
+      <circle cx="49" cy="175.79999999999998" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(521,0)">
+      <circle cx="49" cy="339.19999999999993" r="3"></circle>
+      <circle cx="49" cy="183.39999999999998" r="3"></circle>
+    </g>
+    <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(541,0)">
+      <circle cx="49" cy="156.79999999999995" r="3"></circle>
+      <circle cx="49" cy="350.59999999999997" r="3"></circle>
+    </g>
+  </g>
+  <g aria-label="tip" transform="translate(0.5,0.5)">
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(1,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(21,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(41,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(61,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(81,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(101,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(121,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(141,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(161,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(181,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(201,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(221,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(241,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(261,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(281,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(301,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(321,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(341,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(361,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(381,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(401,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(421,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(441,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(461,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(481,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(501,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(521,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(541,0)"></g>
+    <g fill="white" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(561,0)"></g>
+  </g>
+</svg>

--- a/test/plots/boxplot.ts
+++ b/test/plots/boxplot.ts
@@ -17,7 +17,7 @@ export async function boxplotFacetInterval() {
     marks: [
       Plot.boxX(
         olympians.filter((d) => d.height),
-        {x: "weight", fy: "height"}
+        {x: "weight", fy: "height", tip: true}
       )
     ]
   });
@@ -36,6 +36,24 @@ export async function boxplotFacetNegativeInterval() {
       Plot.boxX(
         olympians.filter((d) => d.height),
         {x: "weight", fy: "height"}
+      )
+    ]
+  });
+}
+
+export async function boxplotY() {
+  const olympians = await d3.csv<any>("data/athletes.csv", d3.autoType);
+  return Plot.plot({
+    fx: {
+      grid: true,
+      tickFormat: String, // for debugging
+      interval: 5,
+      reverse: true
+    },
+    marks: [
+      Plot.boxY(
+        olympians.filter((d) => d.height),
+        {fx: "weight", y: "height", tip: true}
       )
     ]
   });


### PR DESCRIPTION
An alternative to #1839 for boxplot tips; this one shows the # of items in each quartile (and # of outliers), using numbers and math. symbols (as opposed to English language). We don't show empty quartiles and redundant information (i.e. when the # of values is small).

I don't know what users of box plots expect from a tip. The visual summary is one thing, but making it into “sentences” is quite challenging, given the complex definition of the elements.

For example, we can't really show percentages, as they are misleading when the data is “discrete” (few values). For instance, if you have 5 values, the proportion that are lower to the median is 2 out of 5 (40%), and the proportion that are lower or equal to the median is 3 out of 5 (60%). There is never a 50%. So, recount everything wrt the quartiles, and don't display %. But of course now it makes things much more difficult to grasp, because these statistics are coming from percentages, and it's hard to understand why the tip would show “made up” values of 4.25, 7, 10.75 as interesting edges to summarize an array of integers.

<img width="703" alt="Capture d’écran 2023-08-31 à 13 26 39" src="https://github.com/observablehq/plot/assets/7001/65eb3198-4857-4bd1-b6de-7cc53c52729b">

This is my gripe with the whole concept of a box plot, maybe, more than with the tip :)
