### PR TITLE
expose projection

### DIFF
--- a/src/plot.d.ts
+++ b/src/plot.d.ts
@@ -1,7 +1,13 @@
 import type {ChannelValue} from "./channel.js";
 import type {LegendOptions} from "./legends.js";
 import type {Data, MarkOptions, Markish} from "./mark.js";
-import type {ProjectionFactory, ProjectionImplementation, ProjectionName, ProjectionOptions} from "./projection.js";
+import type {
+  Projection,
+  ProjectionFactory,
+  ProjectionImplementation,
+  ProjectionName,
+  ProjectionOptions
+} from "./projection.js";
 import type {Scale, ScaleDefaults, ScaleName, ScaleOptions} from "./scales.js";
 
 export interface PlotOptions extends ScaleDefaults {
@@ -403,6 +409,12 @@ export interface Plot {
    * does not use the specified scale.
    */
   scale(name: ScaleName): Scale | undefined;
+
+  /**
+   * Returns this plot’s projection, or undefined if this plot does not use a
+   * projection.
+   */
+  projection(): Projection | undefined;
 
   /**
    * Generates a legend for the scale with the specified *name* and the given

--- a/src/plot.js
+++ b/src/plot.js
@@ -11,7 +11,7 @@ import {frame} from "./marks/frame.js";
 import {tip} from "./marks/tip.js";
 import {isColor, isIterable, isNone, isScaleOptions} from "./options.js";
 import {arrayify, map, yes, maybeIntervalTransform, subarray} from "./options.js";
-import {createProjection, getGeometryChannels, hasProjection} from "./projection.js";
+import {createProjection, exposeProjection, getGeometryChannels, hasProjection} from "./projection.js";
 import {createScales, createScaleFunctions, autoScaleRange, exposeScales} from "./scales.js";
 import {innerDimensions, outerDimensions} from "./scales.js";
 import {isPosition, registry as scaleRegistry} from "./scales/index.js";
@@ -334,6 +334,7 @@ export function plot(options = {}) {
     if (caption != null) figure.append(createFigcaption(document, caption));
   }
 
+  figure.projection = exposeProjection(context.projection);
   figure.scale = exposeScales(scales.scales);
   figure.legend = exposeLegends(scaleDescriptors, context, options);
 

--- a/src/projection.d.ts
+++ b/src/projection.d.ts
@@ -70,6 +70,12 @@ export interface ProjectionOptions extends InsetOptions {
   type?: ProjectionName | ProjectionFactory | null;
 
   /**
+   * The projection’s name. If you pass a projection function, you can mention
+   * its name which will be passed through to the exposed *plot*.projection().
+   */
+  name?: string;
+
+  /**
    * A GeoJSON object to fit to the plot’s frame (minus insets); defaults to a
    * Sphere for spherical projections (outline of the the whole globe).
    */
@@ -111,4 +117,21 @@ export interface ProjectionOptions extends InsetOptions {
    * [2]: https://observablehq.com/@d3/berghaus-star
    */
   clip?: boolean | number | "frame" | null;
+}
+
+/**
+ * A materialized projection, as returned by *plot*.projection()
+ */
+export interface Projection {
+  /** The projection’s name, if specified. */
+  name?: string;
+  /** A function that projects a point coordinates. */
+  point: (point: [number, number]) => [x: number, y: number] | undefined;
+  /** The projection’s stream. */
+  stream: GeoStreamWrapper["stream"];
+  rotate: ProjectionOptions["rotate"];
+  /** The projection’s reference scale. */
+  scale: number;
+  parallels: ProjectionOptions["parallels"];
+  precision: ProjectionOptions["precision"];
 }


### PR DESCRIPTION
This is more the direction in which I'd like to go: expose just enough to make it possible to reuse the projection in another chart (we're not there yet), and to support advanced brushing (https://github.com/uwdata/mosaic/pull/336).

(Not solved yet!)

We need:
- [ ] more concrete use cases (of reuse)
- [ ] tests
- [ ] enough information to recreate the same projection
- [ ] invert: currently lost in translation (^^), but we could do it by being more careful when we compose with the scale+translate transform. (The clip transform is traditionally ignored/considered as a pass-thru when inverting.)

This somewhat supersedes @jheer's suggestion in https://github.com/observablehq/plot/issues/1191#issuecomment-2011275448 

closes #1191