### PR TITLE
tip ignores literal colors

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -48,11 +48,13 @@ export function inferChannelScale(name, channel) {
       case "stroke":
       case "color":
         channel.scale = scale !== true && isEvery(value, isColor) ? null : "color";
+        channel.defaultScale = "color";
         break;
       case "fillOpacity":
       case "strokeOpacity":
       case "opacity":
         channel.scale = scale !== true && isEvery(value, isOpacity) ? null : "opacity";
+        channel.defaultScale = "opacity";
         break;
       case "symbol":
         if (scale !== true && isEvery(value, isSymbol)) {
@@ -61,6 +63,7 @@ export function inferChannelScale(name, channel) {
         } else {
           channel.scale = "symbol";
         }
+        channel.defaultScale = "symbol";
         break;
       default:
         channel.scale = registry.has(name) ? name : null;

--- a/src/legends.js
+++ b/src/legends.js
@@ -45,7 +45,7 @@ function legendOptions({className, ...context}, {label, ticks, tickFormat} = {},
 
 function legendColor(color, {legend = true, ...options}) {
   if (legend === true) legend = color.type === "ordinal" ? "swatches" : "ramp";
-  if (color.domain === undefined) return;
+  if (color.domain === undefined) return; // no identity legend
   switch (`${legend}`.toLowerCase()) {
     case "swatches":
       return legendSwatches(color, options);

--- a/src/marks/tip.js
+++ b/src/marks/tip.js
@@ -345,7 +345,11 @@ function getSourceChannels(channels, scales) {
   for (const key in channels) {
     if (key in sources || key in format || ignoreChannels.has(key)) continue;
     const source = getSource(channels, key);
-    if (source) sources[key] = source;
+    if (source) {
+      // Ignore color channels if the values are all literal colors.
+      if (source.scale == null && source.defaultScale === "color") continue;
+      sources[key] = source;
+    }
   }
 
   // And lastly facet channels, but only if this mark is faceted.

--- a/test/output/tipColorLiteral.svg
+++ b/test/output/tipColorLiteral.svg
@@ -1,0 +1,418 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-grid" aria-hidden="true" stroke="currentColor" stroke-opacity="0.1" transform="translate(0,0.5)">
+    <line x1="40" x2="620" y1="332.5" y2="332.5"></line>
+    <line x1="40" x2="620" y1="290.8333333333333" y2="290.8333333333333"></line>
+    <line x1="40" x2="620" y1="249.16666666666663" y2="249.16666666666663"></line>
+    <line x1="40" x2="620" y1="207.5" y2="207.5"></line>
+    <line x1="40" x2="620" y1="165.83333333333331" y2="165.83333333333331"></line>
+    <line x1="40" x2="620" y1="124.16666666666664" y2="124.16666666666664"></line>
+    <line x1="40" x2="620" y1="82.50000000000001" y2="82.50000000000001"></line>
+    <line x1="40" x2="620" y1="40.83333333333334" y2="40.83333333333334"></line>
+  </g>
+  <g aria-label="y-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+    <path transform="translate(40,332.5)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,290.8333333333333)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,249.16666666666663)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,207.5)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,165.83333333333331)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,124.16666666666664)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,82.50000000000001)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,40.83333333333334)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+    <text y="0.32em" transform="translate(40,332.5)">14</text>
+    <text y="0.32em" transform="translate(40,290.8333333333333)">15</text>
+    <text y="0.32em" transform="translate(40,249.16666666666663)">16</text>
+    <text y="0.32em" transform="translate(40,207.5)">17</text>
+    <text y="0.32em" transform="translate(40,165.83333333333331)">18</text>
+    <text y="0.32em" transform="translate(40,124.16666666666664)">19</text>
+    <text y="0.32em" transform="translate(40,82.50000000000001)">20</text>
+    <text y="0.32em" transform="translate(40,40.83333333333334)">21</text>
+  </g>
+  <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-16.5)">
+    <text y="0.71em" transform="translate(40,20)">↑ culmen_depth_mm</text>
+  </g>
+  <g aria-label="x-grid" aria-hidden="true" stroke="currentColor" stroke-opacity="0.1" transform="translate(0.5,0)">
+    <line x1="101.16363636363633" x2="101.16363636363633" y1="20" y2="370"></line>
+    <line x1="206.6181818181818" x2="206.6181818181818" y1="20" y2="370"></line>
+    <line x1="312.07272727272726" x2="312.07272727272726" y1="20" y2="370"></line>
+    <line x1="417.5272727272727" x2="417.5272727272727" y1="20" y2="370"></line>
+    <line x1="522.9818181818182" x2="522.9818181818182" y1="20" y2="370"></line>
+  </g>
+  <g aria-label="x-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(101.16363636363633,370)" d="M0,0L0,6"></path>
+    <path transform="translate(206.6181818181818,370)" d="M0,0L0,6"></path>
+    <path transform="translate(312.07272727272726,370)" d="M0,0L0,6"></path>
+    <path transform="translate(417.5272727272727,370)" d="M0,0L0,6"></path>
+    <path transform="translate(522.9818181818182,370)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(101.16363636363633,370)">35</text>
+    <text y="0.71em" transform="translate(206.6181818181818,370)">40</text>
+    <text y="0.71em" transform="translate(312.07272727272726,370)">45</text>
+    <text y="0.71em" transform="translate(417.5272727272727,370)">50</text>
+    <text y="0.71em" transform="translate(522.9818181818182,370)">55</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,370)">culmen_length_mm →</text>
+  </g>
+  <g aria-label="dot" transform="translate(0.5,0.5)">
+    <circle cx="187.63636363636363" cy="136.66666666666669" r="3" fill="orange"></circle>
+    <circle cx="196.07272727272726" cy="190.8333333333334" r="3" fill="orange"></circle>
+    <circle cx="212.94545454545448" cy="165.83333333333331" r="3" fill="orange"></circle>
+    <circle cx="137.01818181818186" cy="111.66666666666664" r="3" fill="orange"></circle>
+    <circle cx="191.85454545454536" cy="57.49999999999994" r="3" fill="orange"></circle>
+    <circle cx="183.41818181818178" cy="174.16666666666663" r="3" fill="orange"></circle>
+    <circle cx="189.74545454545455" cy="99.16666666666661" r="3" fill="orange"></circle>
+    <circle cx="82.18181818181819" cy="161.66666666666657" r="3" fill="orange"></circle>
+    <circle cx="248.79999999999995" cy="74.1666666666667" r="3" fill="orange"></circle>
+    <circle cx="160.21818181818173" cy="203.33333333333326" r="3" fill="orange"></circle>
+    <circle cx="160.21818181818173" cy="194.99999999999997" r="3" fill="orange"></circle>
+    <circle cx="229.8181818181818" cy="182.49999999999994" r="3" fill="orange"></circle>
+    <circle cx="177.09090909090907" cy="32.500000000000036" r="3" fill="orange"></circle>
+    <circle cx="92.72727272727272" cy="36.66666666666661" r="3" fill="orange"></circle>
+    <circle cx="134.9090909090909" cy="174.16666666666663" r="3" fill="orange"></circle>
+    <circle cx="179.20000000000005" cy="124.16666666666664" r="3" fill="orange"></circle>
+    <circle cx="259.3454545454545" cy="53.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="88.50909090909084" cy="149.1666666666667" r="3" fill="orange"></circle>
+    <circle cx="333.16363636363633" cy="20" r="3" fill="orange"></circle>
+    <circle cx="160.21818181818173" cy="153.3333333333333" r="3" fill="orange"></circle>
+    <circle cx="158.10909090909095" cy="136.66666666666669" r="3" fill="orange"></circle>
+    <circle cx="120.14545454545447" cy="115.83333333333334" r="3" fill="orange"></circle>
+    <circle cx="168.65454545454548" cy="161.66666666666657" r="3" fill="orange"></circle>
+    <circle cx="181.3090909090908" cy="199.16666666666669" r="3" fill="orange"></circle>
+    <circle cx="107.49090909090901" cy="128.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="219.27272727272725" cy="140.83333333333326" r="3" fill="orange"></circle>
+    <circle cx="217.16363636363636" cy="170.00000000000003" r="3" fill="orange"></circle>
+    <circle cx="162.32727272727266" cy="140.83333333333326" r="3" fill="orange"></circle>
+    <circle cx="217.16363636363636" cy="128.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="196.07272727272726" cy="220" r="3" fill="orange"></circle>
+    <circle cx="147.5636363636364" cy="161.66666666666657" r="3" fill="orange"></circle>
+    <circle cx="196.07272727272726" cy="174.16666666666663" r="3" fill="orange"></circle>
+    <circle cx="225.59999999999997" cy="128.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="130.69090909090903" cy="207.5" r="3" fill="orange"></circle>
+    <circle cx="189.74545454545455" cy="36.66666666666661" r="3" fill="orange"></circle>
+    <circle cx="181.3090909090908" cy="82.50000000000001" r="3" fill="orange"></circle>
+    <circle cx="253.01818181818183" cy="145" r="3" fill="orange"></circle>
+    <circle cx="156" cy="111.66666666666664" r="3" fill="orange"></circle>
+    <circle cx="202.39999999999992" cy="119.99999999999996" r="3" fill="orange"></circle>
+    <circle cx="132.79999999999998" cy="165.83333333333331" r="3" fill="orange"></circle>
+    <circle cx="223.490909090909" cy="149.1666666666667" r="3" fill="orange"></circle>
+    <circle cx="122.25454545454542" cy="145" r="3" fill="orange"></circle>
+    <circle cx="293.09090909090907" cy="95.00000000000004" r="3" fill="orange"></circle>
+    <circle cx="143.34545454545452" cy="211.6666666666667" r="3" fill="orange"></circle>
+    <circle cx="198.18181818181816" cy="132.49999999999994" r="3" fill="orange"></circle>
+    <circle cx="229.8181818181818" cy="124.16666666666664" r="3" fill="orange"></circle>
+    <circle cx="153.89090909090908" cy="128.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="122.25454545454542" cy="170.00000000000003" r="3" fill="orange"></circle>
+    <circle cx="255.1272727272726" cy="32.500000000000036" r="3" fill="orange"></circle>
+    <circle cx="198.18181818181816" cy="178.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="208.72727272727272" cy="128.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="101.16363636363633" cy="170.00000000000003" r="3" fill="orange"></circle>
+    <circle cx="248.79999999999995" cy="103.33333333333336" r="3" fill="orange"></circle>
+    <circle cx="90.6181818181818" cy="161.66666666666657" r="3" fill="orange"></circle>
+    <circle cx="236.14545454545447" cy="140.83333333333326" r="3" fill="orange"></circle>
+    <circle cx="185.5272727272727" cy="186.66666666666666" r="3" fill="orange"></circle>
+    <circle cx="219.27272727272725" cy="132.49999999999994" r="3" fill="orange"></circle>
+    <circle cx="132.79999999999998" cy="224.1666666666666" r="3" fill="orange"></circle>
+    <circle cx="156" cy="119.99999999999996" r="3" fill="orange"></circle>
+    <circle cx="115.92727272727274" cy="211.6666666666667" r="3" fill="orange"></circle>
+    <circle cx="234.03636363636355" cy="36.66666666666661" r="3" fill="orange"></circle>
+    <circle cx="156" cy="207.5" r="3" fill="orange"></circle>
+    <circle cx="229.8181818181818" cy="157.5" r="3" fill="orange"></circle>
+    <circle cx="130.69090909090903" cy="203.33333333333326" r="3" fill="orange"></circle>
+    <circle cx="240.36363636363637" cy="165.83333333333331" r="3" fill="orange"></circle>
+    <circle cx="111.70909090909089" cy="240.83333333333331" r="3" fill="orange"></circle>
+    <circle cx="229.8181818181818" cy="119.99999999999996" r="3" fill="orange"></circle>
+    <circle cx="120.14545454545447" cy="224.1666666666666" r="3" fill="orange"></circle>
+    <circle cx="244.58181818181808" cy="107.50000000000004" r="3" fill="orange"></circle>
+    <circle cx="69.52727272727269" cy="124.16666666666664" r="3" fill="orange"></circle>
+    <circle cx="200.2909090909091" cy="149.1666666666667" r="3" fill="orange"></circle>
+    <circle cx="198.18181818181816" cy="199.16666666666669" r="3" fill="orange"></circle>
+    <circle cx="328.9454545454544" cy="128.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="111.70909090909089" cy="186.66666666666666" r="3" fill="orange"></circle>
+    <circle cx="265.6727272727272" cy="145" r="3" fill="orange"></circle>
+    <circle cx="225.59999999999997" cy="215.83333333333331" r="3" fill="orange"></circle>
+    <circle cx="147.5636363636364" cy="107.50000000000004" r="3" fill="orange"></circle>
+    <circle cx="126.4727272727273" cy="244.99999999999994" r="3" fill="orange"></circle>
+    <circle cx="250.90909090909093" cy="119.99999999999996" r="3" fill="orange"></circle>
+    <circle cx="92.72727272727272" cy="199.16666666666669" r="3" fill="orange"></circle>
+    <circle cx="267.78181818181815" cy="182.49999999999994" r="3" fill="orange"></circle>
+    <circle cx="137.01818181818186" cy="132.49999999999994" r="3" fill="orange"></circle>
+    <circle cx="103.27272727272725" cy="107.50000000000004" r="3" fill="orange"></circle>
+    <circle cx="149.67272727272717" cy="174.16666666666663" r="3" fill="orange"></circle>
+    <circle cx="234.03636363636355" cy="69.99999999999997" r="3" fill="orange"></circle>
+    <circle cx="128.58181818181808" cy="103.33333333333336" r="3" fill="orange"></circle>
+    <circle cx="141.2363636363636" cy="140.83333333333326" r="3" fill="orange"></circle>
+    <circle cx="170.7636363636363" cy="115.83333333333334" r="3" fill="orange"></circle>
+    <circle cx="183.41818181818178" cy="132.49999999999994" r="3" fill="orange"></circle>
+    <circle cx="115.92727272727274" cy="165.83333333333331" r="3" fill="orange"></circle>
+    <circle cx="229.8181818181818" cy="161.66666666666657" r="3" fill="orange"></circle>
+    <circle cx="80.07272727272724" cy="203.33333333333326" r="3" fill="orange"></circle>
+    <circle cx="198.18181818181816" cy="161.66666666666657" r="3" fill="orange"></circle>
+    <circle cx="126.4727272727273" cy="194.99999999999997" r="3" fill="orange"></circle>
+    <circle cx="223.490909090909" cy="128.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="166.54545454545453" cy="140.83333333333326" r="3" fill="orange"></circle>
+    <circle cx="212.94545454545448" cy="145" r="3" fill="orange"></circle>
+    <circle cx="61.09090909090909" cy="244.99999999999994" r="3" fill="orange"></circle>
+    <circle cx="274.1090909090909" cy="145" r="3" fill="orange"></circle>
+    <circle cx="101.16363636363633" cy="170.00000000000003" r="3" fill="orange"></circle>
+    <circle cx="227.7090909090909" cy="82.50000000000001" r="3" fill="orange"></circle>
+    <circle cx="158.10909090909095" cy="249.16666666666663" r="3" fill="orange"></circle>
+    <circle cx="160.21818181818173" cy="82.50000000000001" r="3" fill="orange"></circle>
+    <circle cx="162.32727272727266" cy="140.83333333333326" r="3" fill="orange"></circle>
+    <circle cx="200.2909090909091" cy="128.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="177.09090909090907" cy="199.16666666666669" r="3" fill="orange"></circle>
+    <circle cx="168.65454545454548" cy="82.50000000000001" r="3" fill="orange"></circle>
+    <circle cx="166.54545454545453" cy="207.5" r="3" fill="orange"></circle>
+    <circle cx="274.1090909090909" cy="124.16666666666664" r="3" fill="orange"></circle>
+    <circle cx="166.54545454545453" cy="228.33333333333334" r="3" fill="orange"></circle>
+    <circle cx="324.72727272727275" cy="69.99999999999997" r="3" fill="orange"></circle>
+    <circle cx="200.2909090909091" cy="178.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="253.01818181818183" cy="103.33333333333336" r="3" fill="orange"></circle>
+    <circle cx="198.18181818181816" cy="53.33333333333337" r="3" fill="orange"></circle>
+    <circle cx="263.56363636363636" cy="153.3333333333333" r="3" fill="orange"></circle>
+    <circle cx="177.09090909090907" cy="207.5" r="3" fill="orange"></circle>
+    <circle cx="149.67272727272717" cy="61.66666666666668" r="3" fill="orange"></circle>
+    <circle cx="115.92727272727274" cy="207.5" r="3" fill="orange"></circle>
+    <circle cx="229.8181818181818" cy="140.83333333333326" r="3" fill="orange"></circle>
+    <circle cx="126.4727272727273" cy="199.16666666666669" r="3" fill="orange"></circle>
+    <circle cx="158.10909090909095" cy="90.83333333333331" r="3" fill="orange"></circle>
+    <circle cx="210.83636363636367" cy="207.5" r="3" fill="orange"></circle>
+    <circle cx="236.14545454545447" cy="145" r="3" fill="orange"></circle>
+    <circle cx="105.3818181818182" cy="253.33333333333326" r="3" fill="orange"></circle>
+    <circle cx="219.27272727272725" cy="124.16666666666664" r="3" fill="orange"></circle>
+    <circle cx="181.3090909090908" cy="182.49999999999994" r="3" fill="orange"></circle>
+    <circle cx="238.2545454545454" cy="153.3333333333333" r="3" fill="orange"></circle>
+    <circle cx="185.5272727272727" cy="203.33333333333326" r="3" fill="orange"></circle>
+    <circle cx="293.09090909090907" cy="165.83333333333331" r="3" fill="orange"></circle>
+    <circle cx="174.98181818181814" cy="170.00000000000003" r="3" fill="orange"></circle>
+    <circle cx="272" cy="115.83333333333334" r="3" fill="orange"></circle>
+    <circle cx="139.12727272727264" cy="145" r="3" fill="orange"></circle>
+    <circle cx="153.89090909090908" cy="145" r="3" fill="orange"></circle>
+    <circle cx="166.54545454545453" cy="182.49999999999994" r="3" fill="orange"></circle>
+    <circle cx="229.8181818181818" cy="186.66666666666666" r="3" fill="orange"></circle>
+    <circle cx="113.81818181818181" cy="186.66666666666666" r="3" fill="orange"></circle>
+    <circle cx="210.83636363636367" cy="78.33333333333329" r="3" fill="orange"></circle>
+    <circle cx="143.34545454545452" cy="228.33333333333334" r="3" fill="orange"></circle>
+    <circle cx="200.2909090909091" cy="170.00000000000003" r="3" fill="orange"></circle>
+    <circle cx="210.83636363636367" cy="203.33333333333326" r="3" fill="orange"></circle>
+    <circle cx="219.27272727272725" cy="199.16666666666669" r="3" fill="orange"></circle>
+    <circle cx="40" cy="270" r="3" fill="orange"></circle>
+    <circle cx="221.38181818181823" cy="207.5" r="3" fill="orange"></circle>
+    <circle cx="149.67272727272717" cy="215.83333333333331" r="3" fill="orange"></circle>
+    <circle cx="185.5272727272727" cy="136.66666666666669" r="3" fill="orange"></circle>
+    <circle cx="189.74545454545455" cy="140.83333333333326" r="3" fill="orange"></circle>
+    <circle cx="134.9090909090909" cy="149.1666666666667" r="3" fill="orange"></circle>
+    <circle cx="122.25454545454542" cy="174.16666666666663" r="3" fill="orange"></circle>
+    <circle cx="160.21818181818173" cy="161.66666666666657" r="3" fill="orange"></circle>
+    <circle cx="122.25454545454542" cy="203.33333333333326" r="3" fill="orange"></circle>
+    <circle cx="238.2545454545454" cy="145" r="3" fill="orange"></circle>
+    <circle cx="343.7090909090909" cy="170.00000000000003" r="3" fill="steelblue"></circle>
+    <circle cx="417.5272727272727" cy="103.33333333333336" r="3" fill="steelblue"></circle>
+    <circle cx="444.9454545454544" cy="115.83333333333334" r="3" fill="steelblue"></circle>
+    <circle cx="320.5090909090909" cy="136.66666666666669" r="3" fill="steelblue"></circle>
+    <circle cx="474.47272727272735" cy="90.83333333333331" r="3" fill="steelblue"></circle>
+    <circle cx="316.2909090909091" cy="174.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="335.27272727272725" cy="157.5" r="3" fill="steelblue"></circle>
+    <circle cx="444.9454545454544" cy="157.5" r="3" fill="steelblue"></circle>
+    <circle cx="333.16363636363633" cy="128.33333333333337" r="3" fill="steelblue"></circle>
+    <circle cx="444.9454545454544" cy="86.66666666666674" r="3" fill="steelblue"></circle>
+    <circle cx="345.8181818181818" cy="174.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="453.38181818181823" cy="69.99999999999997" r="3" fill="steelblue"></circle>
+    <circle cx="354.2545454545454" cy="194.99999999999997" r="3" fill="steelblue"></circle>
+    <circle cx="459.7090909090909" cy="161.66666666666657" r="3" fill="steelblue"></circle>
+    <circle cx="331.0545454545454" cy="203.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="428.07272727272726" cy="99.16666666666661" r="3" fill="steelblue"></circle>
+    <circle cx="423.85454545454536" cy="82.50000000000001" r="3" fill="steelblue"></circle>
+    <circle cx="586.2545454545455" cy="174.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="341.5999999999999" cy="140.83333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="400.6545454545455" cy="157.5" r="3" fill="steelblue"></circle>
+    <circle cx="257.2363636363636" cy="194.99999999999997" r="3" fill="steelblue"></circle>
+    <circle cx="385.890909090909" cy="186.66666666666666" r="3" fill="steelblue"></circle>
+    <circle cx="274.1090909090909" cy="224.1666666666666" r="3" fill="steelblue"></circle>
+    <circle cx="430.18181818181813" cy="107.50000000000004" r="3" fill="steelblue"></circle>
+    <circle cx="347.9272727272728" cy="170.00000000000003" r="3" fill="steelblue"></circle>
+    <circle cx="459.7090909090909" cy="124.16666666666664" r="3" fill="steelblue"></circle>
+    <circle cx="428.07272727272726" cy="149.1666666666667" r="3" fill="steelblue"></circle>
+    <circle cx="406.98181818181814" cy="124.16666666666664" r="3" fill="steelblue"></circle>
+    <circle cx="341.5999999999999" cy="174.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="476.58181818181805" cy="82.50000000000001" r="3" fill="steelblue"></circle>
+    <circle cx="225.59999999999997" cy="224.1666666666666" r="3" fill="steelblue"></circle>
+    <circle cx="506.109090909091" cy="49.16666666666664" r="3" fill="steelblue"></circle>
+    <circle cx="259.3454545454545" cy="220" r="3" fill="steelblue"></circle>
+    <circle cx="438.6181818181818" cy="132.49999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="411.2" cy="140.83333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="364.8" cy="215.83333333333331" r="3" fill="steelblue"></circle>
+    <circle cx="366.9090909090909" cy="153.3333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="459.7090909090909" cy="53.33333333333337" r="3" fill="steelblue"></circle>
+    <circle cx="352.1454545454545" cy="224.1666666666666" r="3" fill="steelblue"></circle>
+    <circle cx="491.3454545454545" cy="86.66666666666674" r="3" fill="steelblue"></circle>
+    <circle cx="396.43636363636364" cy="103.33333333333336" r="3" fill="steelblue"></circle>
+    <circle cx="337.38181818181823" cy="186.66666666666666" r="3" fill="steelblue"></circle>
+    <circle cx="436.50909090909084" cy="119.99999999999996" r="3" fill="steelblue"></circle>
+    <circle cx="322.61818181818177" cy="207.5" r="3" fill="steelblue"></circle>
+    <circle cx="436.50909090909084" cy="170.00000000000003" r="3" fill="steelblue"></circle>
+    <circle cx="434.3999999999999" cy="145" r="3" fill="steelblue"></circle>
+    <circle cx="419.6363636363636" cy="170.00000000000003" r="3" fill="steelblue"></circle>
+    <circle cx="396.43636363636364" cy="99.16666666666661" r="3" fill="steelblue"></circle>
+    <circle cx="449.16363636363633" cy="136.66666666666669" r="3" fill="steelblue"></circle>
+    <circle cx="413.3090909090908" cy="194.99999999999997" r="3" fill="steelblue"></circle>
+    <circle cx="377.45454545454544" cy="232.50000000000003" r="3" fill="steelblue"></circle>
+    <circle cx="447.05454545454535" cy="124.16666666666664" r="3" fill="steelblue"></circle>
+    <circle cx="326.83636363636367" cy="194.99999999999997" r="3" fill="steelblue"></circle>
+    <circle cx="432.2909090909091" cy="95.00000000000004" r="3" fill="steelblue"></circle>
+    <circle cx="259.3454545454545" cy="194.99999999999997" r="3" fill="steelblue"></circle>
+    <circle cx="463.92727272727274" cy="132.49999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="316.2909090909091" cy="224.1666666666666" r="3" fill="steelblue"></circle>
+    <circle cx="402.76363636363624" cy="86.66666666666674" r="3" fill="steelblue"></circle>
+    <circle cx="421.74545454545455" cy="132.49999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="324.72727272727275" cy="107.50000000000004" r="3" fill="steelblue"></circle>
+    <circle cx="457.5999999999999" cy="103.33333333333336" r="3" fill="steelblue"></circle>
+    <circle cx="350.03636363636355" cy="228.33333333333334" r="3" fill="steelblue"></circle>
+    <circle cx="326.83636363636367" cy="207.5" r="3" fill="steelblue"></circle>
+    <circle cx="539.8545454545454" cy="90.83333333333331" r="3" fill="steelblue"></circle>
+    <circle cx="280.43636363636364" cy="161.66666666666657" r="3" fill="steelblue"></circle>
+    <circle cx="409.0909090909091" cy="157.5" r="3" fill="steelblue"></circle>
+    <circle cx="434.3999999999999" cy="124.16666666666664" r="3" fill="steelblue"></circle>
+    <circle cx="421.74545454545455" cy="136.66666666666669" r="3" fill="steelblue"></circle>
+    <circle cx="335.27272727272725" cy="365.83333333333337" r="3" fill="steelblue"></circle>
+    <circle cx="417.5272727272727" cy="236.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="390.1090909090909" cy="328.33333333333337" r="3" fill="steelblue"></circle>
+    <circle cx="417.5272727272727" cy="282.5" r="3" fill="steelblue"></circle>
+    <circle cx="366.9090909090909" cy="311.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="343.7090909090909" cy="353.3333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="320.5090909090909" cy="307.5" r="3" fill="steelblue"></circle>
+    <circle cx="347.9272727272728" cy="278.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="276.21818181818173" cy="357.5" r="3" fill="steelblue"></circle>
+    <circle cx="350.03636363636355" cy="274.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="225.59999999999997" cy="345" r="3" fill="steelblue"></circle>
+    <circle cx="396.43636363636364" cy="244.99999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="322.61818181818177" cy="345" r="3" fill="steelblue"></circle>
+    <circle cx="383.78181818181815" cy="307.5" r="3" fill="steelblue"></circle>
+    <circle cx="328.9454545454544" cy="307.5" r="3" fill="steelblue"></circle>
+    <circle cx="402.76363636363624" cy="261.6666666666667" r="3" fill="steelblue"></circle>
+    <circle cx="248.79999999999995" cy="353.3333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="400.6545454545455" cy="282.5" r="3" fill="steelblue"></circle>
+    <circle cx="337.38181818181823" cy="311.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="390.1090909090909" cy="286.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="421.74545454545455" cy="319.99999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="314.18181818181813" cy="311.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="343.7090909090909" cy="311.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="339.49090909090904" cy="257.49999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="267.78181818181815" cy="370" r="3" fill="steelblue"></circle>
+    <circle cx="335.27272727272725" cy="286.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="301.5272727272727" cy="319.99999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="371.1272727272726" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="379.5636363636364" cy="319.99999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="417.5272727272727" cy="278.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="360.5818181818181" cy="278.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="265.6727272727272" cy="324.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="314.18181818181813" cy="311.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="620" cy="207.5" r="3" fill="steelblue"></circle>
+    <circle cx="398.5454545454545" cy="299.1666666666666" r="3" fill="steelblue"></circle>
+    <circle cx="383.78181818181815" cy="236.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="261.4545454545455" cy="345" r="3" fill="steelblue"></circle>
+    <circle cx="299.4181818181818" cy="194.99999999999997" r="3" fill="steelblue"></circle>
+    <circle cx="290.98181818181814" cy="349.1666666666667" r="3" fill="steelblue"></circle>
+    <circle cx="390.1090909090909" cy="261.6666666666667" r="3" fill="steelblue"></circle>
+    <circle cx="263.56363636363636" cy="345" r="3" fill="steelblue"></circle>
+    <circle cx="409.0909090909091" cy="249.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="318.3999999999999" cy="345" r="3" fill="steelblue"></circle>
+    <circle cx="409.0909090909091" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="428.07272727272726" cy="253.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="282.5454545454545" cy="336.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="322.61818181818177" cy="336.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="428.07272727272726" cy="253.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="309.9636363636363" cy="361.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="316.2909090909091" cy="257.49999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="345.8181818181818" cy="324.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="385.890909090909" cy="328.33333333333337" r="3" fill="steelblue"></circle>
+    <circle cx="314.18181818181813" cy="315.83333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="419.6363636363636" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="343.7090909090909" cy="315.83333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="312.07272727272726" cy="274.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="286.7636363636363" cy="336.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="322.61818181818177" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="274.1090909090909" cy="311.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="425.9636363636363" cy="278.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="318.3999999999999" cy="340.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="337.38181818181823" cy="294.99999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="326.83636363636367" cy="336.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="508.21818181818173" cy="261.6666666666667" r="3" fill="steelblue"></circle>
+    <circle cx="328.9454545454544" cy="324.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="413.3090909090908" cy="215.83333333333331" r="3" fill="steelblue"></circle>
+    <circle cx="337.38181818181823" cy="315.83333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="406.98181818181814" cy="240.83333333333331" r="3" fill="steelblue"></circle>
+    <circle cx="280.43636363636364" cy="324.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="432.2909090909091" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="369.01818181818186" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="341.5999999999999" cy="265.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="379.5636363636364" cy="265.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="343.7090909090909" cy="299.1666666666666" r="3" fill="steelblue"></circle>
+    <circle cx="341.5999999999999" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="388" cy="249.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="364.8" cy="324.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="440.72727272727275" cy="236.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="316.2909090909091" cy="340.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="316.2909090909091" cy="232.50000000000003" r="3" fill="steelblue"></circle>
+    <circle cx="398.5454545454545" cy="311.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="470.25454545454545" cy="265.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="362.69090909090903" cy="307.5" r="3" fill="steelblue"></circle>
+    <circle cx="417.5272727272727" cy="253.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="309.9636363636363" cy="340.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="434.3999999999999" cy="194.99999999999997" r="3" fill="steelblue"></circle>
+    <circle cx="278.32727272727266" cy="315.83333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="444.9454545454544" cy="324.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="364.8" cy="332.5" r="3" fill="steelblue"></circle>
+    <circle cx="461.81818181818187" cy="207.5" r="3" fill="steelblue"></circle>
+    <circle cx="364.8" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="463.92727272727274" cy="203.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="322.61818181818177" cy="311.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="406.98181818181814" cy="244.99999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="301.5272727272727" cy="303.3333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="434.3999999999999" cy="261.6666666666667" r="3" fill="steelblue"></circle>
+    <circle cx="404.8727272727272" cy="257.49999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="352.1454545454545" cy="307.5" r="3" fill="steelblue"></circle>
+    <circle cx="383.78181818181815" cy="315.83333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="440.72727272727275" cy="228.33333333333334" r="3" fill="steelblue"></circle>
+    <circle cx="385.890909090909" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="541.9636363636363" cy="207.5" r="3" fill="steelblue"></circle>
+    <circle cx="358.4727272727273" cy="270" r="3" fill="steelblue"></circle>
+    <circle cx="398.5454545454545" cy="290.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="360.5818181818181" cy="340.8333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="350.03636363636355" cy="244.99999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="242.4727272727273" cy="303.3333333333333" r="3" fill="steelblue"></circle>
+    <circle cx="489.23636363636354" cy="257.49999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="276.21818181818173" cy="332.5" r="3" fill="steelblue"></circle>
+    <circle cx="377.45454545454544" cy="286.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="428.07272727272726" cy="282.5" r="3" fill="steelblue"></circle>
+    <circle cx="413.3090909090908" cy="253.33333333333326" r="3" fill="steelblue"></circle>
+    <circle cx="280.43636363636364" cy="282.5" r="3" fill="steelblue"></circle>
+    <circle cx="449.16363636363633" cy="236.66666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="337.38181818181823" cy="328.33333333333337" r="3" fill="steelblue"></circle>
+    <circle cx="525.090909090909" cy="249.16666666666663" r="3" fill="steelblue"></circle>
+    <circle cx="301.5272727272727" cy="261.6666666666667" r="3" fill="steelblue"></circle>
+    <circle cx="392.21818181818173" cy="240.83333333333331" r="3" fill="steelblue"></circle>
+    <circle cx="358.4727272727273" cy="345" r="3" fill="steelblue"></circle>
+    <circle cx="350.03636363636355" cy="319.99999999999994" r="3" fill="steelblue"></circle>
+    <circle cx="425.9636363636363" cy="261.6666666666667" r="3" fill="steelblue"></circle>
+    <circle cx="316.2909090909091" cy="299.1666666666666" r="3" fill="steelblue"></circle>
+    <circle cx="415.4181818181818" cy="244.99999999999994" r="3" fill="steelblue"></circle>
+  </g>
+  <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0.5,0.5)"></g>
+</svg>

--- a/test/plots/tip.ts
+++ b/test/plots/tip.ts
@@ -265,3 +265,18 @@ export async function tipFacetX() {
     ]
   });
 }
+
+export async function tipColorLiteral() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return Plot.plot({
+    grid: true,
+    marks: [
+      Plot.dot(penguins, {
+        x: "culmen_length_mm",
+        y: "culmen_depth_mm",
+        fill: (d) => (d.species === "Adelie" ? "orange" : "steelblue"),
+        tip: true
+      })
+    ]
+  });
+}


### PR DESCRIPTION
Fixes #2090. Uses a new `channel.defaultScale` field to record what the `channel.scale` _would_ have been, if it weren’t for the specific values provided. This allows the tip mark to detect when a channel would have been associated with the _color_ scale, but isn’t, and hence contains only literal color values that should not be shown (at least by default) in the tip.

<img width="662" alt="Screenshot 2024-06-14 at 6 08 37 PM" src="https://github.com/observablehq/plot/assets/230541/e8c03370-c260-4eed-908e-920e679d3335">
