### PR TITLE
horizontal↔︎ and vertical︎↕︎

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -18,6 +18,16 @@
   --vp-code-line-height: 1.5;
 }
 
+.emoji-horizontal::after {
+  content: "↔︎";
+  font-family: var(--vp-font-family-mono);
+}
+
+.emoji-vertical::after {
+  content: "↕︎";
+  font-family: var(--vp-font-family-mono);
+}
+
 .dark {
   --theme-phosphate: #37d5be;
   --theme-phosphate-2: #28b39e;

--- a/docs/features/facets.md
+++ b/docs/features/facets.md
@@ -23,9 +23,9 @@ onMounted(() => {
 
 # Facets
 
-Faceting partitions data by ordinal or categorical value and then repeats a plot for each partition (each **facet**), producing [small multiples](https://en.wikipedia.org/wiki/Small_multiple) for comparison. Faceting is typically enabled by declaring the horizontal↔︎ facet channel **fx**, the vertical↕︎ facet channel **fy**, or both for two-dimensional faceting.
+Faceting partitions data by ordinal or categorical value and then repeats a plot for each partition (each **facet**), producing [small multiples](https://en.wikipedia.org/wiki/Small_multiple) for comparison. Faceting is typically enabled by declaring the <span class="emoji-horizontal">horizontal</span> facet channel **fx**, the <span class="emoji-vertical">vertical</span> facet channel **fy**, or both for two-dimensional faceting.
 
-For example, below we recreate the Trellis display (“reminiscent of garden trelliswork”) of [Becker *et al.*](https://hci.stanford.edu/courses/cs448b/papers/becker-trellis-jcgs.pdf) using the dot’s **fy** channel to declare vertical↕︎ facets, showing the yields of several varieties of barley across several sites for the years <span :style="{borderBottom: `solid 2px ${scheme[0]}`}">1931</span> and <span :style="{borderBottom: `solid 2px ${scheme[1]}`}">1932</span>.
+For example, below we recreate the Trellis display (“reminiscent of garden trelliswork”) of [Becker *et al.*](https://hci.stanford.edu/courses/cs448b/papers/becker-trellis-jcgs.pdf) using the dot’s **fy** channel to declare <span class="emoji-vertical">vertical</span> facets, showing the yields of several varieties of barley across several sites for the years <span :style="{borderBottom: `solid 2px ${scheme[0]}`}">1931</span> and <span :style="{borderBottom: `solid 2px ${scheme[1]}`}">1932</span>.
 
 :::plot https://observablehq.com/@observablehq/plot-trellis
 ```js
@@ -116,7 +116,7 @@ Plot.plot({
 If you are interested in automatic faceting for quantitative data, please upvote [#14](https://github.com/observablehq/plot/issues/14).
 :::
 
-When both **fx** and **fy** channels are specified, two-dimensional faceting results, as in the faceted scatterplot of penguin culmen measurements below. The horizontal↔︎ facet shows sex (with the rightmost column representing penguins whose *sex* field is null, indicating missing data), while the vertical↕︎ facet shows species.
+When both **fx** and **fy** channels are specified, two-dimensional faceting results, as in the faceted scatterplot of penguin culmen measurements below. The <span class="emoji-horizontal">horizontal</span> facet shows sex (with the rightmost column representing penguins whose *sex* field is null, indicating missing data), while the <span class="emoji-vertical">vertical</span> facet shows species.
 
 :::plot defer https://observablehq.com/@observablehq/plot-two-dimensional-faceting
 ```js
@@ -293,8 +293,8 @@ Plot.plot({
 For top-level faceting, these **facet** options determine the facets:
 
 * **data** - the data to be faceted
-* **x** - the horizontal↔︎ position; bound to the *fx* scale
-* **y** - the vertical↕︎ position; bound to the *fy* scale
+* **x** - the <span class="emoji-horizontal">horizontal</span> position; bound to the *fx* scale
+* **y** - the <span class="emoji-vertical">vertical</span> position; bound to the *fy* scale
 
 With top-level faceting, any mark that uses the specified facet data will be faceted by default, whereas marks that use different data will be repeated across all facets. Use the mark **facet** option to change the behavior.
 
@@ -302,7 +302,7 @@ With top-level faceting, any mark that uses the specified facet data will be fac
 
 When faceting, two additional [band scales](./scales.md#discrete-scales) may be configured:
 
-* *fx* - the horizontal↔︎ position, a *band* scale
-* *fy* - the vertical↕︎ position, a *band* scale
+* *fx* - the <span class="emoji-horizontal">horizontal</span> position, a *band* scale
+* *fy* - the <span class="emoji-vertical">vertical</span> position, a *band* scale
 
 You can adjust the space between facets using the **padding**, **round**, and **align** scale options.

--- a/docs/features/interactions.md
+++ b/docs/features/interactions.md
@@ -37,7 +37,7 @@ Plot.dot(olympians, {
 ```
 :::
 
-The [crosshair mark](../interactions/crosshair.md) uses the pointer transform internally to display a [rule](../marks/rule.md) and a [text](../marks/text.md) showing the **x** (horizontal↔︎ position) and **y** (vertical↕︎ position) value of the nearest data.
+The [crosshair mark](../interactions/crosshair.md) uses the pointer transform internally to display a [rule](../marks/rule.md) and a [text](../marks/text.md) showing the **x** (<span class="emoji-horizontal">horizontal</span> position) and **y** (<span class="emoji-vertical">vertical</span> position) value of the nearest data.
 
 :::plot defer https://observablehq.com/@observablehq/plot-crosshair
 ```js

--- a/docs/features/plots.md
+++ b/docs/features/plots.md
@@ -73,7 +73,7 @@ aapl = [
 Rather than baking data into JavaScript, use [JSON](https://en.wikipedia.org/wiki/JSON) or [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) files to store data. You can use [d3.json](https://d3js.org/d3-fetch#json), [d3.csv](https://d3js.org/d3-fetch#csv), or [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to load a file. On Observable, you can also use a [file attachment](https://observablehq.com/@observablehq/file-attachments) or [SQL cell](https://observablehq.com/@observablehq/sql-cell).
 :::
 
-To use data with Plot, pass the data as the first argument to the mark constructor. We can then assign columns of data such as *Date* and *Close* to visual properties of the mark (or “channels”) such as horizontal↔︎ position **x** and vertical↕︎ position **y**.
+To use data with Plot, pass the data as the first argument to the mark constructor. We can then assign columns of data such as *Date* and *Close* to visual properties of the mark (or “channels”) such as <span class="emoji-horizontal">horizontal</span> position **x** and <span class="emoji-vertical">vertical</span> position **y**.
 
 :::plot defer https://observablehq.com/@observablehq/plot-first-line-chart
 ```js

--- a/docs/features/scales.md
+++ b/docs/features/scales.md
@@ -39,7 +39,7 @@ onMounted(() => {
 | 1880-05-01 | -0.14   |
 | 1880-06-01 | -0.29   |
 
-When visualizing this data with a [line](../marks/line.md), the *x* scale is responsible for mapping dates to horizontal↔︎ positions. For example, 1880-01-01 might be mapped to *x* = 40 (on the left) and 2016-12-01 might be mapped to *x* = 620 (on the right). Likewise, the *y* scale maps temperature anomalies to vertical↕︎ positions.
+When visualizing this data with a [line](../marks/line.md), the *x* scale is responsible for mapping dates to <span class="emoji-horizontal">horizontal</span> positions. For example, 1880-01-01 might be mapped to *x* = 40 (on the left) and 2016-12-01 might be mapped to *x* = 620 (on the right). Likewise, the *y* scale maps temperature anomalies to <span class="emoji-vertical">vertical</span> positions.
 
 :::plot https://observablehq.com/@observablehq/plot-scales-intro
 ```js

--- a/docs/interactions/crosshair.md
+++ b/docs/interactions/crosshair.md
@@ -10,7 +10,7 @@ import penguins from "../data/penguins.ts";
 
 # Crosshair mark <VersionBadge version="0.6.7" />
 
-The **crosshair mark** shows the *x* (horizontal↔︎ position) and *y* (vertical↕︎ position) value of the point closest to the [pointer](./pointer.md) on the bottom and left sides of the frame, respectively.
+The **crosshair mark** shows the *x* (<span class="emoji-horizontal">horizontal</span> position) and *y* (<span class="emoji-vertical">vertical</span> position) value of the point closest to the [pointer](./pointer.md) on the bottom and left sides of the frame, respectively.
 
 :::plot defer https://observablehq.com/@observablehq/plot-crosshair
 ```js

--- a/docs/interactions/pointer.md
+++ b/docs/interactions/pointer.md
@@ -167,14 +167,14 @@ plot.addEventListener("input", (event) => {
 
 The following options control the pointer transform:
 
-- **px** - the horizontal↔︎ target position; bound to the *x* scale
-- **py** - the vertical↕︎ target position; bound to the *y* scale
-- **x** - the fallback horizontal↔︎ target position; bound to the *x* scale
-- **y** - the fallback vertical↕︎ target position; bound to the *y* scale
-- **x1** - the starting horizontal↔︎ target position; bound to the *x* scale
-- **y1** - the starting vertical↕︎ target position; bound to the *y* scale
-- **x2** - the ending horizontal↔︎ target position; bound to the *x* scale
-- **y2** - the ending vertical↕︎ target position; bound to the *y* scale
+- **px** - the <span class="emoji-horizontal">horizontal</span> target position; bound to the *x* scale
+- **py** - the <span class="emoji-vertical">vertical</span> target position; bound to the *y* scale
+- **x** - the fallback <span class="emoji-horizontal">horizontal</span> target position; bound to the *x* scale
+- **y** - the fallback <span class="emoji-vertical">vertical</span> target position; bound to the *y* scale
+- **x1** - the starting <span class="emoji-horizontal">horizontal</span> target position; bound to the *x* scale
+- **y1** - the starting <span class="emoji-vertical">vertical</span> target position; bound to the *y* scale
+- **x2** - the ending <span class="emoji-horizontal">horizontal</span> target position; bound to the *x* scale
+- **y2** - the ending <span class="emoji-vertical">vertical</span> target position; bound to the *y* scale
 - **maxRadius** - the reach, or maximum distance, in pixels; defaults to 40
 - **frameAnchor** - how to position the target within the frame; defaults to *middle*
 
@@ -202,7 +202,7 @@ Applies the pointer render transform to the specified *options* to filter the ma
 Plot.tip(aapl, Plot.pointerX({x: "Date", y: "Close"}))
 ```
 
-Like [pointer](#pointer), except the determination of the closest point considers mostly the *x* (horizontal↔︎) position; this should be used for plots where *x* is the dominant dimension, such as time in a time-series chart, the binned quantitative dimension in a histogram, or the categorical dimension of a bar chart.
+Like [pointer](#pointer), except the determination of the closest point considers mostly the *x* (<span class="emoji-horizontal">horizontal</span>) position; this should be used for plots where *x* is the dominant dimension, such as time in a time-series chart, the binned quantitative dimension in a histogram, or the categorical dimension of a bar chart.
 
 ## pointerY(*options*) {#pointerY}
 
@@ -210,4 +210,4 @@ Like [pointer](#pointer), except the determination of the closest point consider
 Plot.tip(alphabet, Plot.pointerY({x: "frequency", y: "letter"}))
 ```
 
-Like [pointer](#pointer), except the determination of the closest point considers mostly the *y* (vertical↕︎) position; this should be used for plots where *y* is the dominant dimension, such as time in a time-series chart, the binned quantitative dimension in a histogram, or the categorical dimension of a bar chart.
+Like [pointer](#pointer), except the determination of the closest point considers mostly the *y* (<span class="emoji-vertical">vertical</span>) position; this should be used for plots where *y* is the dominant dimension, such as time in a time-series chart, the binned quantitative dimension in a histogram, or the categorical dimension of a bar chart.

--- a/docs/marks/rule.md
+++ b/docs/marks/rule.md
@@ -22,7 +22,7 @@ onMounted(() => {
 The rule mark is one of two marks in Plot for drawing horizontal or vertical lines; it should be used when the secondary position dimension, if any, is quantitative. When it is ordinal, use a [tick](./tick.md).
 :::
 
-The **rule mark** comes in two orientations: [ruleY](#ruleY) draws a horizontal↔︎ line with a given *y* value, while [ruleX](#ruleX) draws a vertical↕︎ line with a given *x* value. Rules are often used as annotations, say to mark the *y* = 0 baseline (in red below for emphasis) in a line chart.
+The **rule mark** comes in two orientations: [ruleY](#ruleY) draws a <span class="emoji-horizontal">horizontal</span> line with a given *y* value, while [ruleX](#ruleX) draws a <span class="emoji-vertical">vertical</span> line with a given *x* value. Rules are often used as annotations, say to mark the *y* = 0 baseline (in red below for emphasis) in a line chart.
 
 :::plot https://observablehq.com/@observablehq/plot-rule-zero
 ```js
@@ -165,7 +165,7 @@ Plot.ruleX([0]) // as annotation
 Plot.ruleX(alphabet, {x: "letter", y: "frequency"}) // like barY
 ```
 
-Returns a new vertical↕︎ rule with the given *data* and *options*. The following channels are optional:
+Returns a new <span class="emoji-vertical">vertical</span> rule with the given *data* and *options*. The following channels are optional:
 
 * **x** - the horizontal position; bound to the *x* scale
 * **y1** - the starting vertical position; bound to the *y* scale
@@ -186,7 +186,7 @@ Plot.ruleY([0]) // as annotation
 Plot.ruleY(alphabet, {y: "letter", x: "frequency"}) // like barX
 ```
 
-Returns a new horizontal↔︎ rule with the given *data* and *options*. The following channels are optional:
+Returns a new <span class="emoji-horizontal">horizontal</span> rule with the given *data* and *options*. The following channels are optional:
 
 * **y** - the vertical position; bound to the *y* scale
 * **x1** - the starting horizontal position; bound to the *x* scale

--- a/docs/marks/tick.md
+++ b/docs/marks/tick.md
@@ -23,7 +23,7 @@ onMounted(() => {
 The tick mark is one of two marks in Plot for drawing horizontal or vertical lines; it should be used when the secondary position dimension, if any, is ordinal. When it is quantitative, use a [rule](./rule.md).
 :::
 
-The **tick mark** comes in two orientations: [tickY](#tickY) draws a horizontal↔︎ line with a given *y* value, while [tickX](#tickX) draws a vertical↕︎ line with a given *x* value. Ticks have an optional secondary position dimension (**x** for tickY and **y** for tickX); this second dimension is ordinal, unlike a [rule](./rule.md), and requires a corresponding [band scale](../features/scales.md).
+The **tick mark** comes in two orientations: [tickY](#tickY) draws a <span class="emoji-horizontal">horizontal</span> line with a given *y* value, while [tickX](#tickX) draws a <span class="emoji-vertical">vertical</span> line with a given *x* value. Ticks have an optional secondary position dimension (**x** for tickY and **y** for tickX); this second dimension is ordinal, unlike a [rule](./rule.md), and requires a corresponding [band scale](../features/scales.md).
 
 Ticks are often used to show one-dimensional distributions, as in the “barcode” plot below showing the proportion of the population in each age bracket across U.S. states.
 
@@ -94,7 +94,7 @@ For the required channels, see [tickX](#tickX) and [tickY](#tickY). The tick mar
 Plot.tickX(stateage, {x: "population", y: "age"})
 ```
 
-Returns a new vertical↕︎ tick with the given *data* and *options*. The following channels are required:
+Returns a new <span class="emoji-vertical">vertical</span> tick with the given *data* and *options*. The following channels are required:
 
 * **x** - the horizontal position; bound to the *x* scale
 
@@ -110,7 +110,7 @@ If the **y** channel is not specified, the tick will span the full vertical exte
 Plot.tickY(stateage, {y: "population", x: "age"})
 ```
 
-Returns a new horizontal↔︎ tick with the given *data* and *options*. The following channels are required:
+Returns a new <span class="emoji-horizontal">horizontal</span> tick with the given *data* and *options*. The following channels are required:
 
 * **y** - the vertical position; bound to the *y* scale
 

--- a/docs/marks/tip.md
+++ b/docs/marks/tip.md
@@ -208,8 +208,8 @@ When multiple tips are visible simultaneously, some may collide; consider using 
 
 The following position options are supported:
 
-- **x**, **x1**, or **x2** - the horizontal↔︎ position channel
-- **y**, **y1**, or **y2** - the vertical↕︎ position channel
+- **x**, **x1**, or **x2** - the <span class="emoji-horizontal">horizontal</span> position channel
+- **y**, **y1**, or **y2** - the <span class="emoji-vertical">vertical</span> position channel
 - **frameAnchor** - fallback position if *x* or *y* are otherwise unspecified
 
 To resolve the anchor position, the tip mark applies the following order of precedence:

--- a/docs/transforms/dodge.md
+++ b/docs/transforms/dodge.md
@@ -48,7 +48,7 @@ Plot.plot({
 ```
 :::
 
-The dodge transform works with Plot’s [faceting system](../features/facets.md), allowing independent beeswarm plots on discrete partitions of the data. Below, penguins are grouped by species and colored by sex, while vertical↕︎ position (**y**) encodes body mass.
+The dodge transform works with Plot’s [faceting system](../features/facets.md), allowing independent beeswarm plots on discrete partitions of the data. Below, penguins are grouped by species and colored by sex, while <span class="emoji-vertical">vertical</span> position (**y**) encodes body mass.
 
 :::plot defer https://observablehq.com/@observablehq/plot-dodge-penguins
 ```js

--- a/docs/transforms/interval.md
+++ b/docs/transforms/interval.md
@@ -60,7 +60,7 @@ Plot.plot({
 The interval transform is not a standalone transform, but an option on marks and scales.
 :::
 
-The meaning of the **interval** mark option depends on the associated mark, such as line, bar, rect, or dot. For example, for the [barY mark](../marks/bar.md), the **interval** option affects converts a singular *y* value into an interval [*y1*, *y2*]. In the contrived example below, notice that the vertical↕︎ extent of each bar spans an interval of 5 million, rather than extending to *y* = 0.
+The meaning of the **interval** mark option depends on the associated mark, such as line, bar, rect, or dot. For example, for the [barY mark](../marks/bar.md), the **interval** option affects converts a singular *y* value into an interval [*y1*, *y2*]. In the contrived example below, notice that the <span class="emoji-vertical">vertical</span> extent of each bar spans an interval of 5 million, rather than extending to *y* = 0.
 
 :::plot https://observablehq.com/@observablehq/plot-interval-bars
 ```js


### PR DESCRIPTION
closes #2146

(and it's also probably better for screen readers?)

| before | after |
| - | - |
| ![before](https://github.com/user-attachments/assets/1080df4d-3e1c-403f-a714-43f4c3aa803e) | ![after](https://github.com/user-attachments/assets/31b3d9fe-45d4-44ae-90fc-c822676a93a2) |
