### PR TITLE
fix typescript errors if typescript compiler option "exactOptionalPropertyTypes" is enabled

### DIFF
--- a/src/curve.d.ts
+++ b/src/curve.d.ts
@@ -97,7 +97,7 @@ export interface CurveAutoOptions {
    *
    * [1]: https://d3js.org/d3-shape/curve#custom-curves
    */
-  curve?: Curve | "auto";
+  curve?: Curve | "auto" | undefined;
 
   /**
    * The tension option only has an effect on bundle, cardinal and Catmull–Rom

--- a/src/mark.d.ts
+++ b/src/mark.d.ts
@@ -403,7 +403,7 @@ export interface MarkOptions {
    *
    * [1]: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/opacity
    */
-  opacity?: ChannelValueSpec;
+  opacity?: ChannelValueSpec | undefined;
 
   /**
    * The [mix-blend-mode][1]; a constant string specifying how to blend content


### PR DESCRIPTION
# Huh? What is this PR??
If a developer using plot with typescript has [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) turned on in their own project's tsconfig, then they will get 8 typescript errors from within plot's `.d.ts` files. This PR adjusts plot's `.d.ts` files to eliminate those errors. 

## Other things to note

There should be no change to users who do not have that compiler option enabled. The plot repo itself does not have that compiler option enabled, and so also should not be affected, except by the unsightly / seemingly redundant ` | undefined` I have added :/ It's a bit ugly, but given that this compiler option is recommended by typescript, seems worth supporting.

Let me know if y'all have any questions / concerns. Thanks for the useful library!

### The Errors

For reference, these are the errors that are eliminated by this PR:

```
src/marks/axis.d.ts:55:18 - error TS2430: Interface 'AxisOptions' incorrectly extends interface 'MarkOptions'.
  Types of property 'opacity' are incompatible.
    Type 'ChannelValueSpec | undefined' is not assignable to type 'ChannelValueSpec'.
      Type 'undefined' is not assignable to type 'ChannelValueSpec'.

55 export interface AxisOptions extends GridOptions, MarkOptions, TextOptions, AxisScaleOptions {
                    ~~~~~~~~~~~

src/marks/axis.d.ts:55:18 - error TS2430: Interface 'AxisOptions' incorrectly extends interface 'TextOptions'.
  Types of property 'opacity' are incompatible.
    Type 'ChannelValueSpec | undefined' is not assignable to type 'ChannelValueSpec'.

55 export interface AxisOptions extends GridOptions, MarkOptions, TextOptions, AxisScaleOptions {
                    ~~~~~~~~~~~

src/marks/axis.d.ts:65:18 - error TS2430: Interface 'AxisXOptions' incorrectly extends interface 'TickXOptions'.
  Types of property 'opacity' are incompatible.
    Type 'ChannelValueSpec | undefined' is not assignable to type 'ChannelValueSpec'.

65 export interface AxisXOptions extends AxisOptions, TickXOptions {}
                    ~~~~~~~~~~~~

src/marks/axis.d.ts:68:18 - error TS2430: Interface 'AxisYOptions' incorrectly extends interface 'TickYOptions'.
  Types of property 'opacity' are incompatible.
    Type 'ChannelValueSpec | undefined' is not assignable to type 'ChannelValueSpec'.

68 export interface AxisYOptions extends AxisOptions, TickYOptions {}
                    ~~~~~~~~~~~~

src/marks/axis.d.ts:71:18 - error TS2430: Interface 'GridXOptions' incorrectly extends interface 'Omit<RuleXOptions, "interval">'.
  Types of property 'opacity' are incompatible.
    Type 'ChannelValueSpec | undefined' is not assignable to type 'ChannelValueSpec'.

71 export interface GridXOptions extends GridOptions, Omit<RuleXOptions, "interval"> {}
                    ~~~~~~~~~~~~

src/marks/axis.d.ts:74:18 - error TS2430: Interface 'GridYOptions' incorrectly extends interface 'Omit<RuleYOptions, "interval">'.
  Types of property 'opacity' are incompatible.
    Type 'ChannelValueSpec | undefined' is not assignable to type 'ChannelValueSpec'.

74 export interface GridYOptions extends GridOptions, Omit<RuleYOptions, "interval"> {}
                    ~~~~~~~~~~~~

src/marks/crosshair.d.ts:5:18 - error TS2430: Interface 'CrosshairOptions' incorrectly extends interface 'MarkOptions'.
  Types of property 'opacity' are incompatible.
    Type 'ChannelValueSpec | undefined' is not assignable to type 'ChannelValueSpec'.

5 export interface CrosshairOptions extends MarkOptions {
                   ~~~~~~~~~~~~~~~~

src/marks/link.d.ts:7:18 - error TS2430: Interface 'LinkOptions' incorrectly extends interface 'CurveAutoOptions'.
  Types of property 'curve' are incompatible.
    Type '"auto" | Curve | undefined' is not assignable to type '"auto" | Curve'.
      Type 'undefined' is not assignable to type '"auto" | Curve'.

7 export interface LinkOptions extends MarkOptions, MarkerOptions, CurveAutoOptions {
                   ~~~~~~~~~~~
```