### PR TITLE
fix overload precedence

### DIFF
--- a/src/transforms/dodge.d.ts
+++ b/src/transforms/dodge.d.ts
@@ -59,8 +59,8 @@ export interface DodgeYOptions extends DodgeOptions {
  *
  * If *dodgeOptions* is a string, it is shorthand for the dodge **anchor**.
  */
-export function dodgeX<T>(dodgeOptions?: DodgeXOptions | DodgeXOptions["anchor"], options?: T): Initialized<T>;
 export function dodgeX<T>(options?: T & DodgeXOptions): Initialized<T>;
+export function dodgeX<T>(dodgeOptions?: DodgeXOptions | DodgeXOptions["anchor"], options?: T): Initialized<T>;
 
 /**
  * Given an **x** position channel, derives a new **y** position channel that
@@ -71,5 +71,5 @@ export function dodgeX<T>(options?: T & DodgeXOptions): Initialized<T>;
  *
  * If *dodgeOptions* is a string, it is shorthand for the dodge **anchor**.
  */
-export function dodgeY<T>(dodgeOptions?: DodgeYOptions | DodgeYOptions["anchor"], options?: T): Initialized<T>;
 export function dodgeY<T>(options?: T & DodgeYOptions): Initialized<T>;
+export function dodgeY<T>(dodgeOptions?: DodgeYOptions | DodgeYOptions["anchor"], options?: T): Initialized<T>;

--- a/src/transforms/normalize.d.ts
+++ b/src/transforms/normalize.d.ts
@@ -56,8 +56,8 @@ export interface NormalizeOptions {
  * is used, the derived series values would be [*x₀* / *x₀*, *x₁* / *x₀*, *x₂* /
  * *x₀*, …] as in an index chart.
  */
-export function normalizeX<T>(basis?: NormalizeBasis, options?: T): Transformed<T>;
 export function normalizeX<T>(options?: T & NormalizeOptions): Transformed<T>;
+export function normalizeX<T>(basis?: NormalizeBasis, options?: T): Transformed<T>;
 
 /**
  * Groups data into series using the first channel of **z**, **fill**, or
@@ -67,8 +67,8 @@ export function normalizeX<T>(options?: T & NormalizeOptions): Transformed<T>;
  * is used, the derived series values would be [*y₀* / *y₀*, *y₁* / *y₀*, *y₂* /
  * *y₀*, …] as in an index chart.
  */
-export function normalizeY<T>(basis?: NormalizeBasis, options?: T): Transformed<T>;
 export function normalizeY<T>(options?: T & NormalizeOptions): Transformed<T>;
+export function normalizeY<T>(basis?: NormalizeBasis, options?: T): Transformed<T>;
 
 /**
  * Given a normalize *basis*, returns a corresponding map implementation for use

--- a/src/transforms/stack.d.ts
+++ b/src/transforms/stack.d.ts
@@ -119,24 +119,24 @@ export interface StackOptions {
  * a label. If not specified, the input channel **x** defaults to the constant
  * one.
  */
-export function stackX<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 export function stackX<T>(options?: T & StackOptions): Transformed<T>;
+export function stackX<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 
 /**
  * Like **stackX**, but returns the starting position **x1** as the **x**
  * channel, for example to position a dot on the left-hand side of each element
  * of a stack.
  */
-export function stackX1<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 export function stackX1<T>(options?: T & StackOptions): Transformed<T>;
+export function stackX1<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 
 /**
  * Like **stackX**, but returns the starting position **x2** as the **x**
  * channel, for example to position a dot on the right-hand side of each element
  * of a stack.
  */
-export function stackX2<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 export function stackX2<T>(options?: T & StackOptions): Transformed<T>;
+export function stackX2<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 
 /**
  * Transforms a length channel **y** into starting and ending position channels
@@ -147,20 +147,20 @@ export function stackX2<T>(options?: T & StackOptions): Transformed<T>;
  * midpoint between **y1** and **y2**, for example to place a label. If not
  * specified, the input channel **y** defaults to the constant one.
  */
-export function stackY<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 export function stackY<T>(options?: T & StackOptions): Transformed<T>;
+export function stackY<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 
 /**
  * Like **stackY**, but returns the starting position **y1** as the **y**
  * channel, for example to position a dot at the bottom of each element of a
  * stack.
  */
-export function stackY1<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 export function stackY1<T>(options?: T & StackOptions): Transformed<T>;
+export function stackY1<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 
 /**
  * Like **stackY**, but returns the ending position **y2** as the **y** channel,
  * for example to position a dot at the top of each element of a stack.
  */
-export function stackY2<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;
 export function stackY2<T>(options?: T & StackOptions): Transformed<T>;
+export function stackY2<T>(stackOptions?: StackOptions, options?: T): Transformed<T>;

--- a/src/transforms/window.d.ts
+++ b/src/transforms/window.d.ts
@@ -108,8 +108,8 @@ export interface WindowOptions {
  *
  * If *windowOptions* is a number, it is shorthand for the window size **k**.
  */
-export function windowX<T>(windowOptions?: WindowOptions | WindowOptions["k"], options?: T): Transformed<T>;
 export function windowX<T>(options?: T & WindowOptions): Transformed<T>;
+export function windowX<T>(windowOptions?: WindowOptions | WindowOptions["k"], options?: T): Transformed<T>;
 
 /**
  * Groups data into series using the first channel of *z*, *fill*, or *stroke*
@@ -123,8 +123,8 @@ export function windowX<T>(options?: T & WindowOptions): Transformed<T>;
  *
  * If *windowOptions* is a number, it is shorthand for the window size **k**.
  */
-export function windowY<T>(windowOptions?: WindowOptions | WindowOptions["k"], options?: T): Transformed<T>;
 export function windowY<T>(options?: T & WindowOptions): Transformed<T>;
+export function windowY<T>(windowOptions?: WindowOptions | WindowOptions["k"], options?: T): Transformed<T>;
 
 /**
  * Given the specified window *options*, returns a corresponding map


### PR DESCRIPTION
This fixes a TypeScript type inference bug in a case like this:

```js
Plot.plot({
  marks: [
    Plot.differenceY(
      stocks,
      Plot.normalizeY(
        Plot.groupX(
          {y1: Plot.find((d) => d.Symbol === "GOOG"), y2: Plot.find((d) => d.Symbol === "AAPL")},
          {x: "Date", y: "Close", curve: "cardinal", tension: 0.1}
        )
      )
    )
  ]
})
```

Previously, TypeScript would assume that the normalizeY transform was being passed a single argument of _basis_; now it correctly assumes that it is being passed a single argument of _options_.