### PR TITLE
Experiment: add support for distinguishing hover & click events

### DIFF
--- a/src/interactions/pointer.js
+++ b/src/interactions/pointer.js
@@ -126,7 +126,7 @@ function pointerK(kx, ky, {x, y, px, py, maxRadius = 40, channels, render, ...op
 
         // Dispatch the value. When simultaneously exiting this facet and
         // entering a new one, prioritize the entering facet.
-        if (!(i == null && facetState?.size > 1)) context.dispatchValue(i == null ? null : data[i]);
+        if (!(i == null && facetState?.size > 1)) context.dispatchValue(i == null ? null : data[i], s);
         return r;
       }
 

--- a/src/plot.js
+++ b/src/plot.js
@@ -172,10 +172,11 @@ export function plot(options = {}) {
   };
 
   // Allows e.g. the pointer transform to support viewof.
-  context.dispatchValue = (value) => {
-    if (figure.value === value) return;
+  context.dispatchValue = (value, detail) => {
+    if (figure.value === value && figure._detail === detail) return;
     figure.value = value;
-    figure.dispatchEvent(new Event("input", {bubbles: true}));
+    figure._detail = detail;
+    figure.dispatchEvent(new CustomEvent("input", {bubbles: true, detail}));
   };
 
   // Reinitialize; for deriving channels dependent on other channels.


### PR DESCRIPTION
This is a tiny experimental patch that addresses https://github.com/observablehq/plot/issues/1832 by sending Boolean "sticky" information via the event's `detail` option. 

Plot's behavior is otherwise unchanged. Since the sticky data is part of the event, a user can now create a generator cell that responds to the "substream" of click-relevant events. [Example](https://observablehq.com/@iopsystems/hover-and-click):

```js
click = Generators.observe((notify) => {
  let lastValue = null;
  const listener = (e) => {
    // If e.detail is true, then this was a click (sticky) event.
    // If e.detail is false, then (this feels untidy) deselect if the value is null.
    if (e.detail || (viewof hover.value === null && lastValue !== null)) {
      notify(viewof hover.value);
    }
  };
  viewof hover.addEventListener("input", listener);
  notify(lastValue);
  return () => viewof hover.removeEventListener("input", listener);
})
```

There might be unfavorable trade-offs to the idea of using the `detail` option for this, and the `null` handling is somewhat untidy (though maybe there's a better way?) so please feel free to close if it isn't a good idea. But I was surprised and pleased with the fact that this was a three-line change.

