### PR TITLE
fix build error with missing Event

### DIFF
--- a/docs/components/PlotRender.js
+++ b/docs/components/PlotRender.js
@@ -1,9 +1,12 @@
 import * as Plot from "@observablehq/plot";
 import {h, withDirectives} from "vue";
 
+class Event {}
+
 class Document {
   constructor() {
     this.documentElement = new Element(this, "html");
+    this.defaultView = {Event};
   }
   createElementNS(namespace, tagName) {
     return new Element(this, tagName);


### PR DESCRIPTION
#2169 has introduced an error when building the documentation site; this routes around it. I haven't seen a difference in the public-facing result.

(I had mentioned the potential issue here but not seen where it would happen https://github.com/observablehq/plot/pull/2169#discussion_r1755497591)

```
TypeError: Cannot read properties of undefined (reading 'Event')
    at context.dispatchValue (file:///Users/fil/Source/plot/docs/.vitepress/.temp/index.C4JK4Fq9.js:6179:59)
    at render2 (file:///Users/fil/Source/plot/docs/.vitepress/.temp/index.C4JK4Fq9.js:3542:19)
    at Tip.<anonymous> (file:///Users/fil/Source/plot/docs/.vitepress/.temp/index.C4JK4Fq9.js:3583:14)
    at Tip.render (file:///Users/fil/Source/plot/docs/.vitepress/.temp/index.C4JK4Fq9.js:3329:15)
    at Module.plot (file:///Users/fil/Source/plot/docs/.vitepress/.temp/index.C4JK4Fq9.js:6254:25)
    at Proxy.render (file:///Users/fil/Source/plot/docs/.vitepress/.temp/PlotRender.Db8MMvNF.js:657:35)
    at renderComponentRoot (/Users/fil/Source/plot/node_modules/@vue/runtime-core/dist/runtime-core.cjs.prod.js:4892:16)
    at renderComponentSubTree (/Users/fil/Source/plot/node_modules/@vue/server-renderer/dist/server-renderer.cjs.prod.js:448:28)
    at renderComponentVNode (/Users/fil/Source/plot/node_modules/@vue/server-renderer/dist/server-renderer.cjs.prod.js:375:12)
    at ssrRenderComponent (/Users/fil/Source/plot/node_modules/@vue/server-renderer/dist/server-renderer.cjs.prod.js:84:10)
```