### PR TITLE
Send our own pageLoad, routeChanged events

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -17,11 +17,11 @@ export default {
   }
 };
 
-async function enableAnalytics(router) {
+function enableAnalytics(router) {
   if (typeof location === "undefined" || location.origin !== "https://observablehq.com") return;
-  const {pageLoad, routeChanged} = await import("https://events.observablehq.com/client.js?pageLoad");
   let pageLoaded = false;
-  watch(router.route, () => {
+  watch(router.route, async () => {
+    const {pageLoad, routeChanged} = await import("https://events.observablehq.com/client.js");
     if (pageLoaded) {
       routeChanged();
     } else {


### PR DESCRIPTION
Follow up to #2043.

Synchronously watch for route changes and send pageLoad or routeChanged events. Doesn't rely on the automatic pageLoad event anymore from the analytics client.

Tested locally and verified pageLoad was being sent on initial load and routeChanged sent on client side navigation.