### PR TITLE
Update group.md to fix display error of find heading

### DIFF
--- a/docs/transforms/group.md
+++ b/docs/transforms/group.md
@@ -441,7 +441,7 @@ Plot.groupZ({x: "proportion"}, {fill: "species"})
 
 Groups on the first channel of **z**, **fill**, or **stroke**, if any. If none of **z**, **fill**, or **stroke** are channels, then all data (within each facet) is placed into a single group.
 
-## find(*test*) {#find} <VersionBadge version="0.6.12" pr="1914" />
+## find(*test*) <VersionBadge version="0.6.12" pr="1914" /> {#find}
 
 ```js
 Plot.groupX(


### PR DESCRIPTION
For `find` heading, custom anchors should be specified after `<VersionBadge />`?

| Before    | After |
| -------- | ------- |
| <img width="1435" alt="iShot_2024-04-22_14 33 52" src="https://github.com/observablehq/plot/assets/49330279/c126632a-69de-4b60-b427-a0cc9052f220">  | <img width="1432" alt="iShot_2024-04-22_14 34 13" src="https://github.com/observablehq/plot/assets/49330279/c92e8c14-de49-4259-8ddb-7f4ff4f3d066">   |