### PR TITLE
design tweaks

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -14,6 +14,7 @@
   --vp-c-brand-soft: var(--theme-phosphate-soft);
   --mono-heading: "Spline Sans Mono", monospace;
   --vp-font-family-mono: var(--mono-heading);
+  --vp-font-family-base: Inter, -apple-system, BlinkMacSystemFont, "avenir next", avenir, helvetica, "helvetica neue", ubuntu, roboto, noto, "segoe ui", arial, sans-serif;
   --vp-code-font-size: 14px;
   --vp-code-line-height: 1.5;
 }

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -10,6 +10,9 @@
   --vp-c-brand-3: rgb(243, 139, 233);  /* home page alt color */
   --vp-c-brand-soft: var(--theme-phosphate-soft);
   --mono-heading: "Spline Sans Mono", monospace;
+  --vp-font-family-mono: var(--mono-heading);
+  --vp-code-font-size: 14px;
+  --vp-code-line-height: 1.5;
 }
 
 .dark {
@@ -23,6 +26,10 @@
 .vp-doc h1 {
   font-family: var(--mono-heading);
   font-weight: 500;
+}
+
+.vp-doc p {
+  line-height: 1.5;
 }
 
 .vp-doc a {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,16 +1,14 @@
 :root {
-  --vp-c-purple-1: #7135be;
-  --vp-c-purple-2: #7f42cd;
-  --vp-c-purple-3: #9555e2;
-  --vp-c-purple-soft: rgba(155, 91, 233, 0.14);
   --vp-c-red: #f43f5e;
   --vp-c-green: #10b981;
   --vp-c-blue: #0092ff;
   --vp-c-purple: #a463f2;
-  --vp-c-brand-1: var(--vp-c-purple-1);
-  --vp-c-brand-2: var(--vp-c-purple-2);
-  --vp-c-brand-3: var(--vp-c-purple-3);
-  --vp-c-brand-soft: var(--vp-c-purple-soft);
+  --theme-phosphate: #148576;
+  --theme-phosphate-soft: #d7fbf7;
+  --vp-c-brand-1: var(--theme-phosphate); /* link and brand color */
+  --vp-c-brand-2: var(--theme-phosphate);
+  --vp-c-brand-3: rgb(243, 139, 233);  /* home page alt color */
+  --vp-c-brand-soft: var(--theme-phosphate-soft);
   --vp-font-family-base: -apple-system, BlinkMacSystemFont, "avenir next", avenir, helvetica, "helvetica neue", ubuntu,
     roboto, noto, "segoe ui", arial, sans-serif;
   --sans-text: Inter, var(--vp-font-family-base);
@@ -18,10 +16,9 @@
 }
 
 .dark {
-  --vp-c-purple-1: #db96ff;
-  --vp-c-purple-2: #9a5ae8;
-  --vp-c-purple-3: #884ad6;
-  --vp-c-purple-soft: rgba(155, 91, 233, 0.16);
+  --theme-phosphate: #37d5be;
+  --vp-c-brand-3: rgb(183, 41, 169);  /* home page alt color */
+  --theme-phosphate-soft: #033a32;
   --vp-c-text-1: #f5f5f5;
 }
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -7,7 +7,7 @@
   --theme-phosphate-soft: #d7fbf7;
   --vp-c-brand-1: var(--theme-phosphate); /* link and brand color */
   --vp-c-brand-2: var(--theme-phosphate);
-  --vp-c-brand-3: rgb(243, 139, 233);  /* home page alt color */
+  --vp-c-brand-3: rgb(243, 139, 233); /* home page alt color */
   --vp-c-brand-soft: var(--theme-phosphate-soft);
   --mono-heading: "Spline Sans Mono", monospace;
   --vp-font-family-mono: var(--mono-heading);
@@ -17,11 +17,10 @@
 
 .dark {
   --theme-phosphate: #37d5be;
-  --vp-c-brand-3: rgb(183, 41, 169);  /* home page alt color */
+  --vp-c-brand-3: rgb(183, 41, 169);
   --theme-phosphate-soft: #033a32;
   --vp-c-text-1: #f5f5f5;
 }
-
 
 .vp-doc h1 {
   font-family: var(--mono-heading);

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -9,9 +9,6 @@
   --vp-c-brand-2: var(--theme-phosphate);
   --vp-c-brand-3: rgb(243, 139, 233);  /* home page alt color */
   --vp-c-brand-soft: var(--theme-phosphate-soft);
-  --vp-font-family-base: -apple-system, BlinkMacSystemFont, "avenir next", avenir, helvetica, "helvetica neue", ubuntu,
-    roboto, noto, "segoe ui", arial, sans-serif;
-  --sans-text: Inter, var(--vp-font-family-base);
   --mono-heading: "Spline Sans Mono", monospace;
 }
 
@@ -22,10 +19,6 @@
   --vp-c-text-1: #f5f5f5;
 }
 
-.vp-doc {
-  font-family: var(--sans-text);
-  font-weight: 500;
-}
 
 .vp-doc h1 {
   font-family: var(--mono-heading);

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -4,10 +4,13 @@
   --vp-c-blue: #0092ff;
   --vp-c-purple: #a463f2;
   --theme-phosphate: #148576;
+  --theme-phosphate-2: #1da492;
+  --theme-phosphate-3: #26c1ad;
   --theme-phosphate-soft: #d7fbf7;
   --vp-c-brand-1: var(--theme-phosphate); /* link and brand color */
-  --vp-c-brand-2: var(--theme-phosphate);
-  --vp-c-brand-3: rgb(243, 139, 233); /* home page alt color */
+  --vp-c-brand-2: var(--theme-phosphate-2); 
+  --vp-c-brand-3: var(--theme-phosphate-3);
+  --hero-brand-contrast: rgb(243, 139, 233); /* home page alt color */
   --vp-c-brand-soft: var(--theme-phosphate-soft);
   --mono-heading: "Spline Sans Mono", monospace;
   --vp-font-family-mono: var(--mono-heading);
@@ -17,7 +20,9 @@
 
 .dark {
   --theme-phosphate: #37d5be;
-  --vp-c-brand-3: rgb(183, 41, 169);
+  --theme-phosphate-2: #28b39e;
+  --theme-phosphate-3: #1b9583;
+  --hero-brand-contrast: rgb(183, 41, 169);
   --theme-phosphate-soft: #033a32;
   --vp-c-text-1: #f5f5f5;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ features:
 
 :root {
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: linear-gradient(-30deg, var(--vp-c-brand-3), var(--vp-c-brand-1));
+  --vp-home-hero-name-background: linear-gradient(-30deg, var(--hero-brand-contrast), var(--vp-c-brand-1));
 }
 
 :root.dark .VPHero .VPImage {

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ features:
 
 :root {
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: linear-gradient(-30deg, hsl(200deg 100% 65%), var(--vp-c-purple));
+  --vp-home-hero-name-background: linear-gradient(-30deg, var(--vp-c-brand-3), var(--vp-c-brand-1));
 }
 
 :root.dark .VPHero .VPImage {


### PR DESCRIPTION
Following https://github.com/observablehq/framework/pull/1591 we:
* use the same (sans serif) font on the body
* restore normal weight copy
* adopt phosphate as the brand color
* change the colors in the hero / home page to match

Notes:
* the "soft" color is used for tip backgrounds, it must be very close to the white (or black) background but with the same chroma as phosphate.
* the chroma of the pink colors chosen as alternative is from the Plot logo.
* "Inter" is the default from VitePress

![Capture d’écran 2024-08-21 à 11 24 51](https://github.com/user-attachments/assets/67c86946-25cf-4147-9aa9-47f74188754f)
![Capture d’écran 2024-08-21 à 11 25 59](https://github.com/user-attachments/assets/9ae6be5e-113a-45f3-830e-8f943f21dcc1)
![Capture d’écran 2024-08-21 à 11 26 31](https://github.com/user-attachments/assets/f6d88d3c-397b-4976-bd6e-41b243ddd31b)
![Capture d’écran 2024-08-21 à 11 26 43](https://github.com/user-attachments/assets/a55cef05-46a3-4bce-9a39-8105164f9568)
