### PR TITLE
fix date typing in arrow tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/node": "^20.5.0",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
+    "apache-arrow": "^16.1.0",
     "c8": "^9.1.0",
     "canvas": "^2.0.0",
     "d3-geo-projection": "^4.0.0",
@@ -87,7 +88,6 @@
     ]
   },
   "dependencies": {
-    "apache-arrow": "^16.1.0",
     "d3": "^7.9.0",
     "interval-tree-1d": "^1.0.0",
     "isoformat": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     ]
   },
   "dependencies": {
+    "apache-arrow": "^16.1.0",
     "d3": "^7.9.0",
     "interval-tree-1d": "^1.0.0",
     "isoformat": "^0.2.0"

--- a/src/options.js
+++ b/src/options.js
@@ -148,6 +148,20 @@ export function arrayify(values) {
     case "Sphere":
       return [values];
   }
+
+  // Duck type Arrow tables to retype date fields to Dates. Note that we only
+  // need the first non-nullish value to be typed correctly for isTemporal to
+  // return true.
+  const fields = values?.schema?.fields;
+  if (Array.isArray(fields)) {
+    values = Array.from(values);
+    for (const f of fields) {
+      if (String(f).endsWith("<MILLISECOND>"))
+        values.some((d, i) => d[f.name] != null && (values[i] = {...values[i], [f.name]: new Date(values[i][f.name])}));
+    }
+    return values;
+  }
+
   return Array.from(values);
 }
 

