### PR TITLE
Export inferTimeFormat function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,4 +57,4 @@ export {formatIsoDate, formatNumber, formatWeekday, formatMonth} from "./format.
 export {scale} from "./scales.js";
 export {legend} from "./legends.js";
 export {numberInterval} from "./options.js";
-export {timeInterval, utcInterval, inferTimeFormat} from "./time.js";
+export {inferTimeFormat, timeInterval, utcInterval} from "./time.js";

--- a/src/index.js
+++ b/src/index.js
@@ -57,4 +57,4 @@ export {formatIsoDate, formatNumber, formatWeekday, formatMonth} from "./format.
 export {scale} from "./scales.js";
 export {legend} from "./legends.js";
 export {numberInterval} from "./options.js";
-export {timeInterval, utcInterval} from "./time.js";
+export {timeInterval, utcInterval, inferTimeFormat} from "./time.js";


### PR DESCRIPTION
This PR simply exports the `inferTimeFormat` function. 

The `inferTimeFormat` function is quite useful, and also depends on a number of other methods and constants (making it difficult to use without defining functions such as `formatTimeInterval` and `getTimeTemplate`). 