### PR TITLE
Use context2D to convert CSS4 colors to display-p3

### DIFF
--- a/test/output/rasterVaporP3.svg
+++ b/test/output/rasterVaporP3.svg
@@ -1,0 +1,59 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="y-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0,0.5)">
+    <path transform="translate(40,350.55555555555554)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,311.6666666666667)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,272.77777777777777)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,233.8888888888889)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,195)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,156.1111111111111)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,117.22222222222223)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,78.33333333333331)" d="M0,0L-6,0"></path>
+    <path transform="translate(40,39.44444444444446)" d="M0,0L-6,0"></path>
+  </g>
+  <g aria-label="y-axis tick label" text-anchor="end" font-variant="tabular-nums" transform="translate(-8.5,0.5)">
+    <text y="0.32em" transform="translate(40,350.55555555555554)">−80</text>
+    <text y="0.32em" transform="translate(40,311.6666666666667)">−60</text>
+    <text y="0.32em" transform="translate(40,272.77777777777777)">−40</text>
+    <text y="0.32em" transform="translate(40,233.8888888888889)">−20</text>
+    <text y="0.32em" transform="translate(40,195)">0</text>
+    <text y="0.32em" transform="translate(40,156.1111111111111)">20</text>
+    <text y="0.32em" transform="translate(40,117.22222222222223)">40</text>
+    <text y="0.32em" transform="translate(40,78.33333333333331)">60</text>
+    <text y="0.32em" transform="translate(40,39.44444444444446)">80</text>
+  </g>
+  <g aria-label="x-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(88.33333333333333,370)" d="M0,0L0,6"></path>
+    <path transform="translate(168.88888888888889,370)" d="M0,0L0,6"></path>
+    <path transform="translate(249.44444444444443,370)" d="M0,0L0,6"></path>
+    <path transform="translate(330,370)" d="M0,0L0,6"></path>
+    <path transform="translate(410.55555555555554,370)" d="M0,0L0,6"></path>
+    <path transform="translate(491.11111111111114,370)" d="M0,0L0,6"></path>
+    <path transform="translate(571.6666666666666,370)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(88.33333333333333,370)">−150</text>
+    <text y="0.71em" transform="translate(168.88888888888889,370)">−100</text>
+    <text y="0.71em" transform="translate(249.44444444444443,370)">−50</text>
+    <text y="0.71em" transform="translate(330,370)">0</text>
+    <text y="0.71em" transform="translate(410.55555555555554,370)">50</text>
+    <text y="0.71em" transform="translate(491.11111111111114,370)">100</text>
+    <text y="0.71em" transform="translate(571.6666666666666,370)">150</text>
+  </g>
+  <g aria-label="raster" transform="translate(0.5,0.5)">
+    <image transform="translate(40,20) scale(1,1)" width="580" height="350" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWgAAAC0CAYAAAC5brY1AAAABmJLR0QA/wD/AP+gvaeTAAAKpklEQVR4nO3d7ZKkKBYA0KyJff9Xrv0xmxs2DYgKepFzIiaqptI2TT6uV0Dz8wEgpJ/N77+PHcW6fj7PlfvP/iZ/0UauOVLmypqfJwMEABX/PH0AAA/4+Zy7iryVDBogKBk0QFACNEBQAjRAUP95+gDghSxfpQuThNBHy4oAfY1DBGi4rtdyLX2RPwjQ0E8uUP8W/p7bLrcf/XNhxqChn1owbQnAuYTpJ7Mdi5BBQ0y5wLz9W6nv6tMvojJhDH2LyzQigKDcqAL/Cv/gHNZzJoP+/pu0QcvE4TmlMWv9cmKtFVhaPpR7TYNgdU8ERqs9XqilIaXbWKMJsWz7qKz5RY5WpsoHuMnRSULBOZ4jk1vRvkUi0rFAODJi7qKtlSkbsiyzo7c0KzZ5VaZsqHLm5irPj6jTxzhNBh3TiLHZUeO9ueWWv59+QWn2cWrBmdOc3ePrsaxRRgsTEqDXkbsD9Grd525S0qagE0Mc9/pJfpZeb91Py+vbpXWlCbyzfpP/0v3ufV6gQrZzj1KASjPOszcO7d1uX9qutD0QgLHJ8WoPselxgjz6PJX0ZHAlaNceGt+6D9Y0Mjl8TeKZ+8qrnsGD8kOltq+NUgrCLRl3bqw6bROW1/3Nw8Pa9JrwzsWpEWX+SDz8J/Omv8lP44d91AJbj/22ngDSBp4G8J/ktVJH+PnkA/lsAelo+86d7EpBebaySEXr+982+ES5lt5zaBnVxj9l0ONEuEppGZ7YO763Pdnw6nDRXe9/1/5XjwF77Xt4+dxdAa0dfuVGcdSZR8Zu//75lE/MpbsEV6yflsncXu33bSe+HmrtrnebLCUpI5aq7h7IXR+aPq5mby0NrjT+vP3/0vFAb0/EqVoQvu1Kp7YOOkKHizYG1tPZz/YdgzsbGFsCbGl8OvdeufXPqTfXI+PV2nhtJVIvd0/8/n//d9yocqTwSqsHZlG7KSR15bP1XJ5XmmQ8MjO+Nyk2Wz1GkmtHTnjHnCmv3+S/Hvts8cd+7wjQK3XObWWO/Nw9ZpT3lsvtBYbVg0TrifiqvauWKJ5sD6WrwtLrI95zyH5NAvXTs9zuHNdNJ0S277s3Dpf7e2/R2+MTx7c3ucs9XreKg2NaVg70fr9Uy3j3lZUknGO1zfv9HKnESCs+NL7xckuNWgL13uvq7T7K+7pH16YfGYNumSRibtux59Kqju2225/ptjkztpPoY+2l+YLPZ87yjua2FRs5zrCkRlwua2e81dm2XbvZ6XdvI9YUaRiLfW4SmlNzX/LAfra2k05X1qRHHxZ4g3QdO8+rtftTN3HNmBXNeMwz2CtX5Q5/ar2COb0aa8YMWpAYS/YL7f2gJR7VbgrbPYiIAS/qcQHcJnoGLZsDlnU1QI8KoOm62/R9BG7g9fYC9MgnsrXKDXcY/gBmlEs2i3HWWO/81CG8VPQx6JShjb8JztBfiFgj+wIIarYMGuANmjL0mQN0iEsQgBOaRi4McQAENXMGDfBqAjRAUAI0cBfzRgcZgwYISgYNEJQADRCUAA0QlAANEJQADRCUAA0QlAANEJQADRCUAA0QlAANEJQADRCUAA0QlAANEJQADRCUAA0QlABNCw9aX4N6DkaApmTbWX2pAzxAgH5WxIzle0yC8noi1HnEPvGY0QFaYdf9fuKVUYROyrxa2nNtm22fiNY3bjc6QF/p7KtUzrdB7n3eno12lbLlWaV2thcXfjc/c/tYpv0e/dLY1S9/R3/Jbrr/tLyf/JJfXzDM05aLPzpdH99y3Auw6d9Lr+XqRF3NTx3WtZTPUmW41IftaFtuuaDcq0xH7hvucKTNjtp2Wkt8yKBaLte226groitdGZ4ZmjiaBL0ymXnFh1iAemIWuWB8Zq6rNMxX23c6eTh9n9Hx60zKvZfyHat1PuboflpfewU3qtSdaUw9tttOOjLGqzt2ANus9tuea4E29/t3P6Wldq+vQwG6r5YZ6JbtvtueWQIpqF93pQxb17O/zd6a572bU3K/p3Mwpb+91hJnoeDUwbutXr9nl86Vxps/m7+3Pi9m2jqY9sAhkNI6+BVdvZkkF4RbgvTrVnB8Pi/6IPCQVZ/6txc7zpRLbu6l9Uau1ved6mRqDPr9Xj9OF0T4zt5Zy/M0chODaXvMtc/f5Od2273nc9QmI3P7rB3H46Y4i8BAtRsiKNsbymi5meTI/lqP6Ui2fvX9htMg41I3saWXyuqrzZVyqj3z5uhQyBQMccQ1feN6sW3nL12Or+C7xrllu690fXRum5K0rPeGOkYbPizyirMM3Ey/+dPZSb3SmHKEByaFqOMQB0E4U4zPEdqZJ9P1uj28l8fj4+MHQCjawzHKa1/rjSqfhu2Wo4GR0iYgCJOE44RcV1mRPuOgdvyzfTaYkmxpjNnL9XXP1YUZzR5IGEv7gAcZ4qCm9q0WwGACdB+rBK2jNxYAFwjQfaw4DLDEA9PhScYY71EqZ+UPFMmgnzVbcJYxw41kcJyl7cBgMujnzJ6NCs4wmCwIICgZNEBQAjRAUAI0QFACND3NPvEJoZgkBAhKBg0QlAANEJQADRCUAA0QlAANEJQADRCUAA0QlAANEJQADRCUAA0Q1CoB2jMieLufj3b+Op7FARDUKhk0rKIli65tIwsPRAad17Ncvg1eOcO/xJ1GCuoY5cWdtLfFGeKAuPaCs+GIlxOgj5HNEEUuuxawX8YlFOgHBKVhAj1ss3cxpRMBGiAoY9AAQQnQROOW5fs8Vc7qt5EhDmAWtXj1yhvCZNDzWDHrWPEzv1WPuqwF59/K69OSQRPBXjvUTlmSDJoI9oJv7vWzGdkdWbnMny5mDNClxj+iU4zcp058zZm76O7KxGX7/czcTy4f+5MBOnfwLTP4pcY/olP8fvo3kN/k58xGncCO7rcUeNP99H5CoRUn561QbpfbW61hPx1AIhwDMZxpC2dn9b/vlb7n9u85uX9DnfLasc2g927VvPuMd/VBMLXs5mfn9SiiH1/OmWPO1UePW4fTgJobXipl2em/zQXgdOXASsFm5KoM/ifaGayUvfTer+cGjHe0Dkt10jJ8kW7/ybxWy4hzmXEtQZhtxcmoK5Cea48jltsozeUWtVBGHlfpMY0Ry+EtSg0y/fuRrOxqfbW2gzSA732GnscUeQhyq/V4RiVgM2oqgxkLqnbZWepMpWyppTNwXC1o5TLR2rju0fdtech9Kas+u5/v/38a/l0k2nxwozPVz8D9t7537vccZ/brasHv7GV2LcivVld3tM9cMnO0Hs8Mb0Xuf48d18hldpFuvUyXtv0Wfv+aZRIxmtqEWWtbaB3r3Z4Izkwg3+ns+6WTmiP6097VS3qV01LupWGg3pPAuX2N8FgcG3VmmOFMuJdNr+LObDRqu4jozrKqvVd6Bdprkv2Nc0Hdj3/FS8Xc5dTsDQOuqg0L3t03ovTHXiek08N7UQriKS2TWbmMe+Uyg9W1XHF8XYoVqwfoVGmFQS7j3m4Tgbqcm/rjLxrFeIZUgFMEipjUCyAQTCDicApwAwH6fsocaCJYAAQ14zeqACxBgAYISoAGCEqABghKgAYISoAGCEqABghKgAYISoAGCEqABghKgAYISoAGCEqABghKgAYISoAGCEqABghKgAYIyvfdAQDAEf8Fhc/BKQcePW8AAAAASUVORK5CYII="></image>
+  </g>
+</svg>

--- a/test/plots/raster-vapor.ts
+++ b/test/plots/raster-vapor.ts
@@ -61,6 +61,24 @@ export async function contourVapor() {
   });
 }
 
+export async function rasterVaporP3() {
+  return Plot.plot({
+    x: {transform: (x) => x - 180},
+    y: {transform: (y) => 90 - y},
+    color: {
+      type: "sqrt",
+      interpolate: (t: number) => `oklch(50% 0.25 ${220 + t * 140}deg)`
+    },
+    marks: [
+      Plot.raster(await vapor(), {
+        width: 360,
+        height: 180,
+        colorSpace: "display-p3"
+      })
+    ]
+  });
+}
+
 export async function rasterVaporPeters() {
   const radians = Math.PI / 180;
   const sin = (y) => Math.sin(y * radians);


### PR DESCRIPTION
Since we rely on the browser to parse CSS4, and to create a canvas, we can rely on it to also convert these colors to whatever color space it supports.

Maybe this is a hack—or maybe it's the only correct way.

If it's the correct way, maybe we can apply this technique to _also_ support CSS4 colors in the sRGB color space, instead of relying on d3.rgb.

