### PR TITLE
zoom option

### DIFF
--- a/src/plot.d.ts
+++ b/src/plot.d.ts
@@ -298,6 +298,9 @@ export interface PlotOptions extends ScaleDefaults {
    */
   projection?: ProjectionOptions | ProjectionName | ProjectionFactory | ProjectionImplementation | null;
 
+  /** TODO */
+  zoom?: boolean;
+
   /**
    * Options for the horizontal facet position *fx* scale. If present, the *fx*
    * scale is always a *band* scale.

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,4 +1,4 @@
-import {creator, select} from "d3";
+import {creator, select, zoom as Zoom} from "d3";
 import {createChannel, inferChannelScale} from "./channel.js";
 import {createContext} from "./context.js";
 import {createDimensions} from "./dimensions.js";
@@ -20,7 +20,7 @@ import {initializer} from "./transforms/basic.js";
 import {consumeWarnings, warn} from "./warnings.js";
 
 export function plot(options = {}) {
-  const {facet, style, title, subtitle, caption, ariaLabel, ariaDescription} = options;
+  const {zoom, facet, style, title, subtitle, caption, ariaLabel, ariaDescription} = options;
 
   // className for inline styles
   const className = maybeClassName(options.className);
@@ -287,6 +287,7 @@ export function plot(options = {}) {
       const node = mark.render(index, scales, values, superdimensions, context);
       if (node == null) continue;
       svg.appendChild(node);
+      stateByMark.get(mark).node = node; // TODO
     }
 
     // Render a faceted mark.
@@ -319,6 +320,67 @@ export function plot(options = {}) {
       }
       g?.selectChildren().attr("transform", facetTranslate);
     }
+  }
+
+  // Apply the zoom behavior.
+  // TODO Keyboard shortcuts for zooming (+-) and panning (↑↓←→).
+  // TODO Some affordance for resetting to the “home” view.
+  // TODO Conditional x and y (scale may not exist, or may not be zoomable).
+  // TODO Constrained zoom (both in translate and scale extent).
+  // TODO Support mark initializers (axis ticks).
+  // TODO Support transforms (bin transform)?
+  // TODO Support faceted marks.
+  // TODO Handle marks with conditional output.
+  if (zoom) {
+    const zoomed = ({transform}) => {
+      const {x, y} = scaleDescriptors;
+
+      // Compute the zoomed x and y domains.
+      const xDomain = Array.from(x.range, (v) => x.scale.invert(transform.invertX(v)));
+      const yDomain = Array.from(y.range, (v) => y.scale.invert(transform.invertY(v)));
+
+      // Compute the zoomed x and y scales.
+      const zoomX = {...x, domain: xDomain, scale: x.scale.copy().domain(xDomain)};
+      const zoomY = {...y, domain: yDomain, scale: y.scale.copy().domain(yDomain)};
+      const zoomScales = createScaleFunctions({x: zoomX, y: zoomY});
+
+      // Merge the zoomed scales with the other scales.
+      const mergeScales = {...scales, ...zoomScales, scales: {...scales.scales, ...zoomScales.scales}};
+
+      // Re-render each mark.
+      for (const [mark, state] of stateByMark) {
+        const {channels, values, facets: indexes} = state;
+
+        // Extract the zoomed position channels.
+        // TODO Handle mark initializers (e.g., axes).
+        const zoomChannels = {};
+        for (const key in channels) {
+          const channel = channels[key];
+          if (channel.scale === "x" || channel.scale === "y") {
+            zoomChannels[key] = channel;
+          }
+        }
+
+        // Compute the zoomed position channel values.
+        const zoomValues = mark.scale(zoomChannels, zoomScales, context);
+        const mergeValues = {...values, ...zoomValues, channels: {...values.channels, ...zoomValues.channels}};
+
+        // Replace the mark’s previously-rendered output.
+        if (facets === undefined || mark.facet === "super") {
+          let index = null;
+          if (indexes) {
+            index = indexes[0];
+            index = mark.filter(index, channels, mergeValues);
+            if (index.length === 0) continue;
+          }
+          const node = mark.render(index, mergeScales, mergeValues, superdimensions, context);
+          if (node == null) continue;
+          state.node.replaceWith(node);
+          state.node = node;
+        }
+      }
+    };
+    select(svg).call(Zoom().on("zoom", zoomed));
   }
 
   // Wrap the plot in a figure, if needed.

--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -345,3 +345,4 @@ export * from "./yearly-requests-line.js";
 export * from "./yearly-requests.js";
 export * from "./young-adults.js";
 export * from "./zero.js";
+export * from "./zoom.js";

--- a/test/plots/zoom.ts
+++ b/test/plots/zoom.ts
@@ -1,0 +1,7 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export async function zoomDot() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return Plot.dot(penguins, {x: "culmen_length_mm", y: "culmen_depth_mm"}).plot({grid: true, zoom: true});
+}


### PR DESCRIPTION
This adds a top-level **zoom** option which can be set to true to enable panning and zooming (via [d3-zoom](https://d3js.org/d3-zoom)). The option can also be set to *xy* to zoom both the *x* and *y* scales, *x* to only zoom the *x* scale, *y* to only zoom the *y* scale, or false (the default) or null to disable zooming.

Setting the **zoom** option is functionally equivalent to setting the **domain**s of the *x* and *y* scales interactively; all marks that use position scales are affected, as well as any transforms or initializers that may depend on these scales. (See [Julien Colot’s notebook](https://observablehq.com/d/223f34bca10702a3) for a userland example of this technique.)

The goal of this initial implementation is not optimal performance, but rather functional correctness. I make some effort at performance — for example, tracking which channels need to be rescaled when the *x* or *y* domains change, and only re-rendering the affected marks — but there is room for future improvement, especially if mark implementations can assist by updating the DOM directly rather than re-rendering and replacing.

I am also interested in exploring usability improvements to panning and zooming. I’d like keyboard shortcuts (when the plot is focused), such as + to zoom in, - to zoom out, and arrow keys ↑↓←→ to pan. I also want a reset button to zoom to the home view, but I don’t know yet where that button should live. We might also support one-dimensional zooming by clicking in the axes.

I’d also like programmatic zooming with zoom transitions (a _plot_.zoom method), and a configurable duration for zoom transitions (such as double-clicking to zoom in). Another possibility is a dedicated method for updating a scale’s domain and recomputing everything downstream, though at least for now I’m just interested in position scales (_x_ and _y_).

TODO

- [x] Basic panning and zooming
- [ ] Handle _x_ or _y_ scales not being defined
- [ ] Handle _x_ or _y_ scales not being zoomable
- [ ] Keyboard shortcuts
- [ ] Reset button
- [ ] Constrained zoom (either translate or scale)
- [ ] Handle mark initializers
- [ ] Handle mark transforms
- [ ] Handle faceted marks
- [ ] Handle conditional marks

Fixes #1590.

Previously #1738 #1964.