### PR TITLE
further design tweaks

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -10,6 +10,9 @@
   --vp-c-brand-3: rgb(243, 139, 233);  /* home page alt color */
   --vp-c-brand-soft: var(--theme-phosphate-soft);
   --mono-heading: "Spline Sans Mono", monospace;
+  --vp-font-family-mono: var(--mono-heading);
+  --vp-code-font-size: 14px;
+  --vp-code-line-height: 1.5;
 }
 
 .dark {
@@ -23,6 +26,10 @@
 .vp-doc h1 {
   font-family: var(--mono-heading);
   font-weight: 500;
+}
+
+.vp-doc p {
+  line-height: 1.5;
 }
 
 .vp-doc a {


### PR DESCRIPTION
In looking at the Framework docs, I think we should also change the code font to Spline Sans Mono and set the size and line height to match. 

Also, the `p` line-height is 1.7, so this changes it to 1.5 to match Framework.