### PR TITLE
filterFacets is a private method of context

### DIFF
--- a/src/marks/axis.js
+++ b/src/marks/axis.js
@@ -632,7 +632,7 @@ function axisMark(mark, k, data, properties, options, initialize) {
         return [name, {...channel, value: valueof(data, channel.value)}];
       })
     );
-    if (initializeFacets) facets = context.filterFacets(data, initializedChannels);
+    if (initializeFacets) facets = context._filterFacets(data, initializedChannels);
     return {data, facets, channels: initializedChannels};
   }
 

--- a/src/plot.js
+++ b/src/plot.js
@@ -160,7 +160,7 @@ export function plot(options = {}) {
   context.projection = createProjection(options, subdimensions);
 
   // Allows e.g. the axis mark to determine faceting lazily.
-  context.filterFacets = (data, channels) => {
+  context._filterFacets = (data, channels) => {
     return facetFilter(facets, {channels, groups: facetGroups(data, channels)});
   };
 


### PR DESCRIPTION
I believe this is not usable outside of the axis mark, and we won't document it as being part of the API (#1811). So let's reinforce that with the customary `_` prefix.