### PR TITLE
axis marks’ ariaLabel option

### DIFF
--- a/src/marks/axis.js
+++ b/src/marks/axis.js
@@ -89,6 +89,7 @@ function axisKy(
     labelAnchor,
     labelArrow,
     labelOffset,
+    ariaLabel = `${k}-axis`,
     ...options
   }
 ) {
@@ -107,6 +108,7 @@ function axisKy(
           tickPadding,
           tickRotate,
           x,
+          ariaLabel,
           ...options
         })
       : null,
@@ -126,6 +128,7 @@ function axisKy(
           marginRight,
           marginBottom,
           marginLeft,
+          ariaLabel,
           ...options
         })
       : null,
@@ -150,7 +153,7 @@ function axisKy(
             }
             this.dy = cla === "top" ? 3 - marginTop : cla === "bottom" ? marginBottom - 3 : 0;
             this.dx = anchor === "right" ? clo : -clo;
-            this.ariaLabel = `${k}-axis label`;
+            this.ariaLabel = `${ariaLabel} label`;
             return {
               facets: [[0]],
               channels: {text: {value: [formatAxisLabel(k, scale, {anchor, label, labelAnchor: cla, labelArrow})]}}
@@ -190,6 +193,7 @@ function axisKx(
     labelAnchor,
     labelArrow,
     labelOffset,
+    ariaLabel = `${k}-axis`,
     ...options
   }
 ) {
@@ -208,6 +212,7 @@ function axisKx(
           tickPadding,
           tickRotate,
           y,
+          ariaLabel,
           ...options
         })
       : null,
@@ -227,6 +232,7 @@ function axisKx(
           marginRight,
           marginBottom,
           marginLeft,
+          ariaLabel,
           ...options
         })
       : null,
@@ -248,7 +254,7 @@ function axisKx(
             this.lineAnchor = anchor;
             this.dy = anchor === "top" ? -clo : clo;
             this.dx = cla === "right" ? marginRight - 3 : cla === "left" ? 3 - marginLeft : 0;
-            this.ariaLabel = `${k}-axis label`;
+            this.ariaLabel = `${ariaLabel} label`;
             return {
               facets: [[0]],
               channels: {text: {value: [formatAxisLabel(k, scale, {anchor, label, labelAnchor: cla, labelArrow})]}}
@@ -275,6 +281,7 @@ function axisTickKy(
     insetRight = inset,
     dx = 0,
     y = k === "y" ? undefined : null,
+    ariaLabel,
     ...options
   }
 ) {
@@ -283,7 +290,7 @@ function axisTickKy(
     k,
     data,
     {
-      ariaLabel: `${k}-axis tick`,
+      ariaLabel: `${ariaLabel} tick`,
       ariaHidden: true
     },
     {
@@ -318,6 +325,7 @@ function axisTickKx(
     insetBottom = inset,
     dy = 0,
     x = k === "x" ? undefined : null,
+    ariaLabel,
     ...options
   }
 ) {
@@ -326,7 +334,7 @@ function axisTickKx(
     k,
     data,
     {
-      ariaLabel: `${k}-axis tick`,
+      ariaLabel: `${ariaLabel} tick`,
       ariaHidden: true
     },
     {
@@ -363,6 +371,7 @@ function axisTextKy(
     insetLeft = inset,
     insetRight = inset,
     dx = 0,
+    ariaLabel,
     y = k === "y" ? undefined : null,
     ...options
   }
@@ -371,7 +380,7 @@ function axisTextKy(
     textY,
     k,
     data,
-    {ariaLabel: `${k}-axis tick label`},
+    {ariaLabel: `${ariaLabel} tick label`},
     {
       facetAnchor,
       frameAnchor,
@@ -410,6 +419,7 @@ function axisTextKx(
     insetBottom = inset,
     dy = 0,
     x = k === "x" ? undefined : null,
+    ariaLabel,
     ...options
   }
 ) {
@@ -417,7 +427,7 @@ function axisTextKx(
     textX,
     k,
     data,
-    {ariaLabel: `${k}-axis tick label`},
+    {ariaLabel: `${ariaLabel} tick label`},
     {
       facetAnchor,
       frameAnchor,
@@ -466,10 +476,12 @@ function gridKy(
     x = null,
     x1 = anchor === "left" ? x : null,
     x2 = anchor === "right" ? x : null,
+    ariaLabel = `${k}-grid`,
+    ariaHidden = true,
     ...options
   }
 ) {
-  return axisMark(ruleY, k, data, {ariaLabel: `${k}-grid`, ariaHidden: true}, {y, x1, x2, ...gridDefaults(options)});
+  return axisMark(ruleY, k, data, {ariaLabel, ariaHidden}, {y, x1, x2, ...gridDefaults(options)});
 }
 
 function gridKx(
@@ -481,10 +493,12 @@ function gridKx(
     y = null,
     y1 = anchor === "top" ? y : null,
     y2 = anchor === "bottom" ? y : null,
+    ariaLabel = `${k}-grid`,
+    ariaHidden = true,
     ...options
   }
 ) {
-  return axisMark(ruleX, k, data, {ariaLabel: `${k}-grid`, ariaHidden: true}, {x, y1, y2, ...gridDefaults(options)});
+  return axisMark(ruleX, k, data, {ariaLabel, ariaHidden}, {x, y1, y2, ...gridDefaults(options)});
 }
 
 function gridDefaults({


### PR DESCRIPTION
Fix the **ariaLabel** option on the axis mark.

Including a realistic use case where we don't want the aria-label of the custom mark to be "axis-x", otherwise Plot skips the implicit axis.

https://github.com/user-attachments/assets/1804ea6b-628e-41d6-872e-5f21a86a7947

The test chart — a continuous “crosshair-x” — is not necessarily what I would recommend to use (maybe I'd anchor the new mark at the top, or I would fade out the axis mark when hovering…), but it's a nice way to see how things overlap—and consistent with what the crosshair mark does.


[Note that this is not enough to solve the continuous crosshair issue (#1629); visually OK if  you add these two marks in x and y, but the Plot's _value_ on the dispatched input event is either x or y — what we want is (x, y).]
