### PR TITLE
lazily materialize the groups

### DIFF
--- a/src/transforms/group.js
+++ b/src/transforms/group.js
@@ -362,7 +362,8 @@ function reduceMaybeTemporalAccessor(f) {
 
 export const reduceIdentity = {
   reduceIndex(I, X) {
-    return take(X, I);
+    let K; // lazy
+    return new Proxy(I, {get: (I, prop) => (K ??= take(X, I))[prop]});
   }
 };
 


### PR DESCRIPTION
Makes lazy calls to `take` (which is expensive on arrow tables). The total # of calls to `take` in the tests goes from 34068 to 11778 (differenceY and differenceYVariable are the main consumers of this function). This should give better performance to the group transform on large datasets.


Related: #2030 