### PR TITLE
Add a "line" marker option

### DIFF
--- a/src/marker.js
+++ b/src/marker.js
@@ -24,6 +24,8 @@ function maybeMarker(marker) {
       return markerCircleFill;
     case "circle-stroke":
       return markerCircleStroke;
+    case "line":
+      return markerLine
   }
   throw new Error(`invalid marker: ${marker}`);
 }
@@ -76,6 +78,19 @@ function markerCircleStroke(color, context) {
     .attr("stroke", color)
     .attr("stroke-width", 1.5)
     .call((marker) => marker.append("circle").attr("r", 3))
+    .node();
+}
+
+function markerLine(color, context) {
+  return create("svg:marker", context)
+    .attr("viewBox", "-5 -5 10 10")
+    .attr("markerWidth", 6.67)
+    .attr("markerHeight", 6.67)
+    .attr("stroke", color)
+    .attr("stroke-width", 1.5)
+    .attr("stroke-linecap", "square")
+    .attr("stroke-linejoin", "square")
+    .call((marker) => marker.append("line").attr("x1", "0").attr("x2", "0").attr("y1", "-2").attr("y2", "2"))
     .node();
 }
 

--- a/src/marker.js
+++ b/src/marker.js
@@ -86,6 +86,7 @@ function markerLine(color, context) {
     .attr("viewBox", "-5 -5 10 10")
     .attr("markerWidth", 6.67)
     .attr("markerHeight", 6.67)
+    .attr("orient", "auto")
     .attr("stroke", color)
     .attr("stroke-width", 1.5)
     .attr("stroke-linecap", "square")

--- a/src/marker.js
+++ b/src/marker.js
@@ -25,7 +25,7 @@ function maybeMarker(marker) {
     case "circle-stroke":
       return markerCircleStroke;
     case "line":
-      return markerLine
+      return markerLine(2);
   }
   throw new Error(`invalid marker: ${marker}`);
 }
@@ -81,7 +81,7 @@ function markerCircleStroke(color, context) {
     .node();
 }
 
-function markerLine(lineLength = 2) {
+function markerLine(lineLength) {
   return (color, context) =>
     create("svg:marker", context)
       .attr("viewBox", "-5 -5 10 10")

--- a/src/marker.js
+++ b/src/marker.js
@@ -81,18 +81,19 @@ function markerCircleStroke(color, context) {
     .node();
 }
 
-function markerLine(color, context) {
-  return create("svg:marker", context)
-    .attr("viewBox", "-5 -5 10 10")
-    .attr("markerWidth", 6.67)
-    .attr("markerHeight", 6.67)
-    .attr("orient", "auto")
-    .attr("stroke", color)
-    .attr("stroke-width", 1.5)
-    .attr("stroke-linecap", "square")
-    .attr("stroke-linejoin", "square")
-    .call((marker) => marker.append("line").attr("x1", "0").attr("x2", "0").attr("y1", "-2").attr("y2", "2"))
-    .node();
+function markerLine(lineLength = 2) {
+  return (color, context) =>
+    create("svg:marker", context)
+      .attr("viewBox", "-5 -5 10 10")
+      .attr("markerWidth", 6.67)
+      .attr("markerHeight", 6.67)
+      .attr("orient", "auto")
+      .attr("stroke", color)
+      .attr("stroke-width", 1.5)
+      .attr("stroke-linecap", "square")
+      .attr("stroke-linejoin", "square")
+      .call((marker) => marker.append("line").attr("x1", "0").attr("x2", "0").attr("y1", `-${lineLength}`).attr("y2", `${lineLength}`))
+      .node();
 }
 
 let nextMarkerId = 0;


### PR DESCRIPTION
Useful to render "error" in bars

Here is a (zoomed) example:
<img width="791" alt="Screenshot 2023-09-21 at 4 58 40 pm" src="https://github.com/observablehq/plot/assets/1193670/0f8a02f1-e4fa-4670-88f7-e78f522b1752">


It's my first PR here and I'm, in general, not used to making PRs on JS/TS projects, so please let me know if anything is missing  (tests, etc.), I'll add anything missing 🙂

Also, I'm a super newbie with SVG. To make this work, I just copy/pasted the arrow marker and changed it until it was rendering what I wanted. I'm absolutely not sure of what I'm doing here 😅