--- a/test/output/arrowDates.svg
+++ b/test/output/arrowDates.svg
@@ -1,0 +1,121 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+    <path transform="translate(40,370)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,332.48660235798496)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,294.97320471597)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,257.459807073955)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,219.94640943193997)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,182.43301178992496)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,144.91961414790998)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,107.40621650589496)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,69.89281886387995)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,32.379421221864945)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+    <text y="0.32em" transform="translate(40,370)">0</text>
+    <text y="0.32em" transform="translate(40,332.48660235798496)">100</text>
+    <text y="0.32em" transform="translate(40,294.97320471597)">200</text>
+    <text y="0.32em" transform="translate(40,257.459807073955)">300</text>
+    <text y="0.32em" transform="translate(40,219.94640943193997)">400</text>
+    <text y="0.32em" transform="translate(40,182.43301178992496)">500</text>
+    <text y="0.32em" transform="translate(40,144.91961414790998)">600</text>
+    <text y="0.32em" transform="translate(40,107.40621650589496)">700</text>
+    <text y="0.32em" transform="translate(40,69.89281886387995)">800</text>
+    <text y="0.32em" transform="translate(40,32.379421221864945)">900</text>
+  </g>
+  <g aria-label="y-axis label" text-anchor="start" transform="translate(-36.5,-16.5)">
+    <text y="0.71em" transform="translate(40,20)">↑ Frequency</text>
+  </g>
+  <g aria-label="x-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(51.82879812259038,370)" d="M0,0L0,6"></path>
+    <path transform="translate(111.00519640163157,370)" d="M0,0L0,6"></path>
+    <path transform="translate(170.21400234676202,370)" d="M0,0L0,6"></path>
+    <path transform="translate(229.3904006258032,370)" d="M0,0L0,6"></path>
+    <path transform="translate(288.56679890484435,370)" d="M0,0L0,6"></path>
+    <path transform="translate(347.74319718388557,370)" d="M0,0L0,6"></path>
+    <path transform="translate(406.952003129016,370)" d="M0,0L0,6"></path>
+    <path transform="translate(466.1284014080572,370)" d="M0,0L0,6"></path>
+    <path transform="translate(525.3047996870985,370)" d="M0,0L0,6"></path>
+    <path transform="translate(584.4811979661396,370)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(51.82879812259038,370)">1955</text>
+    <text y="0.71em" transform="translate(111.00519640163157,370)">1960</text>
+    <text y="0.71em" transform="translate(170.21400234676202,370)">1965</text>
+    <text y="0.71em" transform="translate(229.3904006258032,370)">1970</text>
+    <text y="0.71em" transform="translate(288.56679890484435,370)">1975</text>
+    <text y="0.71em" transform="translate(347.74319718388557,370)">1980</text>
+    <text y="0.71em" transform="translate(406.952003129016,370)">1985</text>
+    <text y="0.71em" transform="translate(466.1284014080572,370)">1990</text>
+    <text y="0.71em" transform="translate(525.3047996870985,370)">1995</text>
+    <text y="0.71em" transform="translate(584.4811979661396,370)">2000</text>
+  </g>
+  <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
+    <text transform="translate(620,370)">date_of_birth →</text>
+  </g>
+  <g aria-label="rect">
+    <rect x="41" y="369.2497320471597" width="10.828798122590378" height="0.7502679528403178"></rect>
+    <rect x="52.82879812259038" y="369.62486602357984" width="10.828798122590378" height="0.3751339764201589"></rect>
+    <rect x="64.65759624518076" y="369.2497320471597" width="10.86120578867967" height="0.7502679528403178"></rect>
+    <rect x="76.51880203386042" y="369.62486602357984" width="10.82879812259037" height="0.3751339764201589"></rect>
+    <rect x="88.3476001564508" y="369.62486602357984" width="10.828798122590385" height="0.3751339764201589"></rect>
+    <rect x="100.17639827904118" y="369.2497320471597" width="10.828798122590385" height="0.7502679528403178"></rect>
+    <rect x="112.00519640163157" y="369.2497320471597" width="10.86120578867967" height="0.7502679528403178"></rect>
+    <rect x="123.86640219031123" y="369.2497320471597" width="10.828798122590356" height="0.7502679528403178"></rect>
+    <rect x="135.6952003129016" y="367.7491961414791" width="10.828798122590399" height="2.2508038585208965"></rect>
+    <rect x="147.523998435492" y="366.24866023579847" width="10.82879812259037" height="3.751339764201532"></rect>
+    <rect x="159.35279655808236" y="366.24866023579847" width="10.861205788679655" height="3.751339764201532"></rect>
+    <rect x="171.21400234676202" y="366.9989281886388" width="10.82879812259037" height="3.0010718113612143"></rect>
+    <rect x="183.0428004693524" y="368.4994640943194" width="10.828798122590399" height="1.5005359056805787"></rect>
+    <rect x="194.87159859194279" y="367.37406216505894" width="10.82879812259037" height="2.6259378349410554"></rect>
+    <rect x="206.70039671453316" y="367.37406216505894" width="10.861205788679655" height="2.6259378349410554"></rect>
+    <rect x="218.5616025032128" y="363.24758842443725" width="10.828798122590399" height="6.752411575562746"></rect>
+    <rect x="230.3904006258032" y="366.24866023579847" width="10.82879812259037" height="3.751339764201532"></rect>
+    <rect x="242.21919874839358" y="365.8735262593783" width="10.82879812259037" height="4.126473740621691"></rect>
+    <rect x="254.04799687098395" y="363.24758842443725" width="10.861205788679655" height="6.752411575562746"></rect>
+    <rect x="265.9092026596636" y="360.9967845659164" width="10.828798122590399" height="9.003215434083586"></rect>
+    <rect x="277.738000782254" y="360.2465166130761" width="10.828798122590342" height="9.753483386923904"></rect>
+    <rect x="289.56679890484435" y="357.2454448017149" width="10.828798122590399" height="12.754555198285118"></rect>
+    <rect x="301.39559702743475" y="353.4941050375134" width="10.861205788679683" height="16.505894962486593"></rect>
+    <rect x="313.25680281611443" y="348.9924973204716" width="10.828798122590342" height="21.007502679528386"></rect>
+    <rect x="325.0856009387048" y="342.6152197213291" width="10.828798122590399" height="27.384780278670917"></rect>
+    <rect x="336.91439906129517" y="333.61200428724544" width="10.828798122590399" height="36.38799571275456"></rect>
+    <rect x="348.74319718388557" y="306.2272240085745" width="10.861205788679626" height="63.772775991425476"></rect>
+    <rect x="360.6044029725652" y="298.72454448017146" width="10.828798122590456" height="71.27545551982854"></rect>
+    <rect x="372.43320109515565" y="263.8370846730976" width="10.828798122590342" height="106.16291532690241"></rect>
+    <rect x="384.261999217746" y="257.459807073955" width="10.828798122590342" height="112.540192926045"></rect>
+    <rect x="396.09079734033634" y="215.06966773847805" width="10.861205788679683" height="154.93033226152195"></rect>
+    <rect x="407.952003129016" y="180.55734190782422" width="10.828798122590399" height="189.44265809217578"></rect>
+    <rect x="419.7808012516064" y="132.1650589496249" width="10.828798122590399" height="237.8349410503751"></rect>
+    <rect x="431.6095993741968" y="113.03322615219723" width="10.828798122590342" height="256.96677384780276"></rect>
+    <rect x="443.43839749678716" y="59.013933547695615" width="10.861205788679683" height="310.9860664523044"></rect>
+    <rect x="455.29960328546684" y="34.63022508038586" width="10.828798122590342" height="335.36977491961414"></rect>
+    <rect x="467.1284014080572" y="23.37620578778136" width="10.828798122590456" height="346.6237942122186"></rect>
+    <rect x="478.95719953064764" y="24.876741693461966" width="10.828798122590285" height="345.12325830653805"></rect>
+    <rect x="490.7859976532379" y="35.00535905680599" width="10.86120578867974" height="334.994640943194"></rect>
+    <rect x="502.64720344191767" y="20" width="10.828798122590342" height="350"></rect>
+    <rect x="514.476001564508" y="54.13719185423365" width="10.828798122590456" height="315.86280814576634"></rect>
+    <rect x="526.3047996870985" y="156.5487674169346" width="10.828798122590229" height="213.4512325830654"></rect>
+    <rect x="538.1335978096887" y="199.6891747052519" width="10.86120578867974" height="170.3108252947481"></rect>
+    <rect x="549.9948035983684" y="248.08145766345126" width="10.828798122590342" height="121.91854233654874"></rect>
+    <rect x="561.8236017209588" y="311.1039657020365" width="10.828798122590456" height="58.896034297963524"></rect>
+    <rect x="573.6523998435492" y="339.2390139335477" width="10.828798122590342" height="30.76098606645229"></rect>
+    <rect x="585.4811979661396" y="353.11897106109325" width="10.861205788679626" height="16.881028938906752"></rect>
+    <rect x="597.3424037548192" y="367.37406216505894" width="10.828798122590342" height="2.6259378349410554"></rect>
+    <rect x="609.1712018774095" y="366.9989281886388" width="10.828798122590456" height="3.0010718113612143"></rect>
+  </g>
+</svg>

