### PR TITLE
fix bollinger reference

### DIFF
--- a/docs/data/api.data.ts
+++ b/docs/data/api.data.ts
@@ -85,7 +85,8 @@ function getInterfaceName(name: string, path: string): string {
   name = name.toLowerCase();
   if (name === "curve auto") name = "curve";
   if (name === "plot facet") name = "plot";
-  if (path.startsWith("marks/")) name += " mark";
+  if (name === "bollinger window") name = "bollinger map method";
+  else if (path.startsWith("marks/")) name += " mark";
   else if (path.startsWith("transforms/")) name += " transform";
   return name;
 }

--- a/src/marks/bollinger.d.ts
+++ b/src/marks/bollinger.d.ts
@@ -4,7 +4,7 @@ import type {WindowOptions} from "../transforms/window.js";
 import type {AreaXOptions, AreaYOptions} from "./area.js";
 import type {LineXOptions, LineYOptions} from "./line.js";
 
-/** Options for the bollinger window transform. */
+/** Options for the bollinger map method. */
 export interface BollingerWindowOptions {
   /** The number of consecutive values in the window; defaults to 20. */
   n?: number;


### PR DESCRIPTION
The bollinger map method is currently erroneously referred to as the “bollinger window mark” in the API reference (since the name is automatically inferred from the BollingerWindowOptions interface which lives in the marks folder). This corrects it to be “bollinger map method” to be consistent with the other docs.

<img width="1624" alt="Screenshot 2023-10-23 at 9 08 43 AM" src="https://github.com/observablehq/plot/assets/230541/951693e6-97f1-4b61-afb9-3c3f06f10873">
