### PR TITLE
Fix testing under node >= v21

### DIFF
--- a/test/jsdom.js
+++ b/test/jsdom.js
@@ -19,7 +19,6 @@ function withJsdom(run) {
     const jsdom = new JSDOM("");
     global.window = jsdom.window;
     global.document = jsdom.window.document;
-    global.navigator = jsdom.window.navigator;
     global.Event = jsdom.window.Event;
     global.Node = jsdom.window.Node;
     global.NodeList = jsdom.window.NodeList;
@@ -30,7 +29,6 @@ function withJsdom(run) {
     } finally {
       delete global.window;
       delete global.document;
-      delete global.navigator;
       delete global.Event;
       delete global.Node;
       delete global.NodeList;


### PR DESCRIPTION
Our tests do not need global.navigator, which is now present on node (https://nodejs.org/en/blog/announcements/v21-release-announce#navigator-object-integration). And, since it's only a getter, upgrading node was breaking the tests with:
> TypeError: Cannot set property navigator of #<Object> which has only a getter

Note: if we needed to use jsdom.window’s navigator, we could remove node’s version by applying the following snippet: https://github.com/nodejs/node/pull/50310/files