### PR TITLE
Patch analytics pageLoad event for now

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -19,8 +19,8 @@ export default {
 
 async function enableAnalytics(router) {
   if (typeof location === "undefined" || location.origin !== "https://observablehq.com") return;
-  const {pageLoad, routeChanged} = await import("https://events.observablehq.com/client.js");
-  let pageLoaded;
+  const {pageLoad, routeChanged} = await import("https://events.observablehq.com/client.js?pageLoad");
+  let pageLoaded = false;
   watch(router.route, () => {
     if (pageLoaded) {
       routeChanged();


### PR DESCRIPTION
This actually isn't correct either, but restores the previous behavior that it seems to rely on. The current code watches router.route, but after an async import which means it actually misses the first actual page load and doesn't fire anything. A subsequent navigation counts as the first pageLoad.

I'll have a better fix soon, but wanted to restore the previous behavior in the meantime.