--- a/test/plots/arrow-dates.ts
+++ b/test/plots/arrow-dates.ts
@@ -1,0 +1,9 @@
+import * as Plot from "@observablehq/plot";
+import * as Arrow from "apache-arrow";
+import * as d3 from "d3";
+
+export async function arrowDates() {
+  const athletes = await d3.csv<any>("data/athletes.csv", d3.autoType);
+  const table = Arrow.tableFromJSON(athletes);
+  return Plot.rectY(table, Plot.binX(undefined, {x: "date_of_birth"})).plot();
+}

--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -11,6 +11,7 @@ export * from "./aapl-volume.js";
 export * from "./anscombe-quartet.js";
 export * from "./arc.js";
 export * from "./armadillo.js";
+export * from "./arrow-dates.js";
 export * from "./aspectRatio.js";
 export * from "./athletes-bins-colors.js";
 export * from "./athletes-birthdays.js";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@75lb/deep-merge@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@75lb/deep-merge/-/deep-merge-1.1.1.tgz#3b06155b90d34f5f8cc2107d796f1853ba02fd6d"
+  integrity sha512-xvgv6pkMGBA6GwdyJbNAnDmfAIR/DfWhrj9jgWh3TY7gRm3KO46x/GPjRg6wJ0nOepwqrNxFfojebh0Df4h4Tw==
+  dependencies:
+    lodash.assignwith "^4.2.0"
+    typical "^7.1.1"
+
 "@algolia/autocomplete-core@1.9.3":
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz#1d56482a768c33aae0868c8533049e02e8961be7"
@@ -617,6 +625,13 @@
   dependencies:
     shiki "1.6.2"
 
+"@swc/helpers@^0.5.10":
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.11.tgz#5bab8c660a6e23c13b2d23fcd1ee44a2db1b0cb7"
+  integrity sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==
+  dependencies:
+    tslib "^2.4.0"
+
 "@ts-morph/common@~0.23.0":
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.23.0.tgz#bd4ddbd3f484f29476c8bd985491592ae5fc147e"
@@ -626,6 +641,16 @@
     minimatch "^9.0.3"
     mkdirp "^3.0.1"
     path-browserify "^1.0.1"
+
+"@types/command-line-args@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/command-line-args/-/command-line-args-5.2.3.tgz#553ce2fd5acf160b448d307649b38ffc60d39639"
+  integrity sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==
+
+"@types/command-line-usage@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/command-line-usage/-/command-line-usage-5.0.4.tgz#374e4c62d78fbc5a670a0f36da10235af879a0d5"
+  integrity sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==
 
 "@types/d3-array@*":
   version "3.2.1"
@@ -874,6 +899,13 @@
   version "10.0.6"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
+
+"@types/node@^20.12.7":
+  version "20.14.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.7.tgz#342cada27f97509eb8eb2dbc003edf21ce8ab5a8"
+  integrity sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^20.5.0":
   version "20.14.0"
