### PR TITLE
monochrome code

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -8,13 +8,14 @@
   --theme-phosphate-3: #26c1ad;
   --theme-phosphate-soft: #d7fbf7;
   --vp-c-brand-1: var(--theme-phosphate); /* link and brand color */
-  --vp-c-brand-2: var(--theme-phosphate-2); 
+  --vp-c-brand-2: var(--theme-phosphate-2);
   --vp-c-brand-3: var(--theme-phosphate-3);
   --hero-brand-contrast: rgb(243, 139, 233); /* home page alt color */
   --vp-c-brand-soft: var(--theme-phosphate-soft);
   --mono-heading: "Spline Sans Mono", monospace;
   --vp-font-family-mono: var(--mono-heading);
   --vp-font-family-base: Inter, -apple-system, BlinkMacSystemFont, "avenir next", avenir, helvetica, "helvetica neue", ubuntu, roboto, noto, "segoe ui", arial, sans-serif;
+  --vp-code-color: inherit;
   --vp-code-font-size: 14px;
   --vp-code-line-height: 1.5;
 }


### PR DESCRIPTION
The phosphate code feels a little “needy” to me — it doesn’t need to be that prominent.

Before:
<img width="1624" alt="Screenshot 2024-08-25 at 9 58 06 PM" src="https://github.com/user-attachments/assets/2a05b8b3-e388-4b54-acac-0dfaf95a7a01">

After:
<img width="1624" alt="Screenshot 2024-08-25 at 9 57 54 PM" src="https://github.com/user-attachments/assets/9d9a2b72-bcac-48c2-aa94-634fb2d37e59">
