### PR TITLE
no ramp legend for continuous scales with a degenerate domain

### DIFF
--- a/src/legends.js
+++ b/src/legends.js
@@ -50,6 +50,7 @@ function legendColor(color, {legend = true, ...options}) {
     case "swatches":
       return legendSwatches(color, options);
     case "ramp":
+      if (color.domain.length < 2) return;
       return legendRamp(color, options);
     default:
       throw new Error(`unknown legend type: ${legend}`);

--- a/test/legend-test.js
+++ b/test/legend-test.js
@@ -6,6 +6,11 @@ it(`Plot.legend({color: {type: "identity"}}) returns undefined`, () => {
   assert.strictEqual(Plot.legend({color: {type: "identity"}}), undefined);
 });
 
+it(`Plot.legend({color: {domain: [x?]}}) returns undefined`, () => {
+  assert.strictEqual(Plot.legend({color: {domain: []}}), undefined);
+  assert.strictEqual(Plot.legend({color: {domain: [1]}}), undefined);
+});
+
 it(`Plot.legend({legend: "swatches", color: {type: "<not-ordinal>"}}) throws an error`, () => {
   assert.throws(() => Plot.legend({legend: "swatches", color: {type: "linear"}}), /swatches legend requires ordinal/);
   assert.throws(() => Plot.legend({legend: "swatches", color: {type: "linear"}}), /\(not linear\)/);


### PR DESCRIPTION
closes #2210

I considered an alternative where we would generate a ramp “from x to x” if there is 1 element, and “from NaN to NaN” if there is none. This would show the interpolator colors (like below).

However the bug report shows that we might be in a case where we normally expect an ordinal scale, but since the empty domain makes it impossible to automatically determine if we're ordinal or linear, the ramp is just a consequence of having defaulted to linear.

![Capture d’écran 2024-10-28 à 07 02 39](https://github.com/user-attachments/assets/2ba750d5-9a5b-42af-93d9-6696faed35b0)
![Capture d’écran 2024-10-28 à 07 02 26](https://github.com/user-attachments/assets/2e954464-72f3-4766-b66e-bd78ef7eb0a1)