@@ -1218,6 +1250,21 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apache-arrow@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-16.1.0.tgz#7aa8d0d436dd0995d9dc5c36febf380d5b207209"
+  integrity sha512-G6GiM6tzPDdGnKUnVkvVr1Nt5+hUaCMBISiasMSiJwI5L5GKDv5Du7Avc2kxlFfB/LEK2LTqh2GKSxutMdf8vQ==
+  dependencies:
+    "@swc/helpers" "^0.5.10"
+    "@types/command-line-args" "^5.2.3"
+    "@types/command-line-usage" "^5.0.4"
+    "@types/node" "^20.12.7"
+    command-line-args "^5.2.1"
+    command-line-usage "^7.0.1"
+    flatbuffers "^24.3.25"
+    json-bignum "^0.0.3"
+    tslib "^2.6.2"
+
 "aproba@^1.0.3 || ^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
@@ -1235,6 +1282,16 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.2.tgz#f567d99e9af88a6d3d2f9dfcc21db6f9ba9fd157"
+  integrity sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==
 
 array-union@^2.1.0:
   version "2.1.0"
@@ -1334,7 +1391,14 @@ canvas@^2.0.0:
     nan "^2.17.0"
     simple-get "^3.0.3"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk-template@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk-template/-/chalk-template-0.4.0.tgz#692c034d0ed62436b9062c1707fadcd0f753204b"
+  integrity sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==
+  dependencies:
+    chalk "^4.1.2"
+
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1408,6 +1472,26 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+command-line-args@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-usage@^7.0.0, command-line-usage@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-7.0.1.tgz#e540afef4a4f3bc501b124ffde33956309100655"
+  integrity sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==
+  dependencies:
+    array-back "^6.2.2"
+    chalk-template "^0.4.0"
+    table-layout "^3.0.0"
+    typical "^7.1.1"
 
 commander@2, commander@^2.20.0:
   version "2.20.3"
@@ -2037,6 +2121,13 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
+
 find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -2058,6 +2149,11 @@ flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+flatbuffers@^24.3.25:
+  version "24.3.25"
+  resolved "https://registry.yarnpkg.com/flatbuffers/-/flatbuffers-24.3.25.tgz#e2f92259ba8aa53acd0af7844afb7c7eb95e7089"
+  integrity sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ==
 
 flatted@^3.2.9:
   version "3.3.1"
@@ -2498,6 +2594,11 @@ jsdom@^24.0.0:
     ws "^8.17.0"
     xml-name-validator "^5.0.0"
 
+json-bignum@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/json-bignum/-/json-bignum-0.0.3.tgz#41163b50436c773d82424dbc20ed70db7604b8d7"
+  integrity sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -2534,6 +2635,16 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.assignwith@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz#127a97f02adc41751a954d24b0de17e100e038eb"
+  integrity sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g==
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -3188,7 +3299,21 @@ speakingurl@^14.0.1:
   resolved "https://registry.yarnpkg.com/speakingurl/-/speakingurl-14.0.1.tgz#f37ec8ddc4ab98e9600c1c9ec324a8c48d772a53"
   integrity sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+stream-read-all@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/stream-read-all/-/stream-read-all-3.0.1.tgz#60762ae45e61d93ba0978cda7f3913790052ad96"
+  integrity sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==
+
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3213,7 +3338,14 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3260,6 +3392,19 @@ tabbable@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
   integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+
+table-layout@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-3.0.2.tgz#69c2be44388a5139b48c59cf21e73b488021769a"
+  integrity sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==
+  dependencies:
+    "@75lb/deep-merge" "^1.1.1"
+    array-back "^6.2.2"
+    command-line-args "^5.2.1"
+    command-line-usage "^7.0.0"
+    stream-read-all "^3.0.1"
+    typical "^7.1.1"
+    wordwrapjs "^5.1.0"
 
 tar@^6.1.11:
   version "6.2.1"
@@ -3346,6 +3491,11 @@ ts-morph@^22.0.0:
     "@ts-morph/common" "~0.23.0"
     code-block-writer "^13.0.1"
 
+tslib@^2.4.0, tslib@^2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
+  integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
+
 tsx@^4.7.0:
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.11.1.tgz#133adc0e08324553e820a813347e697761339b31"
@@ -3372,6 +3522,16 @@ typescript@^5.0.2:
   version "5.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
   integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-7.1.1.tgz#ba177ab7ab103b78534463ffa4c0c9754523ac1f"
+  integrity sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==
 
 undici-types@~5.26.4:
   version "5.26.5"
@@ -3525,12 +3685,26 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+wordwrapjs@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.0.tgz#4c4d20446dcc670b14fa115ef4f8fd9947af2b3a"
+  integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
+
 workerpool@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
uses the same duck type test as https://github.com/observablehq/inputs/pull/263

addresses https://github.com/observablehq/framework/issues/1376 (for the Plot part)

Note: it's not as good as full Arrow support (where the data would not get transformed into an array of Proxy objects, and valueof would use _table_.getChild, see #2030).