### PR TITLE
Fix Axis Tick Vector to Axis Tick Line

### DIFF
--- a/docs/marks/axis.md
+++ b/docs/marks/axis.md
@@ -64,7 +64,7 @@ If you don’t declare an axis mark for a position scale, Plot will implicitly a
 
 Plot’s axis mark is a composite mark comprised of:
 
-* a [vector](./vector.md) for ticks
+* a [tick](./tick.md) for ticks
 * a [text](./text.md) for tick labels
 * a [text](./text.md) for an axis label
 
@@ -193,7 +193,7 @@ Plot.plot({
 ```
 :::
 
-The color of an axis can be controlled with the **color**, **stroke**, and **fill** options, which affect the axis’ component marks differently. The **stroke** option affects the tick vector; the **fill** option affects the label texts. The **color** option is shorthand for setting both **fill** and **stroke**. While these options are typically set to constant colors (such as _red_ or the default _currentColor_), they can be specified as channels to assign colors dynamically based on the associated tick value.
+The color of an axis can be controlled with the **color**, **stroke**, and **fill** options, which affect the axis’ component marks differently. The **stroke** option affects the tick mark; the **fill** option affects the text marks. The **color** option is shorthand for setting both **fill** and **stroke**. While these options are typically set to constant colors (such as _red_ or the default _currentColor_), they can be specified as channels to assign colors dynamically based on the associated tick value.
 
 :::plot https://observablehq.com/@observablehq/plot-axes-with-color
 ```js
@@ -338,8 +338,8 @@ Note that when an axis mark is declared explicitly (via the [**marks** plot opti
 In addition to the [standard mark options](../features/marks.md), the axis mark supports the following options:
 
 * **anchor** - the axis orientation: *top* or *bottom* for *x* or *fx*; *left* or *right* for *y* or *fy*
-* **tickSize** - the length of the tick vector (in pixels; default 6 for *x* or *y*, or 0 for *fx* or *fy*)
-* **tickPadding** - the separation between the tick vector and its label (in pixels; default 3)
+* **tickSize** - the length of the tick line (in pixels; default 6 for *x* or *y*, or 0 for *fx* or *fy*)
+* **tickPadding** - the separation between the tick line and its label (in pixels; default 3)
 * **tickFormat** - either a function or specifier string to format tick values; see [Formats](../features/formats.md)
 * **tickRotate** - whether to rotate tick labels (an angle in degrees clockwise; default 0)
 * **fontVariant** - the ticks’ font-variant; defaults to *tabular-nums* for quantitative axes
@@ -354,7 +354,7 @@ In addition to the [standard mark options](../features/marks.md), the axis mark 
 
 The **labelArrow** option controls the arrow (↑, →, ↓, or ←) added to the axis label indicating the direction of ascending value; for example, horizontal position *x* typically increases in value going right→, while vertical position *y* typically increases in value going up↑. If *auto* (the default), the arrow will be added only if the scale is quantitative or temporal; if true, the arrow will also apply to ordinal scales, provided the domain is consistently ordered.
 
-As a composite mark, the **stroke** option affects the color of the tick vector, while the **fill** option affects the color the text labels; both default to the **color** option, which defaults to *currentColor*. The **x** and **y** channels, if specified, position the ticks; if not specified, the tick positions depend on the axis **anchor**. The orientation of the tick labels likewise depends on the **anchor**. See the [text mark](./text.md) for details on available options for the tick and axis labels.
+As a composite mark, the **stroke** option affects the color of the tick line, while the **fill** option affects the color the text labels; both default to the **color** option, which defaults to *currentColor*. The **x** and **y** channels, if specified, position the ticks; if not specified, the tick positions depend on the axis **anchor**. The orientation of the tick labels likewise depends on the **anchor**. See the [text mark](./text.md) for details on available options for the tick and axis labels.
 
 The axis mark’s [**facetAnchor**](../features/facets.md) option defaults to *top-empty* if anchor is *top*, *right-empty* if anchor is *right*, *bottom-empty* if anchor is *bottom*, and *left-empty* if anchor is *left*. This ensures the proper positioning of the axes with respect to empty facets.
 


### PR DESCRIPTION
Axis uses Tick and Tick uses Line.

In the docs for Axis, there is repeated use of the term vector. Since, vector is also a mark type, it is kinda confusing.

