### PR TITLE
lax className

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -2,9 +2,9 @@ import {channelDomain, createChannels, valueObject} from "./channel.js";
 import {defined} from "./defined.js";
 import {maybeFacetAnchor} from "./facet.js";
 import {maybeClip, maybeNamed, maybeValue} from "./options.js";
-import {dataify, isDomainSort, isObject, isOptions, keyword, range, singleton} from "./options.js";
+import {dataify, isDomainSort, isObject, isOptions, keyword, range, singleton, string} from "./options.js";
 import {project} from "./projection.js";
-import {maybeClassName, styles} from "./style.js";
+import {styles} from "./style.js";
 import {basic, initializer} from "./transforms/basic.js";
 
 export class Mark {
@@ -72,7 +72,7 @@ export class Mark {
     this.marginLeft = +marginLeft;
     this.clip = maybeClip(clip);
     this.tip = maybeTip(tip);
-    this.className = className ? maybeClassName(className) : null;
+    this.className = string(className);
     // Super-faceting currently disallow position channels; in the future, we
     // could allow position to be specified in fx and fy in addition to (or
     // instead of) x and y.

--- a/test/output/classNameOnMarks.svg
+++ b/test/output/classNameOnMarks.svg
@@ -54,7 +54,7 @@
   <g aria-label="x-axis label" text-anchor="end" transform="translate(17.5,27.5)">
     <text transform="translate(620,110)">units →</text>
   </g>
-  <g aria-label="bar" class="fruitbars">
+  <g aria-label="bar" class="fruit units">
     <rect x="50" width="570" y="87" height="19"></rect>
     <rect x="50" width="256.5" y="45" height="19"></rect>
     <rect x="50" width="285" y="66" height="19"></rect>

--- a/test/plots/class-name.ts
+++ b/test/plots/class-name.ts
@@ -12,7 +12,7 @@ export async function classNameOnMarks() {
     marks: [
       Plot.barX(
         sales,
-        Plot.groupY({x: "sum"}, {x: "units", y: "fruit", sort: {y: "x", reverse: true}, className: "fruitbars"})
+        Plot.groupY({x: "sum"}, {x: "units", y: "fruit", sort: {y: "x", reverse: true}, className: "fruit units"})
       ),
       Plot.ruleX([0])
     ]


### PR DESCRIPTION
Fixes #2124 by removing validation of the **className** mark option.

The reason we validate the **className** plot option is because we need to interpolate it into a stylesheet as a selector (prefixed with `.`). That’s not true of the mark-level **className** option, which is simply used to set the `class` attribute. Therefore for the latter we should allow any string, like we do for other attribute mark options such as **ariaLabel** and **ariaDescription**.