### PR TITLE
waffle multiple option

### DIFF
--- a/docs/marks/waffle.md
+++ b/docs/marks/waffle.md
@@ -124,12 +124,21 @@ Plot.waffleX([apples], {y: ["apples"]}).plot({height: 240})
 The number of rows in the waffle above is guaranteed to be an integer, but it might not be a multiple or factor of the *x*-axis tick interval. For example, the waffle might have 15 rows while the *x*-axis shows ticks every 100 units.
 :::
 :::tip
-While you can’t control the number of rows (or columns) directly, you can affect it via the **padding** option on the corresponding band scale. Padding defaults to 0.1; a higher value may produce more rows, while a lower (or zero) value may produce fewer rows.
+To set the number of rows (or columns) directly, use the **multiple** option, though note that manually setting the multiple may result in non-square cells if there isn’t enough room. Alternatively, you can bias the automatic multiple while preserving square cells by setting the **padding** option on the corresponding band scale: padding defaults to 0.1; a higher value may produce more rows, while a lower (or zero) value may produce fewer rows.
 :::
 
 ## Waffle options
 
 For required channels, see the [bar mark](./bar.md). The waffle mark supports the [standard mark options](../features/marks.md), including [insets](../features/marks.md#insets) and [rounded corners](../features/marks.md#rounded-corners). The **stroke** defaults to *none*. The **fill** defaults to *currentColor* if the stroke is *none*, and to *none* otherwise.
+
+The waffle mark supports a few additional options to control the rendering of cells:
+
+* **unit** - the quantity each cell represents; defaults to 1
+* **multiple** - the number of cells per row (or column); defaults to undefine
+* **gap** - the separation between adjacent cells, in pixels; defaults to 1
+* **round** - whether to round values to avoid partial cells; defaults to false
+
+If **multiple** is undefined (the default), the waffle mark will use as many cells per row (or column) that fits within the available bandwidth while ensuring that the cells are square, or one cell per row if square cells are not possible. You can change the rounding behavior by specifying **round** as a function, such as Math.floor or Math.ceil; true is equivalent to Math.round.
 
 ## waffleX(*data*, *options*) {#waffleX}
 

--- a/docs/marks/waffle.md
+++ b/docs/marks/waffle.md
@@ -134,7 +134,7 @@ For required channels, see the [bar mark](./bar.md). The waffle mark supports th
 The waffle mark supports a few additional options to control the rendering of cells:
 
 * **unit** - the quantity each cell represents; defaults to 1
-* **multiple** - the number of cells per row (or column); defaults to undefine
+* **multiple** - the number of cells per row (or column); defaults to undefined
 * **gap** - the separation between adjacent cells, in pixels; defaults to 1
 * **round** - whether to round values to avoid partial cells; defaults to false
 

--- a/src/marks/waffle.d.ts
+++ b/src/marks/waffle.d.ts
@@ -3,6 +3,8 @@ import type {BarXOptions, BarYOptions} from "./bar.js";
 
 /** Options for the waffleX and waffleY mark. */
 interface WaffleOptions {
+  /** The number of cells per row or column; defaults to undefined for automatic. */
+  multiple?: number;
   /** The quantity each cell represents; defaults to 1. */
   unit?: number;
   /** The gap in pixels between cells; defaults to 1. */

--- a/test/output/waffleMultiple.svg
+++ b/test/output/waffleMultiple.svg
@@ -1,0 +1,102 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+    <path transform="translate(40,343.1818181818182)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,293.78787878787875)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,244.39393939393938)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,195)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,145.60606060606062)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,96.21212121212122)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,46.818181818181806)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+    <text y="0.32em" transform="translate(40,343.1818181818182)">−60</text>
+    <text y="0.32em" transform="translate(40,293.78787878787875)">−40</text>
+    <text y="0.32em" transform="translate(40,244.39393939393938)">−20</text>
+    <text y="0.32em" transform="translate(40,195)">0</text>
+    <text y="0.32em" transform="translate(40,145.60606060606062)">20</text>
+    <text y="0.32em" transform="translate(40,96.21212121212122)">40</text>
+    <text y="0.32em" transform="translate(40,46.818181818181806)">60</text>
+  </g>
+  <g aria-label="x-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(43.5,0)">
+    <path transform="translate(50,370)" d="M0,0L0,6"></path>
+    <path transform="translate(145,370)" d="M0,0L0,6"></path>
+    <path transform="translate(240,370)" d="M0,0L0,6"></path>
+    <path transform="translate(335,370)" d="M0,0L0,6"></path>
+    <path transform="translate(430,370)" d="M0,0L0,6"></path>
+    <path transform="translate(525,370)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" transform="translate(43.5,9.5)">
+    <text y="0.71em" transform="translate(50,370)">0</text>
+    <text y="0.71em" transform="translate(145,370)">1</text>
+    <text y="0.71em" transform="translate(240,370)">2</text>
+    <text y="0.71em" transform="translate(335,370)">3</text>
+    <text y="0.71em" transform="translate(430,370)">4</text>
+    <text y="0.71em" transform="translate(525,370)">5</text>
+  </g>
+  <g aria-label="waffle">
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-1">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-2">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-3">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-4">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-5">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-6">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <path transform="translate(50,195)" d="M0,0L0,0L0,0L0,0L0,0L86,0L86,0L34.4,0L34.4,0L34.4,0L34.4,-24.696969696969695L0,-24.696969696969695Z" fill="url(#plot-pattern-1)"></path>
+    <path transform="translate(145,195)" d="M0,0L0,0L0,0L0,0L0,0L86,0L86,0L77.39999999999999,0L77.39999999999999,0L77.39999999999999,0L77.39999999999999,-24.696969696969695L0,-24.696969696969695Z" fill="url(#plot-pattern-2)"></path>
+    <path transform="translate(240,195)" d="M0,0L0,0L0,0L0,0L0,0L86,0L86,-49.39393939393939L34.4,-49.39393939393939L34.4,-49.39393939393939L34.4,-49.39393939393939L34.4,-74.0909090909091L0,-74.0909090909091Z" fill="url(#plot-pattern-3)"></path>
+    <path transform="translate(335,195)" d="M0,0L0,0L0,0L0,0L0,0L86,0L86,-98.78787878787878L51.599999999999994,-98.78787878787878L51.599999999999994,-98.78787878787878L51.599999999999994,-98.78787878787878L51.599999999999994,-123.48484848484847L0,-123.48484848484847Z" fill="url(#plot-pattern-4)"></path>
+    <path transform="translate(430,195)" d="M0,0L0,0L0,0L0,0L0,0L86,0L86,-148.1818181818182L51.599999999999994,-148.1818181818182L51.599999999999994,-148.1818181818182L51.599999999999994,-148.1818181818182L51.599999999999994,-172.87878787878788L0,-172.87878787878788Z" fill="url(#plot-pattern-5)"></path>
+    <path transform="translate(525,195)" d="M0,0L0,0L0,0L0,0L0,0L86,0L86,0L60.199999999999996,0L60.199999999999996,0L60.199999999999996,0L60.199999999999996,-24.696969696969695L0,-24.696969696969695Z" fill="url(#plot-pattern-6)"></path>
+  </g>
+  <g aria-label="waffle" fill="red">
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-7">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-8">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-9">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-10">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-11">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <pattern width="8.6" height="24.696969696969695" patternUnits="userSpaceOnUse" id="plot-pattern-12">
+      <rect x="0.5" y="0.5" width="7.6" height="23.696969696969695"></rect>
+    </pattern>
+    <path transform="translate(50,195)" d="M0,0L51.599999999999994,0L51.599999999999994,24.696969696969695L51.599999999999994,24.696969696969695L51.599999999999994,24.696969696969695L86,24.696969696969695L86,0L0,0L0,0L0,0Z" fill="url(#plot-pattern-7)"></path>
+    <path transform="translate(145,195)" d="M0,0L8.6,0L8.6,24.696969696969695L8.6,24.696969696969695L8.6,24.696969696969695L86,24.696969696969695L86,0L0,0L0,0L0,0Z" fill="url(#plot-pattern-8)"></path>
+    <path transform="translate(240,195)" d="M0,49.39393939393939L51.599999999999994,49.39393939393939L51.599999999999994,74.0909090909091L51.599999999999994,74.0909090909091L51.599999999999994,74.0909090909091L86,74.0909090909091L86,0L0,0L0,0L0,0Z" fill="url(#plot-pattern-9)"></path>
+    <path transform="translate(335,195)" d="M0,98.78787878787878L34.4,98.78787878787878L34.4,123.48484848484847L34.4,123.48484848484847L34.4,123.48484848484847L86,123.48484848484847L86,0L0,0L0,0L0,0Z" fill="url(#plot-pattern-10)"></path>
+    <path transform="translate(430,195)" d="M0,148.1818181818182L34.4,148.1818181818182L34.4,172.87878787878788L34.4,172.87878787878788L34.4,172.87878787878788L86,172.87878787878788L86,0L0,0L0,0L0,0Z" fill="url(#plot-pattern-11)"></path>
+    <path transform="translate(525,195)" d="M0,0L25.799999999999997,0L25.799999999999997,24.696969696969695L25.799999999999997,24.696969696969695L25.799999999999997,24.696969696969695L86,24.696969696969695L86,0L0,0L0,0L0,0Z" fill="url(#plot-pattern-12)"></path>
+  </g>
+</svg>

--- a/test/plots/waffle.ts
+++ b/test/plots/waffle.ts
@@ -15,6 +15,16 @@ export function waffleSquished() {
   return Plot.waffleX([10]).plot();
 }
 
+export function waffleMultiple() {
+  return Plot.plot({
+    y: {inset: 12},
+    marks: [
+      Plot.waffleY([4, 9, 24, 46, 66, 7], {multiple: 10, fill: "currentColor"}),
+      Plot.waffleY([-4, -9, -24, -46, -66, -7], {multiple: 10, fill: "red"})
+    ]
+  });
+}
+
 export function waffleShorthand() {
   return Plot.plot({
     y: {inset: 12},


### PR DESCRIPTION
Now that we support non-square waffle cells, it feels safe and convenient to support a **multiple** option to affect the number of cells per row (or column, depending on the orientation). I’m not sure about the name of this option, but it seemed desirable to have an orientation-independent name so that it’s easy to switch between waffleX and waffleY.