### PR TITLE
fix!: reduce specificity of generated stylesheets to 0

### DIFF
--- a/src/legends/ramp.js
+++ b/src/legends/ramp.js
@@ -38,14 +38,14 @@ export function legendRamp(color, options) {
     .call((svg) =>
       // Warning: if you edit this, change defaultClassName.
       svg.append("style").text(
-        `.${className}-ramp {
+        `:where(.${className}-ramp) {
   display: block;
   height: auto;
   height: intrinsic;
   max-width: 100%;
   overflow: visible;
 }
-.${className}-ramp text {
+:where(.${className}-ramp text) {
   white-space: pre;
 }`
       )

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -96,16 +96,16 @@ function legendItems(scale, options = {}, swatch) {
   let extraStyle;
 
   if (columns != null) {
-    extraStyle = `.${className}-swatches-columns .${className}-swatch {
+    extraStyle = `:where(.${className}-swatches-columns .${className}-swatch) {
   display: flex;
   align-items: center;
   break-inside: avoid;
   padding-bottom: 1px;
 }
-.${className}-swatches-columns .${className}-swatch::before {
+:where(.${className}-swatches-columns .${className}-swatch::before) {
   flex-shrink: 0;
 }
-.${className}-swatches-columns .${className}-swatch-label {
+:where(.${className}-swatches-columns .${className}-swatch-label) {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -123,13 +123,13 @@ function legendItems(scale, options = {}, swatch) {
         item.append("div").attr("class", `${className}-swatch-label`).attr("title", tickFormat).text(tickFormat)
       );
   } else {
-    extraStyle = `.${className}-swatches-wrap {
+    extraStyle = `:where(.${className}-swatches-wrap) {
   display: flex;
   align-items: center;
   min-height: 33px;
   flex-wrap: wrap;
 }
-.${className}-swatches-wrap .${className}-swatch {
+:where(.${className}-swatches-wrap .${className}-swatch) {
   display: inline-flex;
   align-items: center;
   margin-right: 1em;
@@ -150,12 +150,12 @@ function legendItems(scale, options = {}, swatch) {
   return swatches
     .call((div) =>
       div.insert("style", "*").text(
-        `.${className}-swatches {
+        `:where(.${className}-swatches) {
   font-family: system-ui, sans-serif;
   font-size: 10px;
   margin-bottom: 0.5em;
 }
-.${className}-swatch > svg {
+:where(.${className}-swatch > svg) {
   margin-right: 0.5em;
   overflow: visible;
 }

--- a/src/plot.js
+++ b/src/plot.js
@@ -257,15 +257,15 @@ export function plot(options = {}) {
     .call((svg) =>
       // Warning: if you edit this, change defaultClassName.
       svg.append("style").text(
-        `.${className} {
+        `:where(.${className}) {
   --plot-background: white;
   display: block;
   height: auto;
   height: intrinsic;
   max-width: 100%;
 }
-.${className} text,
-.${className} tspan {
+:where(.${className} text),
+:where(.${className} tspan) {
   white-space: pre;
 }`
       )

--- a/test/output/aaplBollinger.svg
+++ b/test/output/aaplBollinger.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplBollingerCandlestick.svg
+++ b/test/output/aaplBollingerCandlestick.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplBollingerGridInterval.svg
+++ b/test/output/aaplBollingerGridInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplBollingerGridSpacing.svg
+++ b/test/output/aaplBollingerGridSpacing.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCandlestick.svg
+++ b/test/output/aaplCandlestick.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="400" viewBox="0 0 960 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplChangeVolume.svg
+++ b/test/output/aaplChangeVolume.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplClose.svg
+++ b/test/output/aaplClose.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCloseClip.svg
+++ b/test/output/aaplCloseClip.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCloseDataTicks.svg
+++ b/test/output/aaplCloseDataTicks.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCloseGridColor.svg
+++ b/test/output/aaplCloseGridColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCloseGridInterval.svg
+++ b/test/output/aaplCloseGridInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCloseGridIntervalName.svg
+++ b/test/output/aaplCloseGridIntervalName.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCloseGridIterable.svg
+++ b/test/output/aaplCloseGridIterable.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCloseImplicitGrid.svg
+++ b/test/output/aaplCloseImplicitGrid.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCloseNormalize.svg
+++ b/test/output/aaplCloseNormalize.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplCloseUntyped.svg
+++ b/test/output/aaplCloseUntyped.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplFancyAxis.svg
+++ b/test/output/aaplFancyAxis.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplInterval.svg
+++ b/test/output/aaplInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplMonthly.svg
+++ b/test/output/aaplMonthly.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplVolume.svg
+++ b/test/output/aaplVolume.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aaplVolumeRect.svg
+++ b/test/output/aaplVolumeRect.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/anscombeQuartet.svg
+++ b/test/output/anscombeQuartet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="240" viewBox="0 0 960 240" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/arcCollatz.svg
+++ b/test/output/arcCollatz.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="520" viewBox="0 0 640 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/arcCollatzUp.svg
+++ b/test/output/arcCollatzUp.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="260" viewBox="0 0 640 260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/arcMiserables.svg
+++ b/test/output/arcMiserables.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1080" viewBox="0 0 640 1080" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/armadillo.svg
+++ b/test/output/armadillo.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="548" viewBox="0 0 960 548" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aspectRatioBand.svg
+++ b/test/output/aspectRatioBand.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="630" viewBox="0 0 640 630" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aspectRatioLinear.svg
+++ b/test/output/aspectRatioLinear.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="630" viewBox="0 0 640 630" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aspectRatioLog.svg
+++ b/test/output/aspectRatioLog.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="630" viewBox="0 0 640 630" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aspectRatioPoint.svg
+++ b/test/output/aspectRatioPoint.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="630" viewBox="0 0 640 630" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/aspectRatioSqrt.svg
+++ b/test/output/aspectRatioSqrt.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="297.273303427918" viewBox="0 0 640 297.273303427918" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesBinsColors.svg
+++ b/test/output/athletesBinsColors.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesBirthdays.svg
+++ b/test/output/athletesBirthdays.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesBoxingHeight.svg
+++ b/test/output/athletesBoxingHeight.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="350" viewBox="0 0 600 350" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesHeightWeight.svg
+++ b/test/output/athletesHeightWeight.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesHeightWeightBin.svg
+++ b/test/output/athletesHeightWeightBin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesHeightWeightBinStroke.svg
+++ b/test/output/athletesHeightWeightBinStroke.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesHeightWeightSex.svg
+++ b/test/output/athletesHeightWeightSex.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesHeightWeightSport.svg
+++ b/test/output/athletesHeightWeightSport.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesSample.svg
+++ b/test/output/athletesSample.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="620" viewBox="0 0 640 620" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesSampleFacet.svg
+++ b/test/output/athletesSampleFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="620" viewBox="0 0 640 620" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesSexWeight.svg
+++ b/test/output/athletesSexWeight.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesSortFacet.svg
+++ b/test/output/athletesSortFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="620" viewBox="0 0 640 620" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesSortNationality.html
+++ b/test/output/athletesSortNationality.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -47,7 +47,7 @@
       </svg>IOA</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -55,8 +55,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/athletesSortNullLimit.html
+++ b/test/output/athletesSortNullLimit.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -47,7 +47,7 @@
       </svg>IOA</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -55,8 +55,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/athletesSortWeightLimit.svg
+++ b/test/output/athletesSortWeightLimit.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="260" viewBox="0 0 640 260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesSportSex.svg
+++ b/test/output/athletesSportSex.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="620" viewBox="0 0 640 620" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesSportWeight.svg
+++ b/test/output/athletesSportWeight.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="620" viewBox="0 0 640 620" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesWeight.svg
+++ b/test/output/athletesWeight.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/athletesWeightCumulative.svg
+++ b/test/output/athletesWeightCumulative.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoArea.svg
+++ b/test/output/autoArea.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoAreaColor.svg
+++ b/test/output/autoAreaColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoAreaColorColor.svg
+++ b/test/output/autoAreaColorColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoAreaColorName.svg
+++ b/test/output/autoAreaColorName.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoAreaColorValue.svg
+++ b/test/output/autoAreaColorValue.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoAreaStackColor.svg
+++ b/test/output/autoAreaStackColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoAutoHistogram.svg
+++ b/test/output/autoAutoHistogram.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBar.svg
+++ b/test/output/autoBar.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBarColorReducer.svg
+++ b/test/output/autoBarColorReducer.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBarMode.svg
+++ b/test/output/autoBarMode.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBarNoReducer.svg
+++ b/test/output/autoBarNoReducer.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="560" viewBox="0 0 640 560" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBarNonZeroReducer.svg
+++ b/test/output/autoBarNonZeroReducer.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBarStackColor.svg
+++ b/test/output/autoBarStackColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBarStackColorConstant.svg
+++ b/test/output/autoBarStackColorConstant.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBarStackColorField.svg
+++ b/test/output/autoBarStackColorField.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBarTimeSeries.svg
+++ b/test/output/autoBarTimeSeries.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoBarTimeSeriesReduce.svg
+++ b/test/output/autoBarTimeSeriesReduce.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoChannels.svg
+++ b/test/output/autoChannels.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="620" viewBox="0 0 640 620" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoConnectedScatterplot.svg
+++ b/test/output/autoConnectedScatterplot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDot.svg
+++ b/test/output/autoDot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotBin.svg
+++ b/test/output/autoDotBin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotColor.svg
+++ b/test/output/autoDotColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotFacet.svg
+++ b/test/output/autoDotFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="430" viewBox="0 0 640 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotFacet2.svg
+++ b/test/output/autoDotFacet2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="510" viewBox="0 0 640 510" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotGroup.svg
+++ b/test/output/autoDotGroup.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotOrdCont.svg
+++ b/test/output/autoDotOrdCont.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotOrdinal.svg
+++ b/test/output/autoDotOrdinal.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1260" viewBox="0 0 640 1260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotSize.svg
+++ b/test/output/autoDotSize.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotSize2.svg
+++ b/test/output/autoDotSize2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotUnsortedDate.svg
+++ b/test/output/autoDotUnsortedDate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoDotZero.svg
+++ b/test/output/autoDotZero.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoHeatmap.svg
+++ b/test/output/autoHeatmap.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoHeatmapOrdCont.svg
+++ b/test/output/autoHeatmapOrdCont.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoHeatmapOrdinal.svg
+++ b/test/output/autoHeatmapOrdinal.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoHistogram.svg
+++ b/test/output/autoHistogram.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoHistogramDate.svg
+++ b/test/output/autoHistogramDate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoHistogramGroup.svg
+++ b/test/output/autoHistogramGroup.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLine.svg
+++ b/test/output/autoLine.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLineColor.svg
+++ b/test/output/autoLineColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLineColorSeries.svg
+++ b/test/output/autoLineColorSeries.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLineFacet.svg
+++ b/test/output/autoLineFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1260" viewBox="0 0 640 1260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLineHistogram.svg
+++ b/test/output/autoLineHistogram.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLineMean.svg
+++ b/test/output/autoLineMean.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLineMeanColor.svg
+++ b/test/output/autoLineMeanColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLineMeanThresholds.svg
+++ b/test/output/autoLineMeanThresholds.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLineMeanZero.svg
+++ b/test/output/autoLineMeanZero.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoLineZero.svg
+++ b/test/output/autoLineZero.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoNullReduceContinuous.svg
+++ b/test/output/autoNullReduceContinuous.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoNullReduceDate.svg
+++ b/test/output/autoNullReduceDate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoNullReduceOrdinal.svg
+++ b/test/output/autoNullReduceOrdinal.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoRectColorReducer.svg
+++ b/test/output/autoRectColorReducer.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoRectStackColor.svg
+++ b/test/output/autoRectStackColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/autoRuleZero.svg
+++ b/test/output/autoRuleZero.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/availability.svg
+++ b/test/output/availability.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="180" viewBox="0 0 640 180" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/axisFilter.svg
+++ b/test/output/axisFilter.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="100" viewBox="0 0 640 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/axisLabelBoth.svg
+++ b/test/output/axisLabelBoth.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/axisLabelBothReverse.svg
+++ b/test/output/axisLabelBothReverse.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/axisLabelFontVariant.svg
+++ b/test/output/axisLabelFontVariant.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/axisLabelHref.svg
+++ b/test/output/axisLabelHref.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/axisLabelVaryingFill.svg
+++ b/test/output/axisLabelVaryingFill.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/axisLabelX.svg
+++ b/test/output/axisLabelX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/axisLabelY.svg
+++ b/test/output/axisLabelY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/ballotStatusRace.svg
+++ b/test/output/ballotStatusRace.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="540" viewBox="0 0 640 540" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/bandClip.svg
+++ b/test/output/bandClip.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/bandClip2.svg
+++ b/test/output/bandClip2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/beagle.svg
+++ b/test/output/beagle.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="480" viewBox="0 0 960 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/beckerBarley.svg
+++ b/test/output/beckerBarley.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="800" viewBox="0 0 640 800" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/bigint1.svg
+++ b/test/output/bigint1.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/bigint2.svg
+++ b/test/output/bigint2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/bigintLog.svg
+++ b/test/output/bigintLog.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/bigintOrdinal.html
+++ b/test/output/bigintOrdinal.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -58,7 +58,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">big1</text>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -66,8 +66,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/bigintStack.svg
+++ b/test/output/bigintStack.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/bin1m.svg
+++ b/test/output/bin1m.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/binFillFirstEmpty.html
+++ b/test/output/binFillFirstEmpty.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>null</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/binStrings.svg
+++ b/test/output/binStrings.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/binTimestamps.svg
+++ b/test/output/binTimestamps.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/boundingBoxes.svg
+++ b/test/output/boundingBoxes.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/boxplot.svg
+++ b/test/output/boxplot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/boxplotFacetInterval.svg
+++ b/test/output/boxplotFacetInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="280" viewBox="0 0 640 280" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/boxplotFacetNegativeInterval.svg
+++ b/test/output/boxplotFacetNegativeInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="280" viewBox="0 0 640 280" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/caltrain.html
+++ b/test/output/caltrain.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>B</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="240" height="520" viewBox="0 0 240 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/caltrainDirection.svg
+++ b/test/output/caltrainDirection.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/carsDodge.svg
+++ b/test/output/carsDodge.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="200" viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/carsHexbin.html
+++ b/test/output/carsHexbin.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -34,7 +34,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">weight (lb)</text>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -42,8 +42,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/carsJitter.html
+++ b/test/output/carsJitter.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -34,7 +34,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">power (hp)</text>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="350" viewBox="0 0 640 350" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -42,8 +42,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/carsMpg.svg
+++ b/test/output/carsMpg.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/carsParcoords.svg
+++ b/test/output/carsParcoords.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="200" viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainAscending.svg
+++ b/test/output/channelDomainAscending.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainAscendingReverse.svg
+++ b/test/output/channelDomainAscendingReverse.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainComparator.svg
+++ b/test/output/channelDomainComparator.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainComparatorReverse.svg
+++ b/test/output/channelDomainComparatorReverse.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainDefault.svg
+++ b/test/output/channelDomainDefault.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainDefaultReverse.svg
+++ b/test/output/channelDomainDefaultReverse.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainDescending.svg
+++ b/test/output/channelDomainDescending.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainDescendingReverse.svg
+++ b/test/output/channelDomainDescendingReverse.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainMinus.svg
+++ b/test/output/channelDomainMinus.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainMinusReverse.svg
+++ b/test/output/channelDomainMinusReverse.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainNull.svg
+++ b/test/output/channelDomainNull.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainNullReverse.svg
+++ b/test/output/channelDomainNullReverse.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainReduceCount.svg
+++ b/test/output/channelDomainReduceCount.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/channelDomainReduceDefault.svg
+++ b/test/output/channelDomainReduceDefault.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="460" viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/clamp.svg
+++ b/test/output/clamp.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/collapsedHistogram.svg
+++ b/test/output/collapsedHistogram.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendCategorical.html
+++ b/test/output/colorLegendCategorical.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/colorLegendCategoricalColumns.html
+++ b/test/output/colorLegendCategoricalColumns.html
@@ -1,28 +1,28 @@
 <div class="plot-swatches plot-swatches-columns" style="columns: 180px;">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-columns .plot-swatch {
+    :where(.plot-swatches-columns .plot-swatch) {
       display: flex;
       align-items: center;
       break-inside: avoid;
       padding-bottom: 1px;
     }
 
-    .plot-swatches-columns .plot-swatch::before {
+    :where(.plot-swatches-columns .plot-swatch::before) {
       flex-shrink: 0;
     }
 
-    .plot-swatches-columns .plot-swatch-label {
+    :where(.plot-swatches-columns .plot-swatch-label) {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/test/output/colorLegendCategoricalReverse.html
+++ b/test/output/colorLegendCategoricalReverse.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/colorLegendCategoricalScheme.html
+++ b/test/output/colorLegendCategoricalScheme.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/colorLegendDiverging.svg
+++ b/test/output/colorLegendDiverging.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendDivergingPivot.svg
+++ b/test/output/colorLegendDivergingPivot.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendDivergingPivotAsymmetric.svg
+++ b/test/output/colorLegendDivergingPivotAsymmetric.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendDivergingSqrt.svg
+++ b/test/output/colorLegendDivergingSqrt.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendImplicitLabel.svg
+++ b/test/output/colorLegendImplicitLabel.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendInterpolate.svg
+++ b/test/output/colorLegendInterpolate.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendInterpolateSqrt.svg
+++ b/test/output/colorLegendInterpolateSqrt.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLabelBoth.svg
+++ b/test/output/colorLegendLabelBoth.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLabelLegend.svg
+++ b/test/output/colorLegendLabelLegend.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLabelScale.svg
+++ b/test/output/colorLegendLabelScale.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLinear.svg
+++ b/test/output/colorLegendLinear.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLinearNoTicks.svg
+++ b/test/output/colorLegendLinearNoTicks.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLinearTruncatedScheme.svg
+++ b/test/output/colorLegendLinearTruncatedScheme.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLog.svg
+++ b/test/output/colorLegendLog.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendLogTicks.svg
+++ b/test/output/colorLegendLogTicks.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendMargins.svg
+++ b/test/output/colorLegendMargins.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="400" height="50" viewBox="0 0 400 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOpacity.html
+++ b/test/output/colorLegendOpacity.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/colorLegendOpacityOrdinalRamp.svg
+++ b/test/output/colorLegendOpacityOrdinalRamp.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOpacityRamp.svg
+++ b/test/output/colorLegendOpacityRamp.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinal.html
+++ b/test/output/colorLegendOrdinal.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/colorLegendOrdinalRamp.svg
+++ b/test/output/colorLegendOrdinalRamp.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinalRampTickSize.svg
+++ b/test/output/colorLegendOrdinalRampTickSize.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinalReverseRamp.svg
+++ b/test/output/colorLegendOrdinalReverseRamp.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinalScheme.html
+++ b/test/output/colorLegendOrdinalScheme.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/colorLegendOrdinalSchemeRamp.svg
+++ b/test/output/colorLegendOrdinalSchemeRamp.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendOrdinalTickFormat.html
+++ b/test/output/colorLegendOrdinalTickFormat.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/colorLegendOrdinalTickFormatFunction.html
+++ b/test/output/colorLegendOrdinalTickFormatFunction.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/colorLegendOrdinalTicks.svg
+++ b/test/output/colorLegendOrdinalTicks.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantile.svg
+++ b/test/output/colorLegendQuantile.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantileImplicit.svg
+++ b/test/output/colorLegendQuantileImplicit.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantileSwatches.html
+++ b/test/output/colorLegendQuantileSwatches.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap" style="font-variant: tabular-nums;">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/colorLegendQuantitative.svg
+++ b/test/output/colorLegendQuantitative.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantitativeScheme.svg
+++ b/test/output/colorLegendQuantitativeScheme.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantize.svg
+++ b/test/output/colorLegendQuantize.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantizeDescending.svg
+++ b/test/output/colorLegendQuantizeDescending.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantizeDescendingReversed.svg
+++ b/test/output/colorLegendQuantizeDescendingReversed.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantizeRange.svg
+++ b/test/output/colorLegendQuantizeRange.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendQuantizeReverse.svg
+++ b/test/output/colorLegendQuantizeReverse.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendSqrt.svg
+++ b/test/output/colorLegendSqrt.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendSqrtPiecewise.svg
+++ b/test/output/colorLegendSqrtPiecewise.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendThreshold.svg
+++ b/test/output/colorLegendThreshold.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorLegendThresholdTickSize.svg
+++ b/test/output/colorLegendThresholdTickSize.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,7 +8,7 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>

--- a/test/output/colorPiecewiseLinearDomain.html
+++ b/test/output/colorPiecewiseLinearDomain.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -37,7 +37,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -45,8 +45,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/colorPiecewiseLinearDomainReverse.html
+++ b/test/output/colorPiecewiseLinearDomainReverse.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -37,7 +37,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -45,8 +45,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/colorPiecewiseLinearRange.html
+++ b/test/output/colorPiecewiseLinearRange.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -41,7 +41,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/colorPiecewiseLinearRangeHcl.html
+++ b/test/output/colorPiecewiseLinearRangeHcl.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -41,7 +41,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/colorPiecewiseLinearRangeReverse.html
+++ b/test/output/colorPiecewiseLinearRangeReverse.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -41,7 +41,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/colorSchemesOrdinal.html
+++ b/test/output/colorSchemesOrdinal.html
@@ -1,25 +1,25 @@
 <div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -30,25 +30,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -61,25 +61,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -96,25 +96,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -141,25 +141,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -198,25 +198,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -227,25 +227,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -258,25 +258,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -293,25 +293,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -338,25 +338,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -395,25 +395,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -424,25 +424,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -455,25 +455,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -490,25 +490,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -535,25 +535,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -592,25 +592,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -621,25 +621,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -652,25 +652,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -687,25 +687,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -732,25 +732,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -789,25 +789,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -818,25 +818,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -849,25 +849,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -884,25 +884,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -929,25 +929,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -986,25 +986,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1015,25 +1015,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1046,25 +1046,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1081,25 +1081,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1126,25 +1126,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1183,25 +1183,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1212,25 +1212,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1243,25 +1243,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1278,25 +1278,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1323,25 +1323,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1380,25 +1380,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1409,25 +1409,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1440,25 +1440,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1475,25 +1475,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1520,25 +1520,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1577,25 +1577,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1606,25 +1606,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1637,25 +1637,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1672,25 +1672,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1717,25 +1717,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1774,25 +1774,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1803,25 +1803,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1834,25 +1834,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1869,25 +1869,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1914,25 +1914,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -1971,25 +1971,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2000,25 +2000,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2031,25 +2031,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2066,25 +2066,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2111,25 +2111,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2168,25 +2168,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2197,25 +2197,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2228,25 +2228,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2263,25 +2263,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2308,25 +2308,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2365,25 +2365,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2394,25 +2394,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2425,25 +2425,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2460,25 +2460,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2505,25 +2505,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2562,25 +2562,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2591,25 +2591,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2622,25 +2622,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2657,25 +2657,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2702,25 +2702,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2759,25 +2759,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2788,25 +2788,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2819,25 +2819,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2854,25 +2854,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2899,25 +2899,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2956,25 +2956,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -2985,25 +2985,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3016,25 +3016,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3051,25 +3051,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3096,25 +3096,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3153,25 +3153,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3182,25 +3182,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3213,25 +3213,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3248,25 +3248,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3293,25 +3293,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3350,25 +3350,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3379,25 +3379,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3410,25 +3410,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3445,25 +3445,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3490,25 +3490,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3547,25 +3547,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3576,25 +3576,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3607,25 +3607,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3642,25 +3642,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3687,25 +3687,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3744,25 +3744,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3773,25 +3773,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3804,25 +3804,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3839,25 +3839,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3884,25 +3884,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3941,25 +3941,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -3970,25 +3970,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4001,25 +4001,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4036,25 +4036,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4081,25 +4081,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4138,25 +4138,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4167,25 +4167,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4198,25 +4198,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4233,25 +4233,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4278,25 +4278,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4335,25 +4335,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4364,25 +4364,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4395,25 +4395,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4430,25 +4430,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4475,25 +4475,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4532,25 +4532,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4561,25 +4561,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4592,25 +4592,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4627,25 +4627,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4672,25 +4672,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4729,25 +4729,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4758,25 +4758,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4789,25 +4789,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4824,25 +4824,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4869,25 +4869,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4926,25 +4926,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4955,25 +4955,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -4986,25 +4986,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5021,25 +5021,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5066,25 +5066,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5123,25 +5123,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5152,25 +5152,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5183,25 +5183,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5218,25 +5218,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5263,25 +5263,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5320,25 +5320,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5349,25 +5349,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5380,25 +5380,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5415,25 +5415,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5460,25 +5460,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5517,25 +5517,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5546,25 +5546,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5577,25 +5577,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5612,25 +5612,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5657,25 +5657,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5714,25 +5714,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5743,25 +5743,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5774,25 +5774,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5809,25 +5809,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5854,25 +5854,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5911,25 +5911,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5940,25 +5940,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -5971,25 +5971,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6006,25 +6006,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6051,25 +6051,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6108,25 +6108,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6137,25 +6137,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6168,25 +6168,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6203,25 +6203,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6248,25 +6248,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6305,25 +6305,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6334,25 +6334,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6365,25 +6365,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6400,25 +6400,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6445,25 +6445,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6502,25 +6502,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6531,25 +6531,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6562,25 +6562,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6597,25 +6597,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6642,25 +6642,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6699,25 +6699,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6728,25 +6728,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6759,25 +6759,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6794,25 +6794,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6839,25 +6839,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6896,25 +6896,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6925,25 +6925,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6956,25 +6956,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -6991,25 +6991,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7036,25 +7036,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7093,25 +7093,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7122,25 +7122,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7153,25 +7153,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7188,25 +7188,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7233,25 +7233,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7290,25 +7290,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7319,25 +7319,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7350,25 +7350,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7385,25 +7385,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7430,25 +7430,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7487,25 +7487,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7516,25 +7516,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7547,25 +7547,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7582,25 +7582,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7627,25 +7627,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7684,25 +7684,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7713,25 +7713,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7744,25 +7744,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7779,25 +7779,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7824,25 +7824,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7881,25 +7881,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7910,25 +7910,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7941,25 +7941,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -7976,25 +7976,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8021,25 +8021,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8078,25 +8078,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8107,25 +8107,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8138,25 +8138,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8173,25 +8173,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8218,25 +8218,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8275,25 +8275,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8304,25 +8304,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8335,25 +8335,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8370,25 +8370,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8415,25 +8415,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8472,25 +8472,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8501,25 +8501,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8532,25 +8532,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8567,25 +8567,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8612,25 +8612,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8669,25 +8669,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8698,25 +8698,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8729,25 +8729,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8764,25 +8764,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8809,25 +8809,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8866,25 +8866,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8895,25 +8895,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8926,25 +8926,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -8961,25 +8961,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9006,25 +9006,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9063,25 +9063,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9092,25 +9092,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9123,25 +9123,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9158,25 +9158,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9203,25 +9203,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9260,25 +9260,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9289,25 +9289,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9320,25 +9320,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9355,25 +9355,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9400,25 +9400,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9457,25 +9457,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9486,25 +9486,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9517,25 +9517,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9552,25 +9552,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9597,25 +9597,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9654,25 +9654,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9683,25 +9683,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9714,25 +9714,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9749,25 +9749,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -9794,25 +9794,25 @@
   </div>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;

--- a/test/output/colorSchemesQuantitative.html
+++ b/test/output/colorSchemesQuantitative.html
@@ -1,6 +1,6 @@
 <div><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -17,7 +17,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">brbg</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -25,7 +25,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -34,7 +34,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">prgn</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -42,7 +42,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -51,7 +51,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">piyg</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -59,7 +59,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -68,7 +68,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">puor</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -76,7 +76,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -85,7 +85,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdbu</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -93,7 +93,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -102,7 +102,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdgy</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -110,7 +110,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -119,7 +119,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdylbu</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -127,7 +127,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -136,7 +136,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdylgn</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -144,7 +144,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -153,7 +153,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">spectral</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -161,7 +161,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -170,7 +170,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">burd</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -178,7 +178,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -187,7 +187,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">buylrd</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -195,7 +195,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -204,7 +204,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">blues</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -212,7 +212,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -221,7 +221,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">greens</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -229,7 +229,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -238,7 +238,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">greys</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -246,7 +246,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -255,7 +255,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">purples</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -263,7 +263,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -272,7 +272,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">reds</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -280,7 +280,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -289,7 +289,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">oranges</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -297,7 +297,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -306,7 +306,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">turbo</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -314,7 +314,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -323,7 +323,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">viridis</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -331,7 +331,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -340,7 +340,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">magma</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -348,7 +348,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -357,7 +357,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">inferno</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -365,7 +365,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -374,7 +374,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">plasma</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -382,7 +382,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -391,7 +391,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">cividis</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -399,7 +399,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -408,7 +408,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">cubehelix</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -416,7 +416,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -425,7 +425,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">warm</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -433,7 +433,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -442,7 +442,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">cool</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -450,7 +450,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -459,7 +459,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">bugn</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -467,7 +467,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -476,7 +476,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">bupu</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -484,7 +484,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -493,7 +493,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">gnbu</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -501,7 +501,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -510,7 +510,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">orrd</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -518,7 +518,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -527,7 +527,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">pubugn</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -535,7 +535,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -544,7 +544,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">pubu</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -552,7 +552,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -561,7 +561,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">purd</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -569,7 +569,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -578,7 +578,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">rdpu</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -586,7 +586,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -595,7 +595,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">ylgnbu</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -603,7 +603,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -612,7 +612,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">ylgn</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -620,7 +620,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -629,7 +629,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">ylorbr</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -637,7 +637,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -646,7 +646,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">ylorrd</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -654,7 +654,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -663,7 +663,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">rainbow</text>
   </svg><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="44" viewBox="0 0 240 44" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -671,7 +671,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>

--- a/test/output/contourCa55.svg
+++ b/test/output/contourCa55.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="484" viewBox="0 0 640 484" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/contourVapor.svg
+++ b/test/output/contourVapor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="468" viewBox="0 0 960 468" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/countryCentroids.svg
+++ b/test/output/countryCentroids.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/covidIhmeProjectedDeaths.svg
+++ b/test/output/covidIhmeProjectedDeaths.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/crimeanWarArrow.svg
+++ b/test/output/crimeanWarArrow.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/crimeanWarLine.svg
+++ b/test/output/crimeanWarLine.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/crimeanWarOverlapped.svg
+++ b/test/output/crimeanWarOverlapped.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/crimeanWarStacked.svg
+++ b/test/output/crimeanWarStacked.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/crosshairDodge.svg
+++ b/test/output/crosshairDodge.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="160" viewBox="0 0 640 160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/crosshairDot.svg
+++ b/test/output/crosshairDot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/crosshairDotFacet.svg
+++ b/test/output/crosshairDotFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="480" viewBox="0 0 640 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/crosshairHexbin.svg
+++ b/test/output/crosshairHexbin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/crosshairLine.svg
+++ b/test/output/crosshairLine.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/curves.svg
+++ b/test/output/curves.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="500" height="547.8103861691175" viewBox="0 0 500 547.8103861691175" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/d3Survey2015Comfort.svg
+++ b/test/output/d3Survey2015Comfort.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="150" viewBox="0 0 960 150" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/d3Survey2015Why.svg
+++ b/test/output/d3Survey2015Why.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="350" viewBox="0 0 960 350" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/darkerDodge.svg
+++ b/test/output/darkerDodge.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="170" viewBox="0 0 640 170" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/decathlon.html
+++ b/test/output/decathlon.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -41,7 +41,7 @@
       </svg>USA</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/diamondsBoxplot.svg
+++ b/test/output/diamondsBoxplot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="220" viewBox="0 0 640 220" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/diamondsCaratPrice.svg
+++ b/test/output/diamondsCaratPrice.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/diamondsCaratPriceDots.svg
+++ b/test/output/diamondsCaratPriceDots.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/diamondsCaratSampling.svg
+++ b/test/output/diamondsCaratSampling.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceFilterX.svg
+++ b/test/output/differenceFilterX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceFilterY1.svg
+++ b/test/output/differenceFilterY1.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceFilterY2.svg
+++ b/test/output/differenceFilterY2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceY.svg
+++ b/test/output/differenceY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceY1.svg
+++ b/test/output/differenceY1.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYClip.svg
+++ b/test/output/differenceYClip.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYClipVariable.svg
+++ b/test/output/differenceYClipVariable.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYConstant.svg
+++ b/test/output/differenceYConstant.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYCurve.svg
+++ b/test/output/differenceYCurve.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYNegative.svg
+++ b/test/output/differenceYNegative.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYOrdinal.svg
+++ b/test/output/differenceYOrdinal.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="160" viewBox="0 0 640 160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYOrdinalFlip.svg
+++ b/test/output/differenceYOrdinalFlip.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="160" viewBox="0 0 640 160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYRandom.svg
+++ b/test/output/differenceYRandom.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYReverse.svg
+++ b/test/output/differenceYReverse.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYVariable.svg
+++ b/test/output/differenceYVariable.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/differenceYZero.svg
+++ b/test/output/differenceYZero.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/documentationLinks.svg
+++ b/test/output/documentationLinks.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="560" viewBox="0 0 640 560" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/dodgeRule.svg
+++ b/test/output/dodgeRule.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/dodgeTextRadius.svg
+++ b/test/output/dodgeTextRadius.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/dodgeTick.svg
+++ b/test/output/dodgeTick.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/dotSort.html
+++ b/test/output/dotSort.html
@@ -1,7 +1,7 @@
 <span>
   <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -9,8 +9,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -30,7 +30,7 @@
   <br>
   <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -38,8 +38,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -59,7 +59,7 @@
   <br>
   <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -67,8 +67,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -88,7 +88,7 @@
   <br>
   <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -96,8 +96,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -117,7 +117,7 @@
   <br>
   <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -125,8 +125,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -146,7 +146,7 @@
   <br>
   <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -154,8 +154,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -175,7 +175,7 @@
   <br>
   <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -183,8 +183,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>

--- a/test/output/downloads.svg
+++ b/test/output/downloads.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/downloadsOrdinal.svg
+++ b/test/output/downloadsOrdinal.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/driving.svg
+++ b/test/output/driving.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/electricityDemand.svg
+++ b/test/output/electricityDemand.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="400" viewBox="0 0 960 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/empty.svg
+++ b/test/output/empty.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/emptyFacet.svg
+++ b/test/output/emptyFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="430" viewBox="0 0 640 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/emptyLegend.svg
+++ b/test/output/emptyLegend.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/emptyX.svg
+++ b/test/output/emptyX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/energyProduction.html
+++ b/test/output/energyProduction.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>Nuclear</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/errorBarX.svg
+++ b/test/output/errorBarX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/errorBarY.svg
+++ b/test/output/errorBarY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/facetReindex.svg
+++ b/test/output/facetReindex.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="830" height="130" viewBox="0 0 830 130" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/faithfulDensity.svg
+++ b/test/output/faithfulDensity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/faithfulDensity1d.svg
+++ b/test/output/faithfulDensity1d.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="100" viewBox="0 0 640 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/faithfulDensityFill.svg
+++ b/test/output/faithfulDensityFill.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/federalFunds.svg
+++ b/test/output/federalFunds.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/figcaption.html
+++ b/test/output/figcaption.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -8,8 +8,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/figcaptionHtml.html
+++ b/test/output/figcaptionHtml.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -8,8 +8,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/findArrow.html
+++ b/test/output/findArrow.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>Y25-29</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/firstLadies.svg
+++ b/test/output/firstLadies.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="1120" viewBox="0 0 960 1120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/flareCluster.svg
+++ b/test/output/flareCluster.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="2400" viewBox="0 0 640 2400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/flareIndent.svg
+++ b/test/output/flareIndent.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="200" height="3600" viewBox="0 0 200 3600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/flareTree.svg
+++ b/test/output/flareTree.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1800" viewBox="0 0 640 1800" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/footballCoverage.svg
+++ b/test/output/footballCoverage.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="430" viewBox="0 0 640 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/frameCorners.svg
+++ b/test/output/frameCorners.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/frameFacet.svg
+++ b/test/output/frameFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/frameFillCategorical.html
+++ b/test/output/frameFillCategorical.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>foo</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/frameFillQuantitative.html
+++ b/test/output/frameFillQuantitative.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -41,7 +41,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/frameSides.svg
+++ b/test/output/frameSides.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="350" height="250" viewBox="0 0 350 250" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/frameSidesX.svg
+++ b/test/output/frameSidesX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="350" height="250" viewBox="0 0 350 250" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/frameSidesXY.svg
+++ b/test/output/frameSidesXY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="350" height="250" viewBox="0 0 350 250" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/frameSidesY.svg
+++ b/test/output/frameSidesY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="350" height="250" viewBox="0 0 350 250" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/fruitSales.svg
+++ b/test/output/fruitSales.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="140" viewBox="0 0 640 140" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/fruitSalesDate.svg
+++ b/test/output/fruitSalesDate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/fruitSalesSingleDate.svg
+++ b/test/output/fruitSalesSingleDate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/functionContour.svg
+++ b/test/output/functionContour.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/functionContourFaceted.svg
+++ b/test/output/functionContourFaceted.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/functionContourFaceted2.svg
+++ b/test/output/functionContourFaceted2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/futureSplom.svg
+++ b/test/output/futureSplom.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="400" height="400" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/geoLine.svg
+++ b/test/output/geoLine.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/geoLink.svg
+++ b/test/output/geoLink.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="312" viewBox="0 0 640 312" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/gistempAnomaly.svg
+++ b/test/output/gistempAnomaly.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/gistempAnomalyMoving.svg
+++ b/test/output/gistempAnomalyMoving.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/gistempAnomalyTransform.svg
+++ b/test/output/gistempAnomalyTransform.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/googleTrendsRidgeline.svg
+++ b/test/output/googleTrendsRidgeline.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="1260" viewBox="0 0 960 1260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/graticule.svg
+++ b/test/output/graticule.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="470" viewBox="0 0 960 470" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/greekGods.svg
+++ b/test/output/greekGods.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/greekGodsExplicit.svg
+++ b/test/output/greekGodsExplicit.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/greekGodsTip.svg
+++ b/test/output/greekGodsTip.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/gridChoropleth.svg
+++ b/test/output/gridChoropleth.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="420" viewBox="0 0 640 420" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/gridChoroplethDx.svg
+++ b/test/output/gridChoroplethDx.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="420" viewBox="0 0 640 420" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/gridReduceIdentity.svg
+++ b/test/output/gridReduceIdentity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="293.66666666666663" viewBox="0 0 640 293.66666666666663" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/groupedRects.svg
+++ b/test/output/groupedRects.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/hadcrutWarmingStripes.svg
+++ b/test/output/hadcrutWarmingStripes.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/heatmap.svg
+++ b/test/output/heatmap.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/heatmapArray.svg
+++ b/test/output/heatmapArray.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/heatmapConstantOpacity.svg
+++ b/test/output/heatmapConstantOpacity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/heatmapFaceted.svg
+++ b/test/output/heatmapFaceted.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/heatmapFillOpacity.svg
+++ b/test/output/heatmapFillOpacity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/heatmapLog.svg
+++ b/test/output/heatmapLog.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="630" viewBox="0 0 640 630" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/heatmapOpacity.svg
+++ b/test/output/heatmapOpacity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/heatmapPartial.svg
+++ b/test/output/heatmapPartial.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/hexbin.svg
+++ b/test/output/hexbin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/hexbinFillX.svg
+++ b/test/output/hexbinFillX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/hexbinIdentityReduce.svg
+++ b/test/output/hexbinIdentityReduce.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="600" viewBox="0 0 640 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/hexbinOranges.svg
+++ b/test/output/hexbinOranges.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/hexbinR.html
+++ b/test/output/hexbinR.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -34,7 +34,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">Proportion of each sex (%)</text>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="320" viewBox="0 0 960 320" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -42,8 +42,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/hexbinSymbol.html
+++ b/test/output/hexbinSymbol.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>null</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/hexbinText.svg
+++ b/test/output/hexbinText.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="320" viewBox="0 0 960 320" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/hexbinZ.html
+++ b/test/output/hexbinZ.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>Gentoo</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/hexbinZNull.svg
+++ b/test/output/hexbinZNull.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/highCardinalityOrdinal.svg
+++ b/test/output/highCardinalityOrdinal.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/hrefFill.svg
+++ b/test/output/hrefFill.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/ibmTrading.svg
+++ b/test/output/ibmTrading.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/identityScale.svg
+++ b/test/output/identityScale.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/imagePixelated.svg
+++ b/test/output/imagePixelated.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="200" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/industryUnemployment.svg
+++ b/test/output/industryUnemployment.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/industryUnemploymentShare.svg
+++ b/test/output/industryUnemploymentShare.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/industryUnemploymentStream.svg
+++ b/test/output/industryUnemploymentStream.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/industryUnemploymentTrack.svg
+++ b/test/output/industryUnemploymentTrack.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="340" viewBox="0 0 640 340" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/infinityLog.svg
+++ b/test/output/infinityLog.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/integerInterval.svg
+++ b/test/output/integerInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/integerIntervalArea.html
+++ b/test/output/integerIntervalArea.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -31,7 +31,7 @@
       </svg>b</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -39,8 +39,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/integerIntervalAreaZ.html
+++ b/test/output/integerIntervalAreaZ.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -37,7 +37,7 @@
       </svg>c</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -45,8 +45,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/internFacetDate.svg
+++ b/test/output/internFacetDate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="900" viewBox="0 0 640 900" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/internFacetNaN.svg
+++ b/test/output/internFacetNaN.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="540" viewBox="0 0 640 540" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/intervalAwareBin.svg
+++ b/test/output/intervalAwareBin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/intervalAwareGroup.svg
+++ b/test/output/intervalAwareGroup.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/intervalAwareStack.svg
+++ b/test/output/intervalAwareStack.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/intradayHistogram.svg
+++ b/test/output/intradayHistogram.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/kittenConstant.svg
+++ b/test/output/kittenConstant.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="520" height="520" viewBox="0 0 520 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/kittenConstantRotate.svg
+++ b/test/output/kittenConstantRotate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="520" height="520" viewBox="0 0 520 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/kittenConstantWidthHeight.svg
+++ b/test/output/kittenConstantWidthHeight.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="520" height="520" viewBox="0 0 520 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/kittenVariable.svg
+++ b/test/output/kittenVariable.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="520" height="520" viewBox="0 0 520 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/kittenVariableDodge.svg
+++ b/test/output/kittenVariableDodge.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="520" height="520" viewBox="0 0 520 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/kittenVariableRotate.svg
+++ b/test/output/kittenVariableRotate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="520" height="520" viewBox="0 0 520 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/learningPoverty.svg
+++ b/test/output/learningPoverty.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1160" viewBox="0 0 640 1160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/letterFrequencyBar.svg
+++ b/test/output/letterFrequencyBar.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" aria-label="letter-frequency chart" aria-description="A horizontal bar chart showing the relative frequency of letters in the English language." xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/letterFrequencyCloud.svg
+++ b/test/output/letterFrequencyCloud.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/letterFrequencyColumn.svg
+++ b/test/output/letterFrequencyColumn.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/letterFrequencyDot.svg
+++ b/test/output/letterFrequencyDot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/letterFrequencyLollipop.svg
+++ b/test/output/letterFrequencyLollipop.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/letterFrequencyWheel.svg
+++ b/test/output/letterFrequencyWheel.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="500" height="250" viewBox="0 0 500 250" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/liborProjections.svg
+++ b/test/output/liborProjections.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="392.4521874459623" viewBox="0 0 960 392.4521874459623" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/liborProjectionsFacet.html
+++ b/test/output/liborProjectionsFacet.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -35,7 +35,7 @@
       </svg>H4</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1040" viewBox="0 0 640 1040" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -43,8 +43,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/likertSurvey.html
+++ b/test/output/likertSurvey.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -37,7 +37,7 @@
       </svg>Strongly Agree</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="160" viewBox="0 0 640 160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -45,8 +45,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/linearRegressionCars.svg
+++ b/test/output/linearRegressionCars.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/linearRegressionMtcars.svg
+++ b/test/output/linearRegressionMtcars.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/linearRegressionPenguins.svg
+++ b/test/output/linearRegressionPenguins.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/logDegenerate.svg
+++ b/test/output/logDegenerate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/longLabels.svg
+++ b/test/output/longLabels.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/mandelbrot.svg
+++ b/test/output/mandelbrot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="500" viewBox="0 0 640 500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/markerRuleX.svg
+++ b/test/output/markerRuleX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/markerRuleY.svg
+++ b/test/output/markerRuleY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/markerTickX.svg
+++ b/test/output/markerTickX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/markerTickY.svg
+++ b/test/output/markerTickY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/markovChain.svg
+++ b/test/output/markovChain.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="400" height="407.26108765585843" viewBox="0 0 400 407.26108765585843" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroInequality.svg
+++ b/test/output/metroInequality.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroInequalityChange.svg
+++ b/test/output/metroInequalityChange.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroUnemployment.svg
+++ b/test/output/metroUnemployment.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroUnemploymentHighlight.svg
+++ b/test/output/metroUnemploymentHighlight.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroUnemploymentIndex.svg
+++ b/test/output/metroUnemploymentIndex.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroUnemploymentMoving.svg
+++ b/test/output/metroUnemploymentMoving.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroUnemploymentNormalize.svg
+++ b/test/output/metroUnemploymentNormalize.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroUnemploymentRidgeline.svg
+++ b/test/output/metroUnemploymentRidgeline.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="1080" viewBox="0 0 960 1080" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroUnemploymentSlope.svg
+++ b/test/output/metroUnemploymentSlope.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/metroUnemploymentStroke.svg
+++ b/test/output/metroUnemploymentStroke.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/mobyDick.svg
+++ b/test/output/mobyDick.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1200" viewBox="0 0 640 1200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/mobyDickFaceted.svg
+++ b/test/output/mobyDickFaceted.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="430" viewBox="0 0 640 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/mobyDickLetterFrequency.svg
+++ b/test/output/mobyDickLetterFrequency.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/mobyDickLetterFrequencyFillX.svg
+++ b/test/output/mobyDickLetterFrequencyFillX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/mobyDickLetterPairs.svg
+++ b/test/output/mobyDickLetterPairs.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="600" viewBox="0 0 640 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/mobyDickLetterPosition.svg
+++ b/test/output/mobyDickLetterPosition.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/mobyDickLetterRelativeFrequency.svg
+++ b/test/output/mobyDickLetterRelativeFrequency.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/morleyBoxplot.svg
+++ b/test/output/morleyBoxplot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="160" viewBox="0 0 640 160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/moviesProfitByGenre.svg
+++ b/test/output/moviesProfitByGenre.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="320" viewBox="0 0 640 320" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/moviesRatingByGenre.svg
+++ b/test/output/moviesRatingByGenre.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="560" viewBox="0 0 960 560" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/multiplicationTable.svg
+++ b/test/output/multiplicationTable.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="450" height="450" viewBox="0 0 450 450" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/musicRevenue.svg
+++ b/test/output/musicRevenue.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/musicRevenueCustomOrder.svg
+++ b/test/output/musicRevenueCustomOrder.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/npmVersions.svg
+++ b/test/output/npmVersions.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="140" viewBox="0 0 640 140" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/opacityDotsFillUnscaled.svg
+++ b/test/output/opacityDotsFillUnscaled.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/opacityDotsStrokeUnscaled.svg
+++ b/test/output/opacityDotsStrokeUnscaled.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/opacityDotsUnscaled.svg
+++ b/test/output/opacityDotsUnscaled.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/opacityLegend.svg
+++ b/test/output/opacityLegend.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,11 +8,11 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>
-  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAWUlEQVQ4jd2SSwoAIAhEx+5/6DZCg/gZqFWBoCZPRzScZwCW+8tjozjmO6tqJxbnlX4K57Y2m3n6Z44h36eqMXK4X2SrO+rmV7hZbeVPepR7UrX9pOWllewNAjMBAXvLNnYAAAAASUVORK5CYII="></image>
+  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAZ0lEQVQ4jaVS2wpAIQjT/v+jewmSMefOKRA0bJc0456MiHXydeosNd6r6HoVVtWAGFH6mDaH3+llPEwzyx1P3VvnP3E+DNsNpR9xlQfUxfLJj5rv1z2bvCiMyUunz+H4O5MXPGf3cwMB/wEBfsriPgAAAABJRU5ErkJggg=="></image>
   <g transform="translate(0,28)" fill="none" text-anchor="middle" font-variant="tabular-nums">
     <g class="tick" opacity="1" transform="translate(0.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line>

--- a/test/output/opacityLegendColor.svg
+++ b/test/output/opacityLegendColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,11 +8,11 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>
-  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAABbElEQVQ4jXWQS24UQRBE38vpHg8WXniBhLgGZ+GSnIwNYoFkxjPdFSyqej429Co7MzIyXsn1k2/fC+Dr8686fnn29ecPAT5NnwvgaXes08eD55cHl8ffPv3Zu3yYXY6z6+HFx9fJ9WEWYM+51tPOdT+5no4e9pMAZ5YCmNhXO59sc7lfdrapBFhYa162utU8lW3RTIutyrmVrRbTFKCYKrXYWjmVpq0CrFRNtdpamdq0rTL+d2299FuqdmlGTXpPUvG6B9CoStroVcU2tBZASFXsPmOW6Kat4KbbvB2epRKMMcFSkyZDl6ikbu9hbDhuNolGrMSIvGHpvhkZLDNqrU3HaISU0t9DdWTJYBBGBsyWa+wBfQVrBL+wXTKJgTIM3+a2hDFx7Omg6TNi0B6h50i3u7ztHUtfK4mAXRt7f3jkysLGFXr+7vBPFgcLdyxsvgrjTkbNTYZ3M7iwvNU6uP8/u/d9N+P2DW61fwF639N9+dGgcwAAAABJRU5ErkJggg=="></image>
+  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAABc0lEQVQ4jWWRQY7TUBBE3+s4njBiFrNAQlyDs3BJTsYGsUAaMon9i8X/ThyNV213dXW9ttwf+fGzAL6//qnzt1fff/8S4Mv0tQBeDue6fD55fXtyef7ry7/Z5dPR5Xx0Pb35/D65Ph0FmLnWejm4zpPr5expngS4shTAxFzterEdy3k5CNCmcmGt41ICLLQ6Tr1ui2ZaPDBVq8U0BSimSi22Vk6laasAK1VTrbZWpjZtq4z3Q1tv31uqDmkCRE1UUvE+B9CoytAVVbHXYgGEVEWjbr1EN20FN93m7fAslWCMCZaaNBm6LdN+H8aGY2eTaMRKjEhUlbSeKVhmZLBMNubh2/2JhpTyuHt4dC0jA2bLNeYAVIM1hm9sZHCLgXL4MXjFwvR/MBgGjV0bg/YIPUe63e22Dyx9rCQCdm3s34dH7ixsXKHn7w4j/7jDYHGwsGfptR2RsSejZpfhQw8Gy+6+3tmym9v79N6j74ce+xvstf8BdDvQfQSOmBsAAAAASUVORK5CYII="></image>
   <g transform="translate(0,28)" fill="none" text-anchor="middle" font-variant="tabular-nums">
     <g class="tick" opacity="1" transform="translate(0.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line>

--- a/test/output/opacityLegendLinear.svg
+++ b/test/output/opacityLegendLinear.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,11 +8,11 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>
-  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAWUlEQVQ4jd2SSwoAIAhEx+5/6DZCg/gZqFWBoCZPRzScZwCW+8tjozjmO6tqJxbnlX4K57Y2m3n6Z44h36eqMXK4X2SrO+rmV7hZbeVPepR7UrX9pOWllewNAjMBAXvLNnYAAAAASUVORK5CYII="></image>
+  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAZ0lEQVQ4jaVS2wpAIQjT/v+jewmSMefOKRA0bJc0456MiHXydeosNd6r6HoVVtWAGFH6mDaH3+llPEwzyx1P3VvnP3E+DNsNpR9xlQfUxfLJj5rv1z2bvCiMyUunz+H4O5MXPGf3cwMB/wEBfsriPgAAAABJRU5ErkJggg=="></image>
   <g transform="translate(0,28)" fill="none" text-anchor="middle" font-variant="tabular-nums">
     <g class="tick" opacity="1" transform="translate(0.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line>

--- a/test/output/opacityLegendLog.svg
+++ b/test/output/opacityLegendLog.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,11 +8,11 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>
-  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAWUlEQVQ4jd2SSwoAIAhEx+5/6DZCg/gZqFWBoCZPRzScZwCW+8tjozjmO6tqJxbnlX4K57Y2m3n6Z44h36eqMXK4X2SrO+rmV7hZbeVPepR7UrX9pOWllewNAjMBAXvLNnYAAAAASUVORK5CYII="></image>
+  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAZ0lEQVQ4jaVS2wpAIQjT/v+jewmSMefOKRA0bJc0456MiHXydeosNd6r6HoVVtWAGFH6mDaH3+llPEwzyx1P3VvnP3E+DNsNpR9xlQfUxfLJj5rv1z2bvCiMyUunz+H4O5MXPGf3cwMB/wEBfsriPgAAAABJRU5ErkJggg=="></image>
   <g transform="translate(0,28)" fill="none" text-anchor="middle" font-variant="tabular-nums">
     <g class="tick" opacity="1" transform="translate(0.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line>

--- a/test/output/opacityLegendRange.svg
+++ b/test/output/opacityLegendRange.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,11 +8,11 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>
-  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAOElEQVQ4jWNkYGCoZ4AARihmwMNHFyeVJtZcUsVJtZ9Sf1CLJuQOdHlcfELmjMYLee4ZaHfQ3N0AAL4BATXN4EIAAAAASUVORK5CYII="></image>
+  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAQElEQVQ4jWNkYGCoZ4AARihmwMNHFydWnlRzSRUnlibVH+TaQ6p7SA0vaoUHreKFVHdRyx+0jpfB4j5y0xMGDQAAngEBTE2LzQAAAABJRU5ErkJggg=="></image>
   <g transform="translate(0,28)" fill="none" text-anchor="middle" font-variant="tabular-nums">
     <g class="tick" opacity="1" transform="translate(0.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line>

--- a/test/output/opacityLegendSqrt.svg
+++ b/test/output/opacityLegendSqrt.svg
@@ -1,6 +1,6 @@
 <svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot-ramp {
+    :where(.plot-ramp) {
       display: block;
       height: auto;
       height: intrinsic;
@@ -8,11 +8,11 @@
       overflow: visible;
     }
 
-    .plot-ramp text {
+    :where(.plot-ramp text) {
       white-space: pre;
     }
   </style>
-  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAWUlEQVQ4jd2SSwoAIAhEx+5/6DZCg/gZqFWBoCZPRzScZwCW+8tjozjmO6tqJxbnlX4K57Y2m3n6Z44h36eqMXK4X2SrO+rmV7hZbeVPepR7UrX9pOWllewNAjMBAXvLNnYAAAAASUVORK5CYII="></image>
+  <image x="0" y="18" width="240" height="10" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAABCAYAAAAxWXB3AAAABmJLR0QA/wD/AP+gvaeTAAAAZ0lEQVQ4jaVS2wpAIQjT/v+jewmSMefOKRA0bJc0456MiHXydeosNd6r6HoVVtWAGFH6mDaH3+llPEwzyx1P3VvnP3E+DNsNpR9xlQfUxfLJj5rv1z2bvCiMyUunz+H4O5MXPGf3cwMB/wEBfsriPgAAAABJRU5ErkJggg=="></image>
   <g transform="translate(0,28)" fill="none" text-anchor="middle" font-variant="tabular-nums">
     <g class="tick" opacity="1" transform="translate(0.5,0)">
       <line stroke="currentColor" y2="6" y1="-10"></line>

--- a/test/output/ordinalBar.svg
+++ b/test/output/ordinalBar.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="200" viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/pairsArea.svg
+++ b/test/output/pairsArea.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="140" viewBox="0 0 640 140" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinAnnotated.svg
+++ b/test/output/penguinAnnotated.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinCulmen.svg
+++ b/test/output/penguinCulmen.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="600" viewBox="0 0 640 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinCulmenArray.svg
+++ b/test/output/penguinCulmenArray.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="600" viewBox="0 0 640 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinCulmenDelaunay.svg
+++ b/test/output/penguinCulmenDelaunay.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinCulmenDelaunayMesh.svg
+++ b/test/output/penguinCulmenDelaunayMesh.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinCulmenDelaunaySpecies.svg
+++ b/test/output/penguinCulmenDelaunaySpecies.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinCulmenMarkFacet.svg
+++ b/test/output/penguinCulmenMarkFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="600" viewBox="0 0 640 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinCulmenVoronoi.svg
+++ b/test/output/penguinCulmenVoronoi.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinDensity.svg
+++ b/test/output/penguinDensity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinDensityFill.html
+++ b/test/output/penguinDensityFill.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -34,7 +34,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">Density</text>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="360" viewBox="0 0 960 360" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -42,8 +42,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinDensityZ.html
+++ b/test/output/penguinDensityZ.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>Gentoo</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="360" viewBox="0 0 960 360" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinDodge.svg
+++ b/test/output/penguinDodge.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="200" viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinDodgeHexbin.svg
+++ b/test/output/penguinDodgeHexbin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinDodgeVoronoi.svg
+++ b/test/output/penguinDodgeVoronoi.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="200" viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinFacetAnnotated.svg
+++ b/test/output/penguinFacetAnnotated.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="240" viewBox="0 0 640 240" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinFacetAnnotatedX.svg
+++ b/test/output/penguinFacetAnnotatedX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="150" viewBox="0 0 640 150" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinFacetDodge.svg
+++ b/test/output/penguinFacetDodge.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinFacetDodgeIdentity.svg
+++ b/test/output/penguinFacetDodgeIdentity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinFacetDodgeIsland.html
+++ b/test/output/penguinFacetDodgeIsland.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>Torgersen</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinFacetDodgeSymbol.html
+++ b/test/output/penguinFacetDodgeSymbol.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>Gentoo</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinHexbinColorExplicit.svg
+++ b/test/output/penguinHexbinColorExplicit.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinIslandUnknown.svg
+++ b/test/output/penguinIslandUnknown.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinMass.svg
+++ b/test/output/penguinMass.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinMassSex.svg
+++ b/test/output/penguinMassSex.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="480" viewBox="0 0 640 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinMassSexSpecies.svg
+++ b/test/output/penguinMassSexSpecies.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="510" viewBox="0 0 640 510" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinMassSpecies.svg
+++ b/test/output/penguinMassSpecies.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinNA1.svg
+++ b/test/output/penguinNA1.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinNA2.svg
+++ b/test/output/penguinNA2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinNA3.svg
+++ b/test/output/penguinNA3.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinQuantileEmpty.svg
+++ b/test/output/penguinQuantileEmpty.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinQuantileUnknown.html
+++ b/test/output/penguinQuantileUnknown.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -40,7 +40,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">body_mass_g</text>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -48,8 +48,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinSex.svg
+++ b/test/output/penguinSex.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinSexMassCulmenSpecies.svg
+++ b/test/output/penguinSexMassCulmenSpecies.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="320" viewBox="0 0 640 320" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinSizeSymbols.html
+++ b/test/output/penguinSizeSymbols.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>Gentoo</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinSpeciesCheysson.html
+++ b/test/output/penguinSpeciesCheysson.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -33,7 +33,7 @@
       </svg>Gentoo</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/penguinSpeciesGradient.svg
+++ b/test/output/penguinSpeciesGradient.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinSpeciesGroup.svg
+++ b/test/output/penguinSpeciesGroup.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinSpeciesImageFilter.svg
+++ b/test/output/penguinSpeciesImageFilter.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinSpeciesIsland.svg
+++ b/test/output/penguinSpeciesIsland.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinSpeciesIslandRelative.svg
+++ b/test/output/penguinSpeciesIslandRelative.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="430" viewBox="0 0 640 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinSpeciesIslandSex.svg
+++ b/test/output/penguinSpeciesIslandSex.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="430" viewBox="0 0 640 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/penguinVoronoi1D.svg
+++ b/test/output/penguinVoronoi1D.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/pointerLinkedRectInterval.svg
+++ b/test/output/pointerLinkedRectInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/pointerNonFaceted.svg
+++ b/test/output/pointerNonFaceted.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/pointerRenderCompose.svg
+++ b/test/output/pointerRenderCompose.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/pointerViewof.html
+++ b/test/output/pointerViewof.html
@@ -1,6 +1,6 @@
 <figure><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -8,8 +8,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/polylinear.svg
+++ b/test/output/polylinear.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/populationByLatitude.svg
+++ b/test/output/populationByLatitude.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="321" viewBox="0 0 640 321" style="overflow: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/populationByLongitude.svg
+++ b/test/output/populationByLongitude.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="321" viewBox="0 0 640 321" style="overflow: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionBleedEdges.svg
+++ b/test/output/projectionBleedEdges.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionBleedEdges2.svg
+++ b/test/output/projectionBleedEdges2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionClipAngle.svg
+++ b/test/output/projectionClipAngle.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionClipAngleFrame.svg
+++ b/test/output/projectionClipAngleFrame.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionClipBerghaus.svg
+++ b/test/output/projectionClipBerghaus.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionFitAntarctica.svg
+++ b/test/output/projectionFitAntarctica.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="600" viewBox="0 0 600 600" style="overflow: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionFitBertin1953.svg
+++ b/test/output/projectionFitBertin1953.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="302" viewBox="0 0 960 302" style="border: 1px solid blue;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionFitConic.svg
+++ b/test/output/projectionFitConic.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionFitIdentity.svg
+++ b/test/output/projectionFitIdentity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionFitUsAlbers.svg
+++ b/test/output/projectionFitUsAlbers.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionHeightAlbers.svg
+++ b/test/output/projectionHeightAlbers.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="401" viewBox="0 0 640 401" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionHeightEqualEarth.svg
+++ b/test/output/projectionHeightEqualEarth.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="169" viewBox="0 0 640 169" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionHeightGeometry.svg
+++ b/test/output/projectionHeightGeometry.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="817" viewBox="0 0 640 817" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionHeightGeometryNull.svg
+++ b/test/output/projectionHeightGeometryNull.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="400" height="725.5555555555555" viewBox="0 0 400 725.5555555555555" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionHeightMercator.svg
+++ b/test/output/projectionHeightMercator.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="1298" viewBox="0 0 640 1298" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionHeightOrthographic.svg
+++ b/test/output/projectionHeightOrthographic.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="630" viewBox="0 0 640 630" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/projectionNull.svg
+++ b/test/output/projectionNull.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/randomBins.svg
+++ b/test/output/randomBins.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/randomBinsXY.svg
+++ b/test/output/randomBinsXY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/randomQuantile.svg
+++ b/test/output/randomQuantile.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/randomWalk.svg
+++ b/test/output/randomWalk.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/randomWalkCustomMap1.svg
+++ b/test/output/randomWalkCustomMap1.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/randomWalkCustomMap2.svg
+++ b/test/output/randomWalkCustomMap2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/randomWalkCustomMap3.svg
+++ b/test/output/randomWalkCustomMap3.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterCa55Barycentric.svg
+++ b/test/output/rasterCa55Barycentric.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="484" viewBox="0 0 640 484" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterCa55Color.svg
+++ b/test/output/rasterCa55Color.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="484" viewBox="0 0 640 484" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterCa55Nearest.svg
+++ b/test/output/rasterCa55Nearest.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="484" viewBox="0 0 640 484" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterCa55None.svg
+++ b/test/output/rasterCa55None.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="484" viewBox="0 0 640 484" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterCa55RandomWalk.svg
+++ b/test/output/rasterCa55RandomWalk.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="484" viewBox="0 0 640 484" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterFacet.svg
+++ b/test/output/rasterFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="334.7368421052631" viewBox="0 0 640 334.7368421052631" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterPenguinsBarycentric.svg
+++ b/test/output/rasterPenguinsBarycentric.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterPenguinsBlur.svg
+++ b/test/output/rasterPenguinsBlur.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterPenguinsRandomWalk.svg
+++ b/test/output/rasterPenguinsRandomWalk.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterPrecision.svg
+++ b/test/output/rasterPrecision.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterVapor.svg
+++ b/test/output/rasterVapor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterVapor2.html
+++ b/test/output/rasterVapor2.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -33,7 +33,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -41,8 +41,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/rasterVaporEqualEarth.svg
+++ b/test/output/rasterVaporEqualEarth.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="312" viewBox="0 0 640 312" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterVaporEqualEarthBarycentric.svg
+++ b/test/output/rasterVaporEqualEarthBarycentric.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="312" viewBox="0 0 640 312" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterVaporPeters.svg
+++ b/test/output/rasterVaporPeters.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="815" height="520" viewBox="0 0 815 520" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterWalmartBarycentric.svg
+++ b/test/output/rasterWalmartBarycentric.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="401" viewBox="0 0 640 401" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterWalmartBarycentricOpacity.svg
+++ b/test/output/rasterWalmartBarycentricOpacity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="401" viewBox="0 0 640 401" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterWalmartRandomWalk.svg
+++ b/test/output/rasterWalmartRandomWalk.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="401" viewBox="0 0 640 401" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rasterWalmartWalkOpacity.svg
+++ b/test/output/rasterWalmartWalkOpacity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="401" viewBox="0 0 640 401" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rectBand.svg
+++ b/test/output/rectBand.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="120" viewBox="0 0 640 120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rectBandX.svg
+++ b/test/output/rectBandX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rectBandX1.svg
+++ b/test/output/rectBandX1.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rectBandY.svg
+++ b/test/output/rectBandY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/rectPointX1.svg
+++ b/test/output/rectPointX1.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/reducerScaleOverrideFunction.svg
+++ b/test/output/reducerScaleOverrideFunction.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="480" viewBox="0 0 640 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/reducerScaleOverrideImplementation.svg
+++ b/test/output/reducerScaleOverrideImplementation.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="480" viewBox="0 0 640 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/reducerScaleOverrideName.svg
+++ b/test/output/reducerScaleOverrideName.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="480" viewBox="0 0 640 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/seattlePrecipitationDensity.svg
+++ b/test/output/seattlePrecipitationDensity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/seattlePrecipitationRule.svg
+++ b/test/output/seattlePrecipitationRule.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/seattlePrecipitationSum.svg
+++ b/test/output/seattlePrecipitationSum.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/seattleTemperatureAmplitude.html
+++ b/test/output/seattleTemperatureAmplitude.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -41,7 +41,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="441.5" viewBox="0 0 640 441.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/seattleTemperatureBand.svg
+++ b/test/output/seattleTemperatureBand.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/seattleTemperatureCell.svg
+++ b/test/output/seattleTemperatureCell.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/sfCovidDeaths.svg
+++ b/test/output/sfCovidDeaths.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/sfTemperatureBand.svg
+++ b/test/output/sfTemperatureBand.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="400" viewBox="0 0 960 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/sfTemperatureBandArea.svg
+++ b/test/output/sfTemperatureBandArea.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="400" viewBox="0 0 960 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/sfTemperatureWindow.svg
+++ b/test/output/sfTemperatureWindow.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shiftX.svg
+++ b/test/output/shiftX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandArea.svg
+++ b/test/output/shorthandArea.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandAreaY.svg
+++ b/test/output/shorthandAreaY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandBarY.svg
+++ b/test/output/shorthandBarY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandBinRectY.svg
+++ b/test/output/shorthandBinRectY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandBoxX.svg
+++ b/test/output/shorthandBoxX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandCell.svg
+++ b/test/output/shorthandCell.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="200" viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandCellCategorical.svg
+++ b/test/output/shorthandCellCategorical.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandCellX.svg
+++ b/test/output/shorthandCellX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandDot.svg
+++ b/test/output/shorthandDot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandDotX.svg
+++ b/test/output/shorthandDotX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandGroupBarY.svg
+++ b/test/output/shorthandGroupBarY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandLine.svg
+++ b/test/output/shorthandLine.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandLineY.svg
+++ b/test/output/shorthandLineY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandLineYWindow.svg
+++ b/test/output/shorthandLineYWindow.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandRectY.svg
+++ b/test/output/shorthandRectY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandRuleX.svg
+++ b/test/output/shorthandRuleX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandText.svg
+++ b/test/output/shorthandText.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandTextX.svg
+++ b/test/output/shorthandTextX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandTickX.svg
+++ b/test/output/shorthandTickX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandVector.svg
+++ b/test/output/shorthandVector.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/shorthandVectorX.svg
+++ b/test/output/shorthandVectorX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/simpsonsRatings.svg
+++ b/test/output/simpsonsRatings.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/simpsonsRatingsDots.svg
+++ b/test/output/simpsonsRatingsDots.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/simpsonsViews.html
+++ b/test/output/simpsonsViews.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -45,7 +45,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">season</text>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -53,8 +53,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/singleValueBar.svg
+++ b/test/output/singleValueBar.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/singleValueBin.svg
+++ b/test/output/singleValueBin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/softwareVersions.svg
+++ b/test/output/softwareVersions.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/sparseCell.svg
+++ b/test/output/sparseCell.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/sparseTitle.svg
+++ b/test/output/sparseTitle.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/sparseTitleTip.svg
+++ b/test/output/sparseTitleTip.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/stackedBar.svg
+++ b/test/output/stackedBar.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/stackedRect.svg
+++ b/test/output/stackedRect.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/stargazers.svg
+++ b/test/output/stargazers.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/stargazersBinned.svg
+++ b/test/output/stargazersBinned.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/stargazersHourly.svg
+++ b/test/output/stargazersHourly.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/stargazersHourlyGroup.svg
+++ b/test/output/stargazersHourlyGroup.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/stocksIndex.svg
+++ b/test/output/stocksIndex.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" style="overflow: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/styleOverrideLegendCategorical.html
+++ b/test/output/styleOverrideLegendCategorical.html
@@ -1,0 +1,103 @@
+<div class="test-wrapper">
+  <style>
+    .style-override-swatches {
+      font-family: cursive;
+      font-size: 25px;
+      margin-bottom: 1em;
+    }
+  </style>
+  <div class="plot-swatches plot-swatches-wrap">
+    <style>
+      :where(.plot-swatches) {
+        font-family: system-ui, sans-serif;
+        font-size: 10px;
+        margin-bottom: 0.5em;
+      }
+
+      :where(.plot-swatch > svg) {
+        margin-right: 0.5em;
+        overflow: visible;
+      }
+
+      :where(.plot-swatches-wrap) {
+        display: flex;
+        align-items: center;
+        min-height: 33px;
+        flex-wrap: wrap;
+      }
+
+      :where(.plot-swatches-wrap .plot-swatch) {
+        display: inline-flex;
+        align-items: center;
+        margin-right: 1em;
+      }
+    </style><span class="plot-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>A</span><span class="plot-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>B</span><span class="plot-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>C</span><span class="plot-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>D</span><span class="plot-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>E</span><span class="plot-swatch"><svg width="15" height="15" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>F</span><span class="plot-swatch"><svg width="15" height="15" fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>G</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>H</span><span class="plot-swatch"><svg width="15" height="15" fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>I</span><span class="plot-swatch"><svg width="15" height="15" fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>J</span>
+  </div>
+  <div class="style-override-swatches style-override-swatches-wrap">
+    <style>
+      :where(.style-override-swatches) {
+        font-family: system-ui, sans-serif;
+        font-size: 10px;
+        margin-bottom: 0.5em;
+      }
+
+      :where(.style-override-swatch > svg) {
+        margin-right: 0.5em;
+        overflow: visible;
+      }
+
+      :where(.style-override-swatches-wrap) {
+        display: flex;
+        align-items: center;
+        min-height: 33px;
+        flex-wrap: wrap;
+      }
+
+      :where(.style-override-swatches-wrap .style-override-swatch) {
+        display: inline-flex;
+        align-items: center;
+        margin-right: 1em;
+      }
+    </style><span class="style-override-swatch"><svg width="15" height="15" fill="#4e79a7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>A</span><span class="style-override-swatch"><svg width="15" height="15" fill="#f28e2c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>B</span><span class="style-override-swatch"><svg width="15" height="15" fill="#e15759" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>C</span><span class="style-override-swatch"><svg width="15" height="15" fill="#76b7b2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>D</span><span class="style-override-swatch"><svg width="15" height="15" fill="#59a14f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>E</span><span class="style-override-swatch"><svg width="15" height="15" fill="#edc949" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>F</span><span class="style-override-swatch"><svg width="15" height="15" fill="#af7aa1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>G</span><span class="style-override-swatch"><svg width="15" height="15" fill="#ff9da7" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>H</span><span class="style-override-swatch"><svg width="15" height="15" fill="#9c755f" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>I</span><span class="style-override-swatch"><svg width="15" height="15" fill="#bab0ab" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%"></rect>
+      </svg>J</span>
+  </div>
+</div>

--- a/test/output/symbolLegendBasic.html
+++ b/test/output/symbolLegendBasic.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendColorFill.html
+++ b/test/output/symbolLegendColorFill.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendColorStroke.html
+++ b/test/output/symbolLegendColorStroke.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendDifferentColor.html
+++ b/test/output/symbolLegendDifferentColor.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendExplicitColor.html
+++ b/test/output/symbolLegendExplicitColor.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendFill.html
+++ b/test/output/symbolLegendFill.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendImplicitRange.html
+++ b/test/output/symbolLegendImplicitRange.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendOpacityColor.html
+++ b/test/output/symbolLegendOpacityColor.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendOpacityFill.html
+++ b/test/output/symbolLegendOpacityFill.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendOpacityStroke.html
+++ b/test/output/symbolLegendOpacityStroke.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolLegendStroke.html
+++ b/test/output/symbolLegendStroke.html
@@ -1,24 +1,24 @@
 <div class="plot-swatches plot-swatches-wrap">
   <style>
-    .plot-swatches {
+    :where(.plot-swatches) {
       font-family: system-ui, sans-serif;
       font-size: 10px;
       margin-bottom: 0.5em;
     }
 
-    .plot-swatch>svg {
+    :where(.plot-swatch > svg) {
       margin-right: 0.5em;
       overflow: visible;
     }
 
-    .plot-swatches-wrap {
+    :where(.plot-swatches-wrap) {
       display: flex;
       align-items: center;
       min-height: 33px;
       flex-wrap: wrap;
     }
 
-    .plot-swatches-wrap .plot-swatch {
+    :where(.plot-swatches-wrap .plot-swatch) {
       display: inline-flex;
       align-items: center;
       margin-right: 1em;

--- a/test/output/symbolSetFill.svg
+++ b/test/output/symbolSetFill.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/symbolSetFillColor.html
+++ b/test/output/symbolSetFillColor.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -41,7 +41,7 @@
       </svg>6</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/symbolSetStroke.svg
+++ b/test/output/symbolSetStroke.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/symbolSetStrokeColor.html
+++ b/test/output/symbolSetStrokeColor.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -41,7 +41,7 @@
       </svg>6</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/textOverflow.svg
+++ b/test/output/textOverflow.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="800" height="830" viewBox="0 0 800 830" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/textOverflowClip.svg
+++ b/test/output/textOverflowClip.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="500" height="730" viewBox="0 0 500 730" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/textOverflowEllipsis.svg
+++ b/test/output/textOverflowEllipsis.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="500" height="730" viewBox="0 0 500 730" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/textOverflowMonospace.svg
+++ b/test/output/textOverflowMonospace.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="500" height="730" viewBox="0 0 500 730" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/textOverflowNone.svg
+++ b/test/output/textOverflowNone.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="500" height="1100" viewBox="0 0 500 1100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/thisIsJustToSay.svg
+++ b/test/output/thisIsJustToSay.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="200" viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/timeAxisBottom.svg
+++ b/test/output/timeAxisBottom.svg
@@ -1,7 +1,7 @@
 <svg width="640" height="1500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g transform="translate(0,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -9,8 +9,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -56,7 +56,7 @@
     </svg></g>
   <g transform="translate(0,60)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -64,8 +64,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -111,7 +111,7 @@
     </svg></g>
   <g transform="translate(0,120)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -119,8 +119,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -166,7 +166,7 @@
     </svg></g>
   <g transform="translate(0,180)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -174,8 +174,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -227,7 +227,7 @@
     </svg></g>
   <g transform="translate(0,240)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -235,8 +235,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -276,7 +276,7 @@
     </svg></g>
   <g transform="translate(0,300)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -284,8 +284,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -325,7 +325,7 @@
     </svg></g>
   <g transform="translate(0,360)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -333,8 +333,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -380,7 +380,7 @@
     </svg></g>
   <g transform="translate(0,420)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -388,8 +388,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -441,7 +441,7 @@
     </svg></g>
   <g transform="translate(0,480)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -449,8 +449,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -496,7 +496,7 @@
     </svg></g>
   <g transform="translate(0,540)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -504,8 +504,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -551,7 +551,7 @@
     </svg></g>
   <g transform="translate(0,600)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -559,8 +559,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -606,7 +606,7 @@
     </svg></g>
   <g transform="translate(0,660)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -614,8 +614,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -661,7 +661,7 @@
     </svg></g>
   <g transform="translate(0,720)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -669,8 +669,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -713,7 +713,7 @@
     </svg></g>
   <g transform="translate(0,780)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -721,8 +721,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -762,7 +762,7 @@
     </svg></g>
   <g transform="translate(0,840)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -770,8 +770,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -811,7 +811,7 @@
     </svg></g>
   <g transform="translate(0,900)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -819,8 +819,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -854,7 +854,7 @@
     </svg></g>
   <g transform="translate(0,960)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -862,8 +862,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -909,7 +909,7 @@
     </svg></g>
   <g transform="translate(0,1020)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -917,8 +917,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -967,7 +967,7 @@
     </svg></g>
   <g transform="translate(0,1080)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -975,8 +975,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1031,7 +1031,7 @@
     </svg></g>
   <g transform="translate(0,1140)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1039,8 +1039,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1092,7 +1092,7 @@
     </svg></g>
   <g transform="translate(0,1200)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1100,8 +1100,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1153,7 +1153,7 @@
     </svg></g>
   <g transform="translate(0,1260)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1161,8 +1161,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1214,7 +1214,7 @@
     </svg></g>
   <g transform="translate(0,1320)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1222,8 +1222,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1275,7 +1275,7 @@
     </svg></g>
   <g transform="translate(0,1380)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1283,8 +1283,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1330,7 +1330,7 @@
     </svg></g>
   <g transform="translate(0,1440)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1338,8 +1338,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>

--- a/test/output/timeAxisExplicitInterval.svg
+++ b/test/output/timeAxisExplicitInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/timeAxisExplicitNonstandardInterval.svg
+++ b/test/output/timeAxisExplicitNonstandardInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/timeAxisExplicitNonstandardIntervalTicks.svg
+++ b/test/output/timeAxisExplicitNonstandardIntervalTicks.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/timeAxisLeft.svg
+++ b/test/output/timeAxisLeft.svg
@@ -1,7 +1,7 @@
 <svg height="400" width="720" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g transform="translate(0,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -9,8 +9,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -56,7 +56,7 @@
     </svg></g>
   <g transform="translate(80,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -64,8 +64,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -117,7 +117,7 @@
     </svg></g>
   <g transform="translate(160,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -125,8 +125,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -172,7 +172,7 @@
     </svg></g>
   <g transform="translate(240,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -180,8 +180,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -227,7 +227,7 @@
     </svg></g>
   <g transform="translate(320,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -235,8 +235,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -279,7 +279,7 @@
     </svg></g>
   <g transform="translate(400,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -287,8 +287,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -340,7 +340,7 @@
     </svg></g>
   <g transform="translate(480,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -348,8 +348,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -404,7 +404,7 @@
     </svg></g>
   <g transform="translate(560,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -412,8 +412,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -465,7 +465,7 @@
     </svg></g>
   <g transform="translate(640,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -473,8 +473,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>

--- a/test/output/timeAxisLocal.svg
+++ b/test/output/timeAxisLocal.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/timeAxisOrdinal.svg
+++ b/test/output/timeAxisOrdinal.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/timeAxisOrdinalSparseInterval.svg
+++ b/test/output/timeAxisOrdinalSparseInterval.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/timeAxisOrdinalSparseTicks.svg
+++ b/test/output/timeAxisOrdinalSparseTicks.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/timeAxisOrdinalTicks.svg
+++ b/test/output/timeAxisOrdinalTicks.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/timeAxisRight.svg
+++ b/test/output/timeAxisRight.svg
@@ -1,7 +1,7 @@
 <svg height="400" width="720" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g transform="translate(0,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -9,8 +9,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -56,7 +56,7 @@
     </svg></g>
   <g transform="translate(80,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -64,8 +64,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -117,7 +117,7 @@
     </svg></g>
   <g transform="translate(160,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -125,8 +125,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -172,7 +172,7 @@
     </svg></g>
   <g transform="translate(240,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -180,8 +180,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -227,7 +227,7 @@
     </svg></g>
   <g transform="translate(320,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -235,8 +235,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -279,7 +279,7 @@
     </svg></g>
   <g transform="translate(400,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -287,8 +287,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -340,7 +340,7 @@
     </svg></g>
   <g transform="translate(480,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -348,8 +348,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -404,7 +404,7 @@
     </svg></g>
   <g transform="translate(560,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -412,8 +412,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -465,7 +465,7 @@
     </svg></g>
   <g transform="translate(640,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="80" height="400" viewBox="0 0 80 400">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -473,8 +473,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>

--- a/test/output/timeAxisTop.svg
+++ b/test/output/timeAxisTop.svg
@@ -1,7 +1,7 @@
 <svg width="640" height="1500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g transform="translate(0,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -9,8 +9,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -56,7 +56,7 @@
     </svg></g>
   <g transform="translate(0,60)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -64,8 +64,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -111,7 +111,7 @@
     </svg></g>
   <g transform="translate(0,120)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -119,8 +119,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -166,7 +166,7 @@
     </svg></g>
   <g transform="translate(0,180)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -174,8 +174,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -227,7 +227,7 @@
     </svg></g>
   <g transform="translate(0,240)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -235,8 +235,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -276,7 +276,7 @@
     </svg></g>
   <g transform="translate(0,300)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -284,8 +284,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -325,7 +325,7 @@
     </svg></g>
   <g transform="translate(0,360)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -333,8 +333,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -380,7 +380,7 @@
     </svg></g>
   <g transform="translate(0,420)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -388,8 +388,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -441,7 +441,7 @@
     </svg></g>
   <g transform="translate(0,480)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -449,8 +449,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -496,7 +496,7 @@
     </svg></g>
   <g transform="translate(0,540)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -504,8 +504,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -551,7 +551,7 @@
     </svg></g>
   <g transform="translate(0,600)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -559,8 +559,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -606,7 +606,7 @@
     </svg></g>
   <g transform="translate(0,660)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -614,8 +614,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -661,7 +661,7 @@
     </svg></g>
   <g transform="translate(0,720)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -669,8 +669,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -713,7 +713,7 @@
     </svg></g>
   <g transform="translate(0,780)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -721,8 +721,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -762,7 +762,7 @@
     </svg></g>
   <g transform="translate(0,840)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -770,8 +770,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -811,7 +811,7 @@
     </svg></g>
   <g transform="translate(0,900)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -819,8 +819,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -854,7 +854,7 @@
     </svg></g>
   <g transform="translate(0,960)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -862,8 +862,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -909,7 +909,7 @@
     </svg></g>
   <g transform="translate(0,1020)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -917,8 +917,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -967,7 +967,7 @@
     </svg></g>
   <g transform="translate(0,1080)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -975,8 +975,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1031,7 +1031,7 @@
     </svg></g>
   <g transform="translate(0,1140)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1039,8 +1039,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1092,7 +1092,7 @@
     </svg></g>
   <g transform="translate(0,1200)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1100,8 +1100,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1153,7 +1153,7 @@
     </svg></g>
   <g transform="translate(0,1260)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1161,8 +1161,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1214,7 +1214,7 @@
     </svg></g>
   <g transform="translate(0,1320)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1222,8 +1222,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1275,7 +1275,7 @@
     </svg></g>
   <g transform="translate(0,1380)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1283,8 +1283,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>
@@ -1330,7 +1330,7 @@
     </svg></g>
   <g transform="translate(0,1440)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60">
       <style>
-        .plot {
+        :where(.plot) {
           --plot-background: white;
           display: block;
           height: auto;
@@ -1338,8 +1338,8 @@
           max-width: 100%;
         }
 
-        .plot text,
-        .plot tspan {
+        :where(.plot text),
+        :where(.plot tspan) {
           white-space: pre;
         }
       </style>

--- a/test/output/tipAreaBand.svg
+++ b/test/output/tipAreaBand.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipAreaStack.svg
+++ b/test/output/tipAreaStack.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipBar.svg
+++ b/test/output/tipBar.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="620" viewBox="0 0 640 620" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipBin.svg
+++ b/test/output/tipBin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipBinStack.svg
+++ b/test/output/tipBinStack.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipCell.svg
+++ b/test/output/tipCell.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipCellFacet.svg
+++ b/test/output/tipCellFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipDodge.svg
+++ b/test/output/tipDodge.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="160" viewBox="0 0 640 160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipDot.svg
+++ b/test/output/tipDot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipDotFacets.svg
+++ b/test/output/tipDotFacets.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="930" viewBox="0 0 640 930" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipDotFilter.svg
+++ b/test/output/tipDotFilter.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipDotX.svg
+++ b/test/output/tipDotX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFacetX.svg
+++ b/test/output/tipFacetX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatChannels.svg
+++ b/test/output/tipFormatChannels.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatFacet.svg
+++ b/test/output/tipFormatFacet.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatFacetFalse.svg
+++ b/test/output/tipFormatFacetFalse.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatFacetFormat.svg
+++ b/test/output/tipFormatFacetFormat.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatFacetFormatDefaultDay.svg
+++ b/test/output/tipFormatFacetFormatDefaultDay.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatFacetFormatDefaultHour.svg
+++ b/test/output/tipFormatFacetFormatDefaultHour.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatFacetFormatDefaultYear.svg
+++ b/test/output/tipFormatFacetFormatDefaultYear.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatFacetLabel.svg
+++ b/test/output/tipFormatFacetLabel.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="110" viewBox="0 0 640 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatFunction.svg
+++ b/test/output/tipFormatFunction.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatNull.svg
+++ b/test/output/tipFormatNull.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPaired.svg
+++ b/test/output/tipFormatPaired.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPairedFormat.svg
+++ b/test/output/tipFormatPairedFormat.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPairedLabel.svg
+++ b/test/output/tipFormatPairedLabel.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPairedLabelChannel.svg
+++ b/test/output/tipFormatPairedLabelChannel.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPairedLabelScale.svg
+++ b/test/output/tipFormatPairedLabelScale.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPairedPartial.svg
+++ b/test/output/tipFormatPairedPartial.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPriority1.svg
+++ b/test/output/tipFormatPriority1.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPriority2.svg
+++ b/test/output/tipFormatPriority2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPriorityDefault.svg
+++ b/test/output/tipFormatPriorityDefault.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPriorityPaired.svg
+++ b/test/output/tipFormatPriorityPaired.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatPriorityPaired2.svg
+++ b/test/output/tipFormatPriorityPaired2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatStringDate.svg
+++ b/test/output/tipFormatStringDate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatStringNumber.svg
+++ b/test/output/tipFormatStringNumber.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatTitleExplicit.svg
+++ b/test/output/tipFormatTitleExplicit.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatTitleIgnoreFormat.svg
+++ b/test/output/tipFormatTitleIgnoreFormat.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipFormatTitlePrimitive.svg
+++ b/test/output/tipFormatTitlePrimitive.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipGeoCentroid.svg
+++ b/test/output/tipGeoCentroid.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipGeoNoProjection.svg
+++ b/test/output/tipGeoNoProjection.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipGeoProjection.svg
+++ b/test/output/tipGeoProjection.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="401" viewBox="0 0 640 401" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipGroupPrimitives.svg
+++ b/test/output/tipGroupPrimitives.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="80" viewBox="0 0 640 80" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipHexbin.svg
+++ b/test/output/tipHexbin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipHexbinExplicit.svg
+++ b/test/output/tipHexbinExplicit.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipLineX.svg
+++ b/test/output/tipLineX.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipLineY.svg
+++ b/test/output/tipLineY.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipLongText.svg
+++ b/test/output/tipLongText.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipNewLines.svg
+++ b/test/output/tipNewLines.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="40" viewBox="0 0 640 40" style="overflow: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipRaster.svg
+++ b/test/output/tipRaster.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="484" viewBox="0 0 640 484" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipRule.svg
+++ b/test/output/tipRule.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipRuleAnchored.svg
+++ b/test/output/tipRuleAnchored.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/tipTransform.html
+++ b/test/output/tipTransform.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -41,7 +41,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="245" height="60" viewBox="0 0 245 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -49,8 +49,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/title.html
+++ b/test/output/title.html
@@ -3,25 +3,25 @@
   <h3>A subtitle about body_mass_g</h3>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -35,7 +35,7 @@
       </svg>Gentoo</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -43,8 +43,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/titleHtml.html
+++ b/test/output/titleHtml.html
@@ -2,7 +2,7 @@
   <h2>A <i>fancy</i> title about penguins</h2>
   <em>A <tt>fancy</tt> subtitle</em><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -10,8 +10,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/trafficHorizon.html
+++ b/test/output/trafficHorizon.html
@@ -1,25 +1,25 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -37,7 +37,7 @@
       </svg>≥8,000</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="1100" viewBox="0 0 960 1100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -45,8 +45,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/travelersCovidDrop.svg
+++ b/test/output/travelersCovidDrop.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="400" viewBox="0 0 960 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/travelersYearOverYear.svg
+++ b/test/output/travelersYearOverYear.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/treeDelimiter.svg
+++ b/test/output/treeDelimiter.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="150" viewBox="0 0 640 150" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/treeDelimiter2.svg
+++ b/test/output/treeDelimiter2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="150" viewBox="0 0 640 150" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/uniformRandomDifference.svg
+++ b/test/output/uniformRandomDifference.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/untypedDateBin.svg
+++ b/test/output/untypedDateBin.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usCongressAge.svg
+++ b/test/output/usCongressAge.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usCongressAgeColorExplicit.svg
+++ b/test/output/usCongressAgeColorExplicit.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usCongressAgeGender.svg
+++ b/test/output/usCongressAgeGender.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usCongressAgeSymbolExplicit.svg
+++ b/test/output/usCongressAgeSymbolExplicit.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usCountyChoropleth.html
+++ b/test/output/usCountyChoropleth.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -60,7 +60,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">Unemployment (%)</text>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -68,8 +68,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/usCountySpikes.svg
+++ b/test/output/usCountySpikes.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usPopulationStateAge.svg
+++ b/test/output/usPopulationStateAge.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="240" viewBox="0 0 640 240" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usPopulationStateAgeDots.svg
+++ b/test/output/usPopulationStateAgeDots.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="660" viewBox="0 0 640 660" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usPopulationStateAgeGrouped.svg
+++ b/test/output/usPopulationStateAgeGrouped.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="430" viewBox="0 0 640 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usPresidentFavorabilityDots.svg
+++ b/test/output/usPresidentFavorabilityDots.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usPresidentGallery.svg
+++ b/test/output/usPresidentGallery.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="300" viewBox="0 0 960 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usPresidentGalleryAlt.svg
+++ b/test/output/usPresidentGalleryAlt.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="300" viewBox="0 0 960 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usPresidentialElection2020.svg
+++ b/test/output/usPresidentialElection2020.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="640" viewBox="0 0 960 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usPresidentialElectionMap2020.svg
+++ b/test/output/usPresidentialElectionMap2020.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usPresidentialForecast2016.svg
+++ b/test/output/usPresidentialForecast2016.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usRetailSales.svg
+++ b/test/output/usRetailSales.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usStateCapitals.svg
+++ b/test/output/usStateCapitals.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usStateCapitalsVoronoi.svg
+++ b/test/output/usStateCapitalsVoronoi.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usStatePopulationChange.svg
+++ b/test/output/usStatePopulationChange.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="800" viewBox="0 0 640 800" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/usStatePopulationChangeRelative.svg
+++ b/test/output/usStatePopulationChangeRelative.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="800" viewBox="0 0 640 800" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/varColor.svg
+++ b/test/output/varColor.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" style="--a: 0.5; --b: rgba(255, 0, 0, var(--a));" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/varColor2.svg
+++ b/test/output/varColor2.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" style="--a: 0.5;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/varColorP3.svg
+++ b/test/output/varColorP3.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/vectorField.svg
+++ b/test/output/vectorField.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="600" viewBox="0 0 640 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/vectorFrame.svg
+++ b/test/output/vectorFrame.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/volcano.svg
+++ b/test/output/volcano.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/volcanoContour.svg
+++ b/test/output/volcanoContour.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/volcanoTerrain.svg
+++ b/test/output/volcanoTerrain.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/walmarts.html
+++ b/test/output/walmarts.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -34,7 +34,7 @@
     <text x="0" y="12" fill="currentColor" font-weight="bold">First year opened</text>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -42,8 +42,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/walmartsAdditions.svg
+++ b/test/output/walmartsAdditions.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="200" height="1132" viewBox="0 0 200 1132" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/walmartsDecades.svg
+++ b/test/output/walmartsDecades.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="150" viewBox="0 0 960 150" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/walmartsDensity.svg
+++ b/test/output/walmartsDensity.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/walmartsDensityUnprojected.svg
+++ b/test/output/walmartsDensityUnprojected.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="600" viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/warnMisalignedDivergingDomain.html
+++ b/test/output/warnMisalignedDivergingDomain.html
@@ -1,6 +1,6 @@
 <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot-ramp {
+      :where(.plot-ramp) {
         display: block;
         height: auto;
         height: intrinsic;
@@ -8,7 +8,7 @@
         overflow: visible;
       }
 
-      .plot-ramp text {
+      :where(.plot-ramp text) {
         white-space: pre;
       }
     </style>
@@ -37,7 +37,7 @@
     </g>
   </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -45,8 +45,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/output/warnTimeAxisOrdinalExplicitIncompatibleTicks.svg
+++ b/test/output/warnTimeAxisOrdinalExplicitIncompatibleTicks.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/warnTimeAxisOrdinalIncompatible.svg
+++ b/test/output/warnTimeAxisOrdinalIncompatible.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/wealthBritainBar.svg
+++ b/test/output/wealthBritainBar.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/wealthBritainProportionPlot.svg
+++ b/test/output/wealthBritainProportionPlot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/wordCloud.svg
+++ b/test/output/wordCloud.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/wordLengthMobyDick.svg
+++ b/test/output/wordLengthMobyDick.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/yearlyRequests.svg
+++ b/test/output/yearlyRequests.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/yearlyRequestsDate.svg
+++ b/test/output/yearlyRequestsDate.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/yearlyRequestsDot.svg
+++ b/test/output/yearlyRequestsDot.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/yearlyRequestsLine.svg
+++ b/test/output/yearlyRequestsLine.svg
@@ -1,6 +1,6 @@
 <svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <style>
-    .plot {
+    :where(.plot) {
       --plot-background: white;
       display: block;
       height: auto;
@@ -8,8 +8,8 @@
       max-width: 100%;
     }
 
-    .plot text,
-    .plot tspan {
+    :where(.plot text),
+    :where(.plot tspan) {
       white-space: pre;
     }
   </style>

--- a/test/output/youngAdults.html
+++ b/test/output/youngAdults.html
@@ -3,25 +3,25 @@
   <h3>…by age and sex. Data: Eurostat</h3>
   <div class="plot-swatches plot-swatches-wrap">
     <style>
-      .plot-swatches {
+      :where(.plot-swatches) {
         font-family: system-ui, sans-serif;
         font-size: 10px;
         margin-bottom: 0.5em;
       }
 
-      .plot-swatch>svg {
+      :where(.plot-swatch > svg) {
         margin-right: 0.5em;
         overflow: visible;
       }
 
-      .plot-swatches-wrap {
+      :where(.plot-swatches-wrap) {
         display: flex;
         align-items: center;
         min-height: 33px;
         flex-wrap: wrap;
       }
 
-      .plot-swatches-wrap .plot-swatch {
+      :where(.plot-swatches-wrap .plot-swatch) {
         display: inline-flex;
         align-items: center;
         margin-right: 1em;
@@ -35,7 +35,7 @@
       </svg>Y25-29</span>
   </div><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="928" height="430" viewBox="0 0 928 430" style="max-width: 4000px; overflow-y: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      .plot {
+      :where(.plot) {
         --plot-background: white;
         display: block;
         height: auto;
@@ -43,8 +43,8 @@
         max-width: 100%;
       }
 
-      .plot text,
-      .plot tspan {
+      :where(.plot text),
+      :where(.plot tspan) {
         white-space: pre;
       }
     </style>

--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -292,6 +292,7 @@ export * from "./stargazers-hourly-group.js";
 export * from "./stargazers-hourly.js";
 export * from "./stargazers.js";
 export * from "./stocks-index.js";
+export * from "./style-overrides.js";
 export * from "./symbol-set.js";
 export * from "./text-overflow.js";
 export * from "./this-is-just-to-say.js";

--- a/test/plots/style-overrides.ts
+++ b/test/plots/style-overrides.ts
@@ -1,0 +1,31 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export function styleOverrideLegendCategorical() {
+  const className = "style-override";
+  const wrapper = d3
+    .create("div")
+    .attr("class", "test-wrapper") // Required by ../plot.js
+    .html(
+      `
+      <style>
+        .${className}-swatches {
+          font-family: cursive;
+          font-size: 25px;
+          margin-bottom: 1em;
+        }
+      </style>
+      `
+    )
+    .node();
+
+  const options = {color: {domain: "ABCDEFGHIJ"}, label: "Hello"};
+
+  // Normal legend without style overrides
+  wrapper.append(Plot.legend(options));
+
+  // Styled legend with className override
+  wrapper.append(Plot.legend({...options, className}));
+
+  return wrapper;
+}


### PR DESCRIPTION
### What is this, and why is it necessary?

By reducing the specificity of selectors in the generated stylesheets to 0, consumers of Plot can much more easily override these styles using their own stylesheets while still enjoying the default styling of Plot.

Without this, consumers of Plot must resort to increasing the specificity of selectors or individual styles, which can be both awkward and hard to do.

### A breaking change, technically

While this change is meant to be safe, it is technically a breaking change. Any consumer of Plot that is trying to override css, but failing due to lower specificity, should start seeing those styles applied. While that may actually fix a few bugs out there, it could also cause some others, where those consumers have simply missed that those styles aren't being applied on top of the defaults.

### Why so many snapshot updates?

Because the change in selector specificity affects every chart, all snapshots will need regenerating. The rendered output should yield no differences however. If it does, that's a bug.

Alas – this many snapshot updates seem to make GitHubs UI practically worthless for reviewing the code however. My apologies, I don't have a good answer for how to fix that. I did however split the changes into two commits for this reason:

- CSS changes: ~[b2ff68e](https://github.com/observablehq/plot/pull/1930/commits/b2ff68eacf41fb7618509859a9510d8fd6fb4653)~ [755954e](https://github.com/observablehq/plot/pull/1930/commits/755954ee08b3a5f317d615b2d4015887f5c5515c) (Edit: updated SHA post rebase)
- Snapshot updates: ~[300c400](https://github.com/observablehq/plot/pull/1930/commits/300c40002c5ac8eb3ec74f092cff0945378c546d)~ [fbcfa1f](https://github.com/observablehq/plot/pull/1930/commits/fbcfa1f311f801fff025006c349544933437e9a1) (Edit: updated SHA post rebase)

I hope this helps.

### Related resources

- MDN Docs on `:where`: https://developer.mozilla.org/en-US/docs/Web/CSS/:where