### PR TITLE
Fix facet positioning of a rendered rendered SVGSVGElement

### DIFF
--- a/docs/features/marks.md
+++ b/docs/features/marks.md
@@ -114,7 +114,7 @@ Plot.plot({
 ```
 :::
 
-Marks may also be a function which returns an SVG element, if you wish to insert arbitrary content. (Here we use [Hypertext Literal](https://github.com/observablehq/htl) to generate an SVG gradient.)
+Marks may also be a function which returns an [SVG element](https://developer.mozilla.org/en-US/docs/Web/SVG/Element), if you wish to insert arbitrary content. (Here we use [Hypertext Literal](https://github.com/observablehq/htl) to generate an SVG gradient.)
 
 :::plot defer https://observablehq.com/@observablehq/plot-gradient-bars
 ```js

--- a/src/facet.js
+++ b/src/facet.js
@@ -1,7 +1,6 @@
 import {InternMap, cross, rollup, sum} from "d3";
 import {keyof, map, range} from "./options.js";
 import {createScales} from "./scales.js";
-import {template} from "./template.js";
 
 // Returns an array of {x?, y?, i} objects representing the facet domain.
 export function createFacets(channelsByScale, options) {
@@ -66,12 +65,13 @@ export function facetGroups(data, {fx, fy}) {
 export function facetTranslator(fx, fy, {marginTop, marginLeft}) {
   const x = fx ? ({x}) => fx(x) - marginLeft : () => 0;
   const y = fy ? ({y}) => fy(y) - marginTop : () => 0;
-  const t = template`translate(${fx ? x : 0},${fy ? y : 0})`;
   return function (d) {
     if (this.tagName === "svg") {
       this.setAttribute("x", x(d));
       this.setAttribute("y", y(d));
-    } else this.setAttribute("transform", t(d));
+    } else {
+      this.setAttribute("transform", `translate(${x(d)},${y(d)})`);
+    }
   };
 }
 

--- a/src/facet.js
+++ b/src/facet.js
@@ -1,6 +1,7 @@
 import {InternMap, cross, rollup, sum} from "d3";
 import {keyof, map, range} from "./options.js";
 import {createScales} from "./scales.js";
+import {template} from "./template.js";
 
 // Returns an array of {x?, y?, i} objects representing the facet domain.
 export function createFacets(channelsByScale, options) {
@@ -63,11 +64,15 @@ export function facetGroups(data, {fx, fy}) {
 }
 
 export function facetTranslator(fx, fy, {marginTop, marginLeft}) {
-  return fx && fy
-    ? ({x, y}) => `translate(${fx(x) - marginLeft},${fy(y) - marginTop})`
-    : fx
-    ? ({x}) => `translate(${fx(x) - marginLeft},0)`
-    : ({y}) => `translate(0,${fy(y) - marginTop})`;
+  const x = fx ? ({x}) => fx(x) - marginLeft : () => 0;
+  const y = fy ? ({y}) => fy(y) - marginTop : () => 0;
+  const t = template`translate(${fx ? x : 0},${fy ? y : 0})`;
+  return function (d) {
+    if (this.tagName === "svg") {
+      this.setAttribute("x", x(d));
+      this.setAttribute("y", y(d));
+    } else this.setAttribute("transform", t(d));
+  };
 }
 
 // Returns an index that for each facet lists all the elements present in other

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,6 +1,6 @@
 import {creator, select} from "d3";
 import {createChannel, inferChannelScale} from "./channel.js";
-import {create, createContext} from "./context.js";
+import {createContext} from "./context.js";
 import {createDimensions} from "./dimensions.js";
 import {createFacets, recreateFacets, facetExclude, facetGroups, facetTranslator, facetFilter} from "./facet.js";
 import {pointer, pointerX, pointerY} from "./interactions/pointer.js";
@@ -284,7 +284,7 @@ export function plot(options = {}) {
         index = mark.filter(index, channels, values);
         if (index.length === 0) continue;
       }
-      const node = maybeWrapSVGElement(mark.render(index, scales, values, superdimensions, context), context);
+      const node = mark.render(index, scales, values, superdimensions, context);
       if (node == null) continue;
       svg.appendChild(node);
     }
@@ -303,7 +303,7 @@ export function plot(options = {}) {
           if (!faceted && index === indexes[0]) index = subarray(index); // copy before assigning fx, fy, fi
           (index.fx = f.x), (index.fy = f.y), (index.fi = f.i);
         }
-        const node = maybeWrapSVGElement(mark.render(index, scales, values, subdimensions, context), context);
+        const node = mark.render(index, scales, values, subdimensions, context);
         if (node == null) continue;
         // Lazily construct the shared group (to drop empty marks).
         (g ??= select(svg).append("g")).append(() => node).datum(f);
@@ -317,7 +317,7 @@ export function plot(options = {}) {
           }
         }
       }
-      g?.selectChildren().attr("transform", facetTranslate);
+      g?.selectChildren().each(facetTranslate);
     }
   }
 
@@ -737,18 +737,4 @@ function outerRange(scale) {
   let x2 = scale(domain[domain.length - 1]);
   if (x2 < x1) [x1, x2] = [x2, x1];
   return [x1, x2 + scale.bandwidth()];
-}
-
-// Wrap any SVGSVGElement in a SVGGElement, in order to support the transform
-// attribute required for faceting.
-function maybeWrapSVGElement(node, context) {
-  if (!node) return null;
-  if (node.nodeType === 1 && node.namespaceURI === "http://www.w3.org/2000/svg") {
-    if (node.tagName === "svg")
-      return create("svg:g", context)
-        .append(() => node)
-        .node().parentElement;
-    return node;
-  }
-  throw new Error(`Unsupported render ${node.tagName}`);
 }

--- a/test/output/nestedFacets.html
+++ b/test/output/nestedFacets.html
@@ -1,0 +1,1012 @@
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+      :where(.plot-ramp) {
+        display: block;
+        height: auto;
+        height: intrinsic;
+        max-width: 100%;
+        overflow: visible;
+      }
+
+      :where(.plot-ramp text) {
+        white-space: pre;
+      }
+    </style>
+    <g>
+      <rect x="0" y="18" width="79" height="10" fill="#4269d0"></rect>
+      <rect x="80" y="18" width="79" height="10" fill="#efb118"></rect>
+      <rect x="160" y="18" width="79" height="10" fill="#ff725c"></rect>
+    </g>
+    <g transform="translate(0,28)" fill="none" text-anchor="middle">
+      <g class="tick" opacity="1" transform="translate(40.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">IF</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(120.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">SI1</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(200.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">I1</text>
+      </g>
+    </g>
+    <text x="0" y="12" fill="currentColor" font-weight="bold">clarity</text>
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="480" viewBox="0 0 960 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+      :where(.plot) {
+        --plot-background: white;
+        display: block;
+        height: auto;
+        height: intrinsic;
+        max-width: 100%;
+      }
+
+      :where(.plot text),
+      :where(.plot tspan) {
+        white-space: pre;
+      }
+    </style>
+    <g aria-label="y-axis tick" aria-hidden="true" transform="translate(0,0.5)">
+      <g fill="none" stroke="currentColor" transform="translate(1,0)">
+        <path transform="translate(40,421.57894736842104)" d="M0,0L-6,0"></path>
+        <path transform="translate(40,384.7368421052632)" d="M0,0L-6,0"></path>
+        <path transform="translate(40,347.89473684210526)" d="M0,0L-6,0"></path>
+        <path transform="translate(40,311.0526315789474)" d="M0,0L-6,0"></path>
+        <path transform="translate(40,274.21052631578954)" d="M0,0L-6,0"></path>
+        <path transform="translate(40,237.36842105263165)" d="M0,0L-6,0"></path>
+        <path transform="translate(40,200.52631578947376)" d="M0,0L-6,0"></path>
+        <path transform="translate(40,163.68421052631584)" d="M0,0L-6,0"></path>
+        <path transform="translate(40,126.84210526315798)" d="M0,0L-6,0"></path>
+        <path transform="translate(40,90.0000000000001)" d="M0,0L-6,0"></path>
+      </g>
+    </g>
+    <g aria-label="y-axis tick label" transform="translate(-8.5,0.5)">
+      <g text-anchor="end" font-variant="tabular-nums" transform="translate(1,0)">
+        <text y="0.32em" transform="translate(40,421.57894736842104)">52</text>
+        <text y="0.32em" transform="translate(40,384.7368421052632)">54</text>
+        <text y="0.32em" transform="translate(40,347.89473684210526)">56</text>
+        <text y="0.32em" transform="translate(40,311.0526315789474)">58</text>
+        <text y="0.32em" transform="translate(40,274.21052631578954)">60</text>
+        <text y="0.32em" transform="translate(40,237.36842105263165)">62</text>
+        <text y="0.32em" transform="translate(40,200.52631578947376)">64</text>
+        <text y="0.32em" transform="translate(40,163.68421052631584)">66</text>
+        <text y="0.32em" transform="translate(40,126.84210526315798)">68</text>
+        <text y="0.32em" transform="translate(40,90.0000000000001)">70</text>
+      </g>
+    </g>
+    <g aria-label="y-axis label" transform="translate(-36.5,0.5)">
+      <text y="0.71em" transform="translate(41,237.5) rotate(-90)">depth →</text>
+    </g>
+    <g aria-label="fx-axis tick label" transform="translate(0.5,-8.5)">
+      <g transform="translate(1,0)">
+        <text transform="translate(179.5,35)">D</text>
+      </g>
+      <g transform="translate(311,0)">
+        <text transform="translate(179.5,35)">E</text>
+      </g>
+      <g transform="translate(621,0)">
+        <text transform="translate(179.5,35)">F</text>
+      </g>
+    </g>
+    <g aria-label="fx-axis label" transform="translate(0.5,-31.5)">
+      <text y="0.71em" transform="translate(490.5,35)">color</text>
+    </g>
+    <g aria-label="frame" transform="translate(0.5,0.5)">
+      <line stroke="currentColor" stroke-linecap="square" x1="40" x2="319" y1="35" y2="35" transform="translate(1,0)"></line>
+      <line stroke="currentColor" stroke-linecap="square" x1="40" x2="319" y1="35" y2="35" transform="translate(311,0)"></line>
+      <line stroke="currentColor" stroke-linecap="square" x1="40" x2="319" y1="35" y2="35" transform="translate(621,0)"></line>
+    </g>
+    <g>
+      <g transform="translate(1,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="339" height="480" viewBox="0 0 339 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <style>
+            :where(.plot) {
+              --plot-background: white;
+              display: block;
+              height: auto;
+              height: intrinsic;
+              max-width: 100%;
+            }
+
+            :where(.plot text),
+            :where(.plot tspan) {
+              white-space: pre;
+            }
+          </style>
+          <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
+            <g transform="translate(8,0)">
+              <text y="0.71em" transform="translate(62,440)">Fair</text>
+            </g>
+            <g transform="translate(63,0)">
+              <text y="0.71em" transform="translate(62,440)">Good</text>
+            </g>
+            <g transform="translate(118,0)">
+              <text y="0.71em" transform="translate(62,440)">Ideal</text>
+            </g>
+            <g transform="translate(173,0)">
+              <text y="0.71em" transform="translate(62,440)">Premium</text>
+            </g>
+            <g transform="translate(228,0)">
+              <text y="0.71em" transform="translate(62,440)">Very Good</text>
+            </g>
+          </g>
+          <g aria-label="fx-axis label" transform="translate(0.5,37.5)">
+            <text transform="translate(180,440)">cut</text>
+          </g>
+          <g aria-label="y-grid" aria-hidden="true" transform="translate(0,0.5)">
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+          </g>
+          <g aria-label="x-grid" aria-hidden="true" transform="translate(7,0)">
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+          </g>
+          <g aria-label="x-axis tick label" transform="translate(7,-8.5)">
+            <g transform="translate(8,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(63,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(118,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(173,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(228,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+          </g>
+          <g aria-label="x-axis label" text-anchor="start" transform="translate(-36.5,-15.5)">
+            <text y="0.71em" transform="translate(48,60)">clarity</text>
+          </g>
+          <g aria-label="frame" transform="translate(0.5,0.5)">
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(8,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(63,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(118,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(173,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(228,0)"></line>
+          </g>
+          <g aria-label="rule" transform="translate(7,0)">
+            <g stroke="currentColor" transform="translate(8,0)">
+              <line x1="56" x2="56" y1="209.73684210526324" y2="139.7368421052633"></line>
+              <line x1="70" x2="70" y1="187.63157894736844" y2="148.94736842105277"></line>
+              <line x1="42" x2="42" y1="265.00000000000006" y2="252.10526315789474"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(63,0)">
+              <line x1="56" x2="56" y1="233.68421052631578" y2="185.78947368421066"></line>
+              <line x1="42" x2="42" y1="314.7368421052633" y2="211.57894736842115"></line>
+              <line x1="70" x2="70" y1="329.47368421052636" y2="200.52631578947376"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(118,0)">
+              <line x1="56" x2="56" y1="276.0526315789474" y2="218.94736842105266"></line>
+              <line x1="42" x2="42" y1="277.8947368421054" y2="218.94736842105266"></line>
+              <line x1="70" x2="70" y1="263.15789473684214" y2="228.15789473684214"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(173,0)">
+              <line x1="56" x2="56" y1="309.2105263157895" y2="218.94736842105266"></line>
+              <line x1="70" x2="70" y1="242.89473684210526" y2="239.21052631578954"></line>
+              <line x1="42" x2="42" y1="274.21052631578954" y2="235.52631578947373"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(228,0)">
+              <line x1="56" x2="56" y1="318.42105263157896" y2="196.8421052631579"></line>
+              <line x1="42" x2="42" y1="292.63157894736844" y2="211.57894736842115"></line>
+              <line x1="70" x2="70" y1="279.7368421052631" y2="211.57894736842115"></line>
+            </g>
+          </g>
+          <g aria-label="bar">
+            <g transform="translate(8,0)">
+              <rect x="56" width="13" y="165.52631578947367" height="23.94736842105283" fill="#efb118"></rect>
+              <rect x="70" width="13" y="157.23684210526332" height="30.394736842105118" fill="#ff725c"></rect>
+              <rect x="42" width="13" y="257.6315789473684" height="6.447368421052772" fill="#4269d0"></rect>
+            </g>
+            <g transform="translate(63,0)">
+              <rect x="56" width="13" y="204.2105263157896" height="12.894736842105175" fill="#efb118"></rect>
+              <rect x="42" width="13" y="215.26315789473688" height="84.73684210526318" fill="#4269d0"></rect>
+              <rect x="70" width="13" y="204.67105263157893" height="113.75000000000014" fill="#ff725c"></rect>
+            </g>
+            <g transform="translate(118,0)">
+              <rect x="56" width="13" y="231.842105263158" height="18.421052631578902" fill="#efb118"></rect>
+              <rect x="42" width="13" y="235.52631578947373" height="22.10526315789477" fill="#4269d0"></rect>
+              <rect x="70" width="13" y="242.89473684210526" height="11.05263157894737" fill="#ff725c"></rect>
+            </g>
+            <g transform="translate(173,0)">
+              <rect x="56" width="13" y="233.68421052631578" height="31.7763157894737" fill="#efb118"></rect>
+              <rect x="70" width="13" y="239.21052631578954" height="2.3026315789473983" fill="#ff725c"></rect>
+              <rect x="42" width="13" y="245.19736842105263" height="23.486842105263094" fill="#4269d0"></rect>
+            </g>
+            <g transform="translate(228,0)">
+              <rect x="56" width="13" y="218.94736842105266" height="41.90789473684214" fill="#efb118"></rect>
+              <rect x="42" width="13" y="226.31578947368425" height="35.921052631578874" fill="#4269d0"></rect>
+              <rect x="70" width="13" y="211.57894736842115" height="34.99999999999994" fill="#ff725c"></rect>
+            </g>
+          </g>
+          <g aria-label="tick" transform="translate(0,0.5)">
+            <g stroke="currentColor" stroke-width="2" transform="translate(8,0)">
+              <line x1="56" x2="69" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="70" x2="83" y1="173.81578947368422" y2="173.81578947368422"></line>
+              <line x1="42" x2="55" y1="263.15789473684214" y2="263.15789473684214"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(63,0)">
+              <line x1="56" x2="69" y1="209.73684210526324" y2="209.73684210526324"></line>
+              <line x1="42" x2="55" y1="242.89473684210526" y2="242.89473684210526"></line>
+              <line x1="70" x2="83" y1="206.9736842105263" y2="206.9736842105263"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(118,0)">
+              <line x1="56" x2="69" y1="241.05263157894748" y2="241.05263157894748"></line>
+              <line x1="42" x2="55" y1="243.81578947368428" y2="243.81578947368428"></line>
+              <line x1="70" x2="83" y1="248.42105263157902" y2="248.42105263157902"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(173,0)">
+              <line x1="56" x2="69" y1="248.42105263157902" y2="248.42105263157902"></line>
+              <line x1="70" x2="83" y1="241.05263157894748" y2="241.05263157894748"></line>
+              <line x1="42" x2="55" y1="252.10526315789474" y2="252.10526315789474"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(228,0)">
+              <line x1="56" x2="69" y1="233.68421052631578" y2="233.68421052631578"></line>
+              <line x1="42" x2="55" y1="242.89473684210526" y2="242.89473684210526"></line>
+              <line x1="70" x2="83" y1="218.94736842105266" y2="218.94736842105266"></line>
+            </g>
+          </g>
+          <g aria-label="dot" transform="translate(7,0.5)">
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(8,0)">
+              <circle cx="56" cy="266.842105263158" r="3"></circle>
+              <circle cx="56" cy="78.94736842105284" r="3"></circle>
+              <circle cx="56" cy="226.31578947368425" r="3"></circle>
+              <circle cx="56" cy="355.2631578947368" r="3"></circle>
+              <circle cx="56" cy="417.89473684210526" r="3"></circle>
+              <circle cx="56" cy="357.1052631578948" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(63,0)">
+              <circle cx="56" cy="250.2631578947369" r="3"></circle>
+              <circle cx="56" cy="272.36842105263156" r="3"></circle>
+              <circle cx="56" cy="239.21052631578954" r="3"></circle>
+              <circle cx="56" cy="239.21052631578954" r="3"></circle>
+              <circle cx="56" cy="318.42105263157896" r="3"></circle>
+              <circle cx="56" cy="237.36842105263165" r="3"></circle>
+              <circle cx="56" cy="253.94736842105263" r="3"></circle>
+              <circle cx="56" cy="239.21052631578954" r="3"></circle>
+              <circle cx="56" cy="301.8421052631579" r="3"></circle>
+              <circle cx="56" cy="255.78947368421058" r="3"></circle>
+              <circle cx="56" cy="180.26315789473702" r="3"></circle>
+              <circle cx="56" cy="331.31578947368433" r="3"></circle>
+              <circle cx="56" cy="266.842105263158" r="3"></circle>
+              <circle cx="56" cy="239.21052631578954" r="3"></circle>
+              <circle cx="56" cy="272.36842105263156" r="3"></circle>
+              <circle cx="56" cy="266.842105263158" r="3"></circle>
+              <circle cx="56" cy="325.7894736842105" r="3"></circle>
+              <circle cx="56" cy="255.78947368421058" r="3"></circle>
+              <circle cx="56" cy="270.52631578947364" r="3"></circle>
+              <circle cx="56" cy="301.8421052631579" r="3"></circle>
+              <circle cx="56" cy="301.8421052631579" r="3"></circle>
+              <circle cx="56" cy="242.89473684210526" r="3"></circle>
+              <circle cx="56" cy="241.05263157894748" r="3"></circle>
+              <circle cx="56" cy="183.94736842105257" r="3"></circle>
+              <circle cx="56" cy="318.42105263157896" r="3"></circle>
+              <circle cx="56" cy="316.57894736842104" r="3"></circle>
+              <circle cx="56" cy="180.26315789473702" r="3"></circle>
+              <circle cx="56" cy="265.00000000000006" r="3"></circle>
+              <circle cx="56" cy="303.68421052631584" r="3"></circle>
+              <circle cx="56" cy="305.5263157894738" r="3"></circle>
+              <circle cx="56" cy="314.7368421052633" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="336.84210526315786" r="3"></circle>
+              <circle cx="56" cy="183.94736842105257" r="3"></circle>
+              <circle cx="56" cy="250.2631578947369" r="3"></circle>
+              <circle cx="56" cy="239.21052631578954" r="3"></circle>
+              <circle cx="56" cy="268.6842105263159" r="3"></circle>
+              <circle cx="56" cy="316.57894736842104" r="3"></circle>
+              <circle cx="56" cy="338.6842105263158" r="3"></circle>
+              <circle cx="56" cy="296.3157894736843" r="3"></circle>
+              <circle cx="56" cy="325.7894736842105" r="3"></circle>
+              <circle cx="56" cy="325.7894736842105" r="3"></circle>
+              <circle cx="56" cy="298.1578947368421" r="3"></circle>
+              <circle cx="56" cy="253.94736842105263" r="3"></circle>
+              <circle cx="56" cy="265.00000000000006" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="292.63157894736844" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="316.57894736842104" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="333.1578947368422" r="3"></circle>
+              <circle cx="56" cy="296.3157894736843" r="3"></circle>
+              <circle cx="56" cy="311.0526315789474" r="3"></circle>
+              <circle cx="56" cy="244.73684210526315" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(118,0)">
+              <circle cx="56" cy="279.7368421052631" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="283.42105263157896" r="3"></circle>
+              <circle cx="56" cy="283.42105263157896" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="283.42105263157896" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(173,0)">
+              <circle cx="70" cy="248.42105263157902" r="3"></circle>
+              <circle cx="70" cy="230.0000000000001" r="3"></circle>
+              <circle cx="70" cy="248.42105263157902" r="3"></circle>
+              <circle cx="70" cy="218.94736842105266" r="3"></circle>
+            </g>
+          </g>
+        </svg></g>
+      <g transform="translate(311,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="339" height="480" viewBox="0 0 339 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <style>
+            :where(.plot) {
+              --plot-background: white;
+              display: block;
+              height: auto;
+              height: intrinsic;
+              max-width: 100%;
+            }
+
+            :where(.plot text),
+            :where(.plot tspan) {
+              white-space: pre;
+            }
+          </style>
+          <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
+            <g transform="translate(8,0)">
+              <text y="0.71em" transform="translate(62,440)">Fair</text>
+            </g>
+            <g transform="translate(63,0)">
+              <text y="0.71em" transform="translate(62,440)">Good</text>
+            </g>
+            <g transform="translate(118,0)">
+              <text y="0.71em" transform="translate(62,440)">Ideal</text>
+            </g>
+            <g transform="translate(173,0)">
+              <text y="0.71em" transform="translate(62,440)">Premium</text>
+            </g>
+            <g transform="translate(228,0)">
+              <text y="0.71em" transform="translate(62,440)">Very Good</text>
+            </g>
+          </g>
+          <g aria-label="fx-axis label" transform="translate(0.5,37.5)">
+            <text transform="translate(180,440)">cut</text>
+          </g>
+          <g aria-label="y-grid" aria-hidden="true" transform="translate(0,0.5)">
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+          </g>
+          <g aria-label="x-grid" aria-hidden="true" transform="translate(7,0)">
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+          </g>
+          <g aria-label="x-axis tick label" transform="translate(7,-8.5)">
+            <g transform="translate(8,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(63,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(118,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(173,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(228,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+          </g>
+          <g aria-label="frame" transform="translate(0.5,0.5)">
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(8,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(63,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(118,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(173,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(228,0)"></line>
+          </g>
+          <g aria-label="rule" transform="translate(7,0)">
+            <g stroke="currentColor" transform="translate(8,0)">
+              <line x1="70" x2="70" y1="191.31578947368428" y2="137.89473684210523"></line>
+              <line x1="56" x2="56" y1="388.421052631579" y2="99.21052631578956"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(63,0)">
+              <line x1="56" x2="56" y1="248.42105263157902" y2="182.1052631578948"></line>
+              <line x1="70" x2="70" y1="331.31578947368433" y2="195.0000000000001"></line>
+              <line x1="42" x2="42" y1="316.57894736842104" y2="171.05263157894757"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(118,0)">
+              <line x1="56" x2="56" y1="272.36842105263156" y2="209.73684210526324"></line>
+              <line x1="42" x2="42" y1="272.36842105263156" y2="218.94736842105266"></line>
+              <line x1="70" x2="70" y1="248.42105263157902" y2="233.68421052631578"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(173,0)">
+              <line x1="56" x2="56" y1="309.2105263157895" y2="218.94736842105266"></line>
+              <line x1="70" x2="70" y1="300.00000000000006" y2="228.15789473684214"></line>
+              <line x1="42" x2="42" y1="292.63157894736844" y2="220.7894736842106"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(228,0)">
+              <line x1="56" x2="56" y1="312.8947368421053" y2="196.8421052631579"></line>
+              <line x1="70" x2="70" y1="303.68421052631584" y2="213.42105263157904"></line>
+              <line x1="42" x2="42" y1="312.8947368421053" y2="202.36842105263167"></line>
+            </g>
+          </g>
+          <g aria-label="bar">
+            <g transform="translate(8,0)">
+              <rect x="70" width="13" y="154.47368421052641" height="36.84210526315786" fill="#ff725c"></rect>
+              <rect x="56" width="13" y="172.89473684210532" height="110.52631578947364" fill="#efb118"></rect>
+            </g>
+            <g transform="translate(63,0)">
+              <rect x="56" width="13" y="204.2105263157896" height="18.42105263157893" fill="#efb118"></rect>
+              <rect x="70" width="13" y="202.36842105263167" height="114.21052631578937" fill="#ff725c"></rect>
+              <rect x="42" width="13" y="196.8421052631579" height="93.94736842105269" fill="#4269d0"></rect>
+            </g>
+            <g transform="translate(118,0)">
+              <rect x="56" width="13" y="233.68421052631578" height="16.578947368421126" fill="#efb118"></rect>
+              <rect x="42" width="13" y="233.68421052631578" height="17.500000000000057" fill="#4269d0"></rect>
+              <rect x="70" width="13" y="237.36842105263165" height="7.368421052631504" fill="#ff725c"></rect>
+            </g>
+            <g transform="translate(173,0)">
+              <rect x="56" width="13" y="232.30263157894746" height="36.38157894736844" fill="#efb118"></rect>
+              <rect x="70" width="13" y="247.03947368421058" height="22.565789473684163" fill="#ff725c"></rect>
+              <rect x="42" width="13" y="242.89473684210526" height="33.15789473684214" fill="#4269d0"></rect>
+            </g>
+            <g transform="translate(228,0)">
+              <rect x="56" width="13" y="217.10526315789477" height="38.68421052631581" fill="#efb118"></rect>
+              <rect x="70" width="13" y="228.6184210526316" height="37.30263157894737" fill="#ff725c"></rect>
+              <rect x="42" width="13" y="226.31578947368425" height="50.65789473684222" fill="#4269d0"></rect>
+            </g>
+          </g>
+          <g aria-label="tick" transform="translate(0,0.5)">
+            <g stroke="currentColor" stroke-width="2" transform="translate(8,0)">
+              <line x1="70" x2="83" y1="172.89473684210532" y2="172.89473684210532"></line>
+              <line x1="56" x2="69" y1="183.94736842105257" y2="183.94736842105257"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(63,0)">
+              <line x1="56" x2="69" y1="209.73684210526324" y2="209.73684210526324"></line>
+              <line x1="70" x2="83" y1="213.42105263157904" y2="213.42105263157904"></line>
+              <line x1="42" x2="55" y1="207.8947368421053" y2="207.8947368421053"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(118,0)">
+              <line x1="56" x2="69" y1="241.05263157894748" y2="241.05263157894748"></line>
+              <line x1="42" x2="55" y1="239.21052631578954" y2="239.21052631578954"></line>
+              <line x1="70" x2="83" y1="239.21052631578954" y2="239.21052631578954"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(173,0)">
+              <line x1="56" x2="69" y1="250.2631578947369" y2="250.2631578947369"></line>
+              <line x1="70" x2="83" y1="257.6315789473685" y2="257.6315789473685"></line>
+              <line x1="42" x2="55" y1="255.78947368421058" y2="255.78947368421058"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(228,0)">
+              <line x1="56" x2="69" y1="230.0000000000001" y2="230.0000000000001"></line>
+              <line x1="70" x2="83" y1="237.36842105263165" y2="237.36842105263165"></line>
+              <line x1="42" x2="55" y1="248.42105263157902" y2="248.42105263157902"></line>
+            </g>
+          </g>
+          <g aria-label="dot" transform="translate(7,0.5)">
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(8,0)">
+              <circle cx="70" cy="-61.05263157894723" r="3"></circle>
+              <circle cx="70" cy="307.3684210526316" r="3"></circle>
+              <circle cx="70" cy="276.0526315789474" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(63,0)">
+              <circle cx="56" cy="305.5263157894738" r="3"></circle>
+              <circle cx="56" cy="285.2631578947369" r="3"></circle>
+              <circle cx="56" cy="259.4736842105264" r="3"></circle>
+              <circle cx="56" cy="318.42105263157896" r="3"></circle>
+              <circle cx="56" cy="309.2105263157895" r="3"></circle>
+              <circle cx="56" cy="259.4736842105264" r="3"></circle>
+              <circle cx="56" cy="266.842105263158" r="3"></circle>
+              <circle cx="56" cy="305.5263157894738" r="3"></circle>
+              <circle cx="56" cy="261.31578947368416" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="277.8947368421054" r="3"></circle>
+              <circle cx="56" cy="277.8947368421054" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="270.52631578947364" r="3"></circle>
+              <circle cx="56" cy="257.6315789473685" r="3"></circle>
+              <circle cx="56" cy="266.842105263158" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="331.31578947368433" r="3"></circle>
+              <circle cx="56" cy="320.2631578947369" r="3"></circle>
+              <circle cx="56" cy="300.00000000000006" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="307.3684210526316" r="3"></circle>
+              <circle cx="56" cy="325.7894736842105" r="3"></circle>
+              <circle cx="56" cy="311.0526315789474" r="3"></circle>
+              <circle cx="56" cy="303.68421052631584" r="3"></circle>
+              <circle cx="56" cy="309.2105263157895" r="3"></circle>
+              <circle cx="56" cy="257.6315789473685" r="3"></circle>
+              <circle cx="56" cy="253.94736842105263" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="172.89473684210532" r="3"></circle>
+              <circle cx="56" cy="266.842105263158" r="3"></circle>
+              <circle cx="56" cy="250.2631578947369" r="3"></circle>
+              <circle cx="56" cy="294.47368421052636" r="3"></circle>
+              <circle cx="56" cy="301.8421052631579" r="3"></circle>
+              <circle cx="56" cy="265.00000000000006" r="3"></circle>
+              <circle cx="56" cy="298.1578947368421" r="3"></circle>
+              <circle cx="56" cy="294.47368421052636" r="3"></circle>
+              <circle cx="56" cy="263.15789473684214" r="3"></circle>
+              <circle cx="56" cy="283.42105263157896" r="3"></circle>
+              <circle cx="56" cy="270.52631578947364" r="3"></circle>
+              <circle cx="56" cy="263.15789473684214" r="3"></circle>
+              <circle cx="56" cy="172.89473684210532" r="3"></circle>
+              <circle cx="56" cy="335" r="3"></circle>
+              <circle cx="56" cy="322.1052631578948" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="325.7894736842105" r="3"></circle>
+              <circle cx="56" cy="314.7368421052633" r="3"></circle>
+              <circle cx="56" cy="301.8421052631579" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="322.1052631578948" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="250.2631578947369" r="3"></circle>
+              <circle cx="56" cy="255.78947368421058" r="3"></circle>
+              <circle cx="56" cy="277.8947368421054" r="3"></circle>
+              <circle cx="56" cy="314.7368421052633" r="3"></circle>
+              <circle cx="56" cy="305.5263157894738" r="3"></circle>
+              <circle cx="56" cy="320.2631578947369" r="3"></circle>
+              <circle cx="56" cy="259.4736842105264" r="3"></circle>
+              <circle cx="56" cy="303.68421052631584" r="3"></circle>
+              <circle cx="56" cy="165.52631578947367" r="3"></circle>
+              <circle cx="56" cy="288.9473684210526" r="3"></circle>
+              <circle cx="56" cy="266.842105263158" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(118,0)">
+              <circle cx="56" cy="290.7894736842106" r="3"></circle>
+              <circle cx="70" cy="257.6315789473685" r="3"></circle>
+              <circle cx="70" cy="218.94736842105266" r="3"></circle>
+              <circle cx="56" cy="294.47368421052636" r="3"></circle>
+              <circle cx="56" cy="290.7894736842106" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="294.47368421052636" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="277.8947368421054" r="3"></circle>
+              <circle cx="56" cy="296.3157894736843" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="70" cy="222.63157894736852" r="3"></circle>
+              <circle cx="56" cy="285.2631578947369" r="3"></circle>
+              <circle cx="70" cy="261.31578947368416" r="3"></circle>
+              <circle cx="70" cy="268.6842105263159" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="70" cy="211.57894736842115" r="3"></circle>
+              <circle cx="56" cy="279.7368421052631" r="3"></circle>
+              <circle cx="56" cy="290.7894736842106" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="277.8947368421054" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(173,0)">
+              <circle cx="70" cy="303.68421052631584" r="3"></circle>
+              <circle cx="70" cy="311.0526315789474" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(228,0)">
+              <circle cx="56" cy="316.57894736842104" r="3"></circle>
+            </g>
+          </g>
+        </svg></g>
+      <g transform="translate(621,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="339" height="480" viewBox="0 0 339 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <style>
+            :where(.plot) {
+              --plot-background: white;
+              display: block;
+              height: auto;
+              height: intrinsic;
+              max-width: 100%;
+            }
+
+            :where(.plot text),
+            :where(.plot tspan) {
+              white-space: pre;
+            }
+          </style>
+          <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
+            <g transform="translate(8,0)">
+              <text y="0.71em" transform="translate(62,440)">Fair</text>
+            </g>
+            <g transform="translate(63,0)">
+              <text y="0.71em" transform="translate(62,440)">Good</text>
+            </g>
+            <g transform="translate(118,0)">
+              <text y="0.71em" transform="translate(62,440)">Ideal</text>
+            </g>
+            <g transform="translate(173,0)">
+              <text y="0.71em" transform="translate(62,440)">Premium</text>
+            </g>
+            <g transform="translate(228,0)">
+              <text y="0.71em" transform="translate(62,440)">Very Good</text>
+            </g>
+          </g>
+          <g aria-label="fx-axis label" transform="translate(0.5,37.5)">
+            <text transform="translate(180,440)">cut</text>
+          </g>
+          <g aria-label="y-grid" aria-hidden="true" transform="translate(0,0.5)">
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
+            </g>
+          </g>
+          <g aria-label="x-grid" aria-hidden="true" transform="translate(7,0)">
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+              <line x1="42" x2="42" y1="60" y2="440"></line>
+              <line x1="56" x2="56" y1="60" y2="440"></line>
+              <line x1="70" x2="70" y1="60" y2="440"></line>
+            </g>
+          </g>
+          <g aria-label="x-axis tick label" transform="translate(7,-8.5)">
+            <g transform="translate(8,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(63,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(118,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(173,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+            <g transform="translate(228,0)">
+              <text transform="translate(42,60)">IF</text>
+              <text transform="translate(56,60)">SI1</text>
+              <text transform="translate(70,60)">I1</text>
+            </g>
+          </g>
+          <g aria-label="frame" transform="translate(0.5,0.5)">
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(8,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(63,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(118,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(173,0)"></line>
+            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(228,0)"></line>
+          </g>
+          <g aria-label="rule" transform="translate(7,0)">
+            <g stroke="currentColor" transform="translate(8,0)">
+              <line x1="70" x2="70" y1="237.36842105263165" y2="71.57894736842114"></line>
+              <line x1="56" x2="56" y1="364.4736842105263" y2="113.94736842105269"></line>
+              <line x1="42" x2="42" y1="416.05263157894746" y2="189.4736842105265"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(63,0)">
+              <line x1="56" x2="56" y1="281.5789473684211" y2="160.00000000000003"></line>
+              <line x1="42" x2="42" y1="344.2105263157894" y2="180.26315789473702"></line>
+              <line x1="70" x2="70" y1="259.4736842105264" y2="195.0000000000001"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(118,0)">
+              <line x1="56" x2="56" y1="274.21052631578954" y2="218.94736842105266"></line>
+              <line x1="42" x2="42" y1="274.21052631578954" y2="217.10526315789477"></line>
+              <line x1="70" x2="70" y1="272.36842105263156" y2="213.42105263157904"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(173,0)">
+              <line x1="56" x2="56" y1="311.0526315789474" y2="218.94736842105266"></line>
+              <line x1="70" x2="70" y1="311.0526315789474" y2="218.94736842105266"></line>
+              <line x1="42" x2="42" y1="287.1052631578948" y2="226.31578947368425"></line>
+            </g>
+            <g stroke="currentColor" transform="translate(228,0)">
+              <line x1="56" x2="56" y1="309.2105263157895" y2="200.52631578947376"></line>
+              <line x1="42" x2="42" y1="307.3684210526316" y2="202.36842105263167"></line>
+              <line x1="70" x2="70" y1="307.3684210526316" y2="213.42105263157904"></line>
+            </g>
+          </g>
+          <g aria-label="bar">
+            <g transform="translate(8,0)">
+              <rect x="70" width="13" y="135.13157894736855" height="49.73684210526321" fill="#ff725c"></rect>
+              <rect x="56" width="13" y="169.21052631578976" height="80.13157894736827" fill="#efb118"></rect>
+              <rect x="42" width="13" y="251.64473684210532" height="75.98684210526307" fill="#4269d0"></rect>
+            </g>
+            <g transform="translate(63,0)">
+              <rect x="56" width="13" y="204.2105263157896" height="31.315789473684134" fill="#efb118"></rect>
+              <rect x="42" width="13" y="219.86842105263162" height="78.28947368421046" fill="#4269d0"></rect>
+              <rect x="70" width="13" y="200.52631578947376" height="23.947368421052545" fill="#ff725c"></rect>
+            </g>
+            <g transform="translate(118,0)">
+              <rect x="56" width="13" y="233.22368421052633" height="17.039473684210577" fill="#efb118"></rect>
+              <rect x="42" width="13" y="235.52631578947373" height="16.578947368421012" fill="#4269d0"></rect>
+              <rect x="70" width="13" y="235.52631578947373" height="18.421052631578902" fill="#ff725c"></rect>
+            </g>
+            <g transform="translate(173,0)">
+              <rect x="56" width="13" y="231.842105263158" height="31.776315789473557" fill="#efb118"></rect>
+              <rect x="70" width="13" y="230.46052631578954" height="40.98684210526318" fill="#ff725c"></rect>
+              <rect x="42" width="13" y="243.81578947368416" height="18.42105263157896" fill="#4269d0"></rect>
+            </g>
+            <g transform="translate(228,0)">
+              <rect x="56" width="13" y="217.10526315789477" height="36.84210526315786" fill="#efb118"></rect>
+              <rect x="42" width="13" y="232.7631578947369" height="42.36842105263153" fill="#4269d0"></rect>
+              <rect x="70" width="13" y="215.26315789473688" height="49.73684210526318" fill="#ff725c"></rect>
+            </g>
+          </g>
+          <g aria-label="tick" transform="translate(0,0.5)">
+            <g stroke="currentColor" stroke-width="2" transform="translate(8,0)">
+              <line x1="70" x2="83" y1="161.8421052631581" y2="161.8421052631581"></line>
+              <line x1="56" x2="69" y1="185.78947368421066" y2="185.78947368421066"></line>
+              <line x1="42" x2="55" y1="285.2631578947368" y2="285.2631578947368"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(63,0)">
+              <line x1="56" x2="69" y1="209.73684210526324" y2="209.73684210526324"></line>
+              <line x1="42" x2="55" y1="261.31578947368416" y2="261.31578947368416"></line>
+              <line x1="70" x2="83" y1="204.2105263157896" y2="204.2105263157896"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(118,0)">
+              <line x1="56" x2="69" y1="242.89473684210526" y2="242.89473684210526"></line>
+              <line x1="42" x2="55" y1="241.9736842105264" y2="241.9736842105264"></line>
+              <line x1="70" x2="83" y1="241.9736842105264" y2="241.9736842105264"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(173,0)">
+              <line x1="56" x2="69" y1="244.73684210526315" y2="244.73684210526315"></line>
+              <line x1="70" x2="83" y1="250.2631578947369" y2="250.2631578947369"></line>
+              <line x1="42" x2="55" y1="246.5789473684211" y2="246.5789473684211"></line>
+            </g>
+            <g stroke="currentColor" stroke-width="2" transform="translate(228,0)">
+              <line x1="56" x2="69" y1="231.842105263158" y2="231.842105263158"></line>
+              <line x1="42" x2="55" y1="253.94736842105263" y2="253.94736842105263"></line>
+              <line x1="70" x2="83" y1="239.21052631578954" y2="239.21052631578954"></line>
+            </g>
+          </g>
+          <g aria-label="dot" transform="translate(7,0.5)">
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(8,0)">
+              <circle cx="70" cy="298.1578947368421" r="3"></circle>
+              <circle cx="70" cy="320.2631578947369" r="3"></circle>
+              <circle cx="70" cy="351.57894736842115" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(63,0)">
+              <circle cx="56" cy="311.0526315789474" r="3"></circle>
+              <circle cx="56" cy="320.2631578947369" r="3"></circle>
+              <circle cx="56" cy="318.42105263157896" r="3"></circle>
+              <circle cx="56" cy="296.3157894736843" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="311.0526315789474" r="3"></circle>
+              <circle cx="56" cy="333.1578947368422" r="3"></circle>
+              <circle cx="70" cy="288.9473684210526" r="3"></circle>
+              <circle cx="56" cy="329.47368421052636" r="3"></circle>
+              <circle cx="56" cy="309.2105263157895" r="3"></circle>
+              <circle cx="56" cy="322.1052631578948" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="296.3157894736843" r="3"></circle>
+              <circle cx="56" cy="314.7368421052633" r="3"></circle>
+              <circle cx="70" cy="263.15789473684214" r="3"></circle>
+              <circle cx="56" cy="318.42105263157896" r="3"></circle>
+              <circle cx="56" cy="320.2631578947369" r="3"></circle>
+              <circle cx="56" cy="316.57894736842104" r="3"></circle>
+              <circle cx="56" cy="325.7894736842105" r="3"></circle>
+              <circle cx="56" cy="283.42105263157896" r="3"></circle>
+              <circle cx="56" cy="303.68421052631584" r="3"></circle>
+              <circle cx="56" cy="287.1052631578948" r="3"></circle>
+              <circle cx="56" cy="331.31578947368433" r="3"></circle>
+              <circle cx="70" cy="323.9473684210527" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="283.42105263157896" r="3"></circle>
+              <circle cx="56" cy="290.7894736842106" r="3"></circle>
+              <circle cx="56" cy="329.47368421052636" r="3"></circle>
+              <circle cx="56" cy="327.6315789473684" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="309.2105263157895" r="3"></circle>
+              <circle cx="56" cy="303.68421052631584" r="3"></circle>
+              <circle cx="56" cy="309.2105263157895" r="3"></circle>
+              <circle cx="56" cy="316.57894736842104" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="298.1578947368421" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="325.7894736842105" r="3"></circle>
+              <circle cx="56" cy="298.1578947368421" r="3"></circle>
+              <circle cx="56" cy="322.1052631578948" r="3"></circle>
+              <circle cx="56" cy="298.1578947368421" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="309.2105263157895" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(118,0)">
+              <circle cx="56" cy="277.8947368421054" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="42" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="279.7368421052631" r="3"></circle>
+              <circle cx="56" cy="285.2631578947369" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="285.2631578947369" r="3"></circle>
+              <circle cx="56" cy="279.7368421052631" r="3"></circle>
+              <circle cx="56" cy="279.7368421052631" r="3"></circle>
+              <circle cx="56" cy="283.42105263157896" r="3"></circle>
+              <circle cx="42" cy="279.7368421052631" r="3"></circle>
+              <circle cx="42" cy="285.2631578947369" r="3"></circle>
+              <circle cx="42" cy="277.8947368421054" r="3"></circle>
+              <circle cx="56" cy="277.8947368421054" r="3"></circle>
+              <circle cx="56" cy="285.2631578947369" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="277.8947368421054" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="276.0526315789474" r="3"></circle>
+              <circle cx="56" cy="281.5789473684211" r="3"></circle>
+              <circle cx="56" cy="277.8947368421054" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(173,0)">
+              <circle cx="42" cy="311.0526315789474" r="3"></circle>
+            </g>
+            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(228,0)">
+              <circle cx="56" cy="311.0526315789474" r="3"></circle>
+              <circle cx="56" cy="311.0526315789474" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+              <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            </g>
+          </g>
+        </svg></g>
+    </g>
+  </svg></figure>

--- a/test/output/nestedFacets.html
+++ b/test/output/nestedFacets.html
@@ -97,916 +97,912 @@
       <line stroke="currentColor" stroke-linecap="square" x1="40" x2="319" y1="35" y2="35" transform="translate(311,0)"></line>
       <line stroke="currentColor" stroke-linecap="square" x1="40" x2="319" y1="35" y2="35" transform="translate(621,0)"></line>
     </g>
-    <g>
-      <g transform="translate(1,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="339" height="480" viewBox="0 0 339 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-          <style>
-            :where(.plot) {
-              --plot-background: white;
-              display: block;
-              height: auto;
-              height: intrinsic;
-              max-width: 100%;
-            }
+    <g><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="339" height="480" viewBox="0 0 339 480" x="1" y="0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <style>
+          :where(.plot) {
+            --plot-background: white;
+            display: block;
+            height: auto;
+            height: intrinsic;
+            max-width: 100%;
+          }
 
-            :where(.plot text),
-            :where(.plot tspan) {
-              white-space: pre;
-            }
-          </style>
-          <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
-            <g transform="translate(8,0)">
-              <text y="0.71em" transform="translate(62,440)">Fair</text>
-            </g>
-            <g transform="translate(63,0)">
-              <text y="0.71em" transform="translate(62,440)">Good</text>
-            </g>
-            <g transform="translate(118,0)">
-              <text y="0.71em" transform="translate(62,440)">Ideal</text>
-            </g>
-            <g transform="translate(173,0)">
-              <text y="0.71em" transform="translate(62,440)">Premium</text>
-            </g>
-            <g transform="translate(228,0)">
-              <text y="0.71em" transform="translate(62,440)">Very Good</text>
-            </g>
+          :where(.plot text),
+          :where(.plot tspan) {
+            white-space: pre;
+          }
+        </style>
+        <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
+          <g transform="translate(8,0)">
+            <text y="0.71em" transform="translate(62,440)">Fair</text>
           </g>
-          <g aria-label="fx-axis label" transform="translate(0.5,37.5)">
-            <text transform="translate(180,440)">cut</text>
+          <g transform="translate(63,0)">
+            <text y="0.71em" transform="translate(62,440)">Good</text>
           </g>
-          <g aria-label="y-grid" aria-hidden="true" transform="translate(0,0.5)">
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
+          <g transform="translate(118,0)">
+            <text y="0.71em" transform="translate(62,440)">Ideal</text>
           </g>
-          <g aria-label="x-grid" aria-hidden="true" transform="translate(7,0)">
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
+          <g transform="translate(173,0)">
+            <text y="0.71em" transform="translate(62,440)">Premium</text>
           </g>
-          <g aria-label="x-axis tick label" transform="translate(7,-8.5)">
-            <g transform="translate(8,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(63,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(118,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(173,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(228,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
+          <g transform="translate(228,0)">
+            <text y="0.71em" transform="translate(62,440)">Very Good</text>
           </g>
-          <g aria-label="x-axis label" text-anchor="start" transform="translate(-36.5,-15.5)">
-            <text y="0.71em" transform="translate(48,60)">clarity</text>
+        </g>
+        <g aria-label="fx-axis label" transform="translate(0.5,37.5)">
+          <text transform="translate(180,440)">cut</text>
+        </g>
+        <g aria-label="y-grid" aria-hidden="true" transform="translate(0,0.5)">
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="frame" transform="translate(0.5,0.5)">
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(8,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(63,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(118,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(173,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(228,0)"></line>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="rule" transform="translate(7,0)">
-            <g stroke="currentColor" transform="translate(8,0)">
-              <line x1="56" x2="56" y1="209.73684210526324" y2="139.7368421052633"></line>
-              <line x1="70" x2="70" y1="187.63157894736844" y2="148.94736842105277"></line>
-              <line x1="42" x2="42" y1="265.00000000000006" y2="252.10526315789474"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(63,0)">
-              <line x1="56" x2="56" y1="233.68421052631578" y2="185.78947368421066"></line>
-              <line x1="42" x2="42" y1="314.7368421052633" y2="211.57894736842115"></line>
-              <line x1="70" x2="70" y1="329.47368421052636" y2="200.52631578947376"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(118,0)">
-              <line x1="56" x2="56" y1="276.0526315789474" y2="218.94736842105266"></line>
-              <line x1="42" x2="42" y1="277.8947368421054" y2="218.94736842105266"></line>
-              <line x1="70" x2="70" y1="263.15789473684214" y2="228.15789473684214"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(173,0)">
-              <line x1="56" x2="56" y1="309.2105263157895" y2="218.94736842105266"></line>
-              <line x1="70" x2="70" y1="242.89473684210526" y2="239.21052631578954"></line>
-              <line x1="42" x2="42" y1="274.21052631578954" y2="235.52631578947373"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(228,0)">
-              <line x1="56" x2="56" y1="318.42105263157896" y2="196.8421052631579"></line>
-              <line x1="42" x2="42" y1="292.63157894736844" y2="211.57894736842115"></line>
-              <line x1="70" x2="70" y1="279.7368421052631" y2="211.57894736842115"></line>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="bar">
-            <g transform="translate(8,0)">
-              <rect x="56" width="13" y="165.52631578947367" height="23.94736842105283" fill="#efb118"></rect>
-              <rect x="70" width="13" y="157.23684210526332" height="30.394736842105118" fill="#ff725c"></rect>
-              <rect x="42" width="13" y="257.6315789473684" height="6.447368421052772" fill="#4269d0"></rect>
-            </g>
-            <g transform="translate(63,0)">
-              <rect x="56" width="13" y="204.2105263157896" height="12.894736842105175" fill="#efb118"></rect>
-              <rect x="42" width="13" y="215.26315789473688" height="84.73684210526318" fill="#4269d0"></rect>
-              <rect x="70" width="13" y="204.67105263157893" height="113.75000000000014" fill="#ff725c"></rect>
-            </g>
-            <g transform="translate(118,0)">
-              <rect x="56" width="13" y="231.842105263158" height="18.421052631578902" fill="#efb118"></rect>
-              <rect x="42" width="13" y="235.52631578947373" height="22.10526315789477" fill="#4269d0"></rect>
-              <rect x="70" width="13" y="242.89473684210526" height="11.05263157894737" fill="#ff725c"></rect>
-            </g>
-            <g transform="translate(173,0)">
-              <rect x="56" width="13" y="233.68421052631578" height="31.7763157894737" fill="#efb118"></rect>
-              <rect x="70" width="13" y="239.21052631578954" height="2.3026315789473983" fill="#ff725c"></rect>
-              <rect x="42" width="13" y="245.19736842105263" height="23.486842105263094" fill="#4269d0"></rect>
-            </g>
-            <g transform="translate(228,0)">
-              <rect x="56" width="13" y="218.94736842105266" height="41.90789473684214" fill="#efb118"></rect>
-              <rect x="42" width="13" y="226.31578947368425" height="35.921052631578874" fill="#4269d0"></rect>
-              <rect x="70" width="13" y="211.57894736842115" height="34.99999999999994" fill="#ff725c"></rect>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="tick" transform="translate(0,0.5)">
-            <g stroke="currentColor" stroke-width="2" transform="translate(8,0)">
-              <line x1="56" x2="69" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="70" x2="83" y1="173.81578947368422" y2="173.81578947368422"></line>
-              <line x1="42" x2="55" y1="263.15789473684214" y2="263.15789473684214"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(63,0)">
-              <line x1="56" x2="69" y1="209.73684210526324" y2="209.73684210526324"></line>
-              <line x1="42" x2="55" y1="242.89473684210526" y2="242.89473684210526"></line>
-              <line x1="70" x2="83" y1="206.9736842105263" y2="206.9736842105263"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(118,0)">
-              <line x1="56" x2="69" y1="241.05263157894748" y2="241.05263157894748"></line>
-              <line x1="42" x2="55" y1="243.81578947368428" y2="243.81578947368428"></line>
-              <line x1="70" x2="83" y1="248.42105263157902" y2="248.42105263157902"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(173,0)">
-              <line x1="56" x2="69" y1="248.42105263157902" y2="248.42105263157902"></line>
-              <line x1="70" x2="83" y1="241.05263157894748" y2="241.05263157894748"></line>
-              <line x1="42" x2="55" y1="252.10526315789474" y2="252.10526315789474"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(228,0)">
-              <line x1="56" x2="69" y1="233.68421052631578" y2="233.68421052631578"></line>
-              <line x1="42" x2="55" y1="242.89473684210526" y2="242.89473684210526"></line>
-              <line x1="70" x2="83" y1="218.94736842105266" y2="218.94736842105266"></line>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="dot" transform="translate(7,0.5)">
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(8,0)">
-              <circle cx="56" cy="266.842105263158" r="3"></circle>
-              <circle cx="56" cy="78.94736842105284" r="3"></circle>
-              <circle cx="56" cy="226.31578947368425" r="3"></circle>
-              <circle cx="56" cy="355.2631578947368" r="3"></circle>
-              <circle cx="56" cy="417.89473684210526" r="3"></circle>
-              <circle cx="56" cy="357.1052631578948" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(63,0)">
-              <circle cx="56" cy="250.2631578947369" r="3"></circle>
-              <circle cx="56" cy="272.36842105263156" r="3"></circle>
-              <circle cx="56" cy="239.21052631578954" r="3"></circle>
-              <circle cx="56" cy="239.21052631578954" r="3"></circle>
-              <circle cx="56" cy="318.42105263157896" r="3"></circle>
-              <circle cx="56" cy="237.36842105263165" r="3"></circle>
-              <circle cx="56" cy="253.94736842105263" r="3"></circle>
-              <circle cx="56" cy="239.21052631578954" r="3"></circle>
-              <circle cx="56" cy="301.8421052631579" r="3"></circle>
-              <circle cx="56" cy="255.78947368421058" r="3"></circle>
-              <circle cx="56" cy="180.26315789473702" r="3"></circle>
-              <circle cx="56" cy="331.31578947368433" r="3"></circle>
-              <circle cx="56" cy="266.842105263158" r="3"></circle>
-              <circle cx="56" cy="239.21052631578954" r="3"></circle>
-              <circle cx="56" cy="272.36842105263156" r="3"></circle>
-              <circle cx="56" cy="266.842105263158" r="3"></circle>
-              <circle cx="56" cy="325.7894736842105" r="3"></circle>
-              <circle cx="56" cy="255.78947368421058" r="3"></circle>
-              <circle cx="56" cy="270.52631578947364" r="3"></circle>
-              <circle cx="56" cy="301.8421052631579" r="3"></circle>
-              <circle cx="56" cy="301.8421052631579" r="3"></circle>
-              <circle cx="56" cy="242.89473684210526" r="3"></circle>
-              <circle cx="56" cy="241.05263157894748" r="3"></circle>
-              <circle cx="56" cy="183.94736842105257" r="3"></circle>
-              <circle cx="56" cy="318.42105263157896" r="3"></circle>
-              <circle cx="56" cy="316.57894736842104" r="3"></circle>
-              <circle cx="56" cy="180.26315789473702" r="3"></circle>
-              <circle cx="56" cy="265.00000000000006" r="3"></circle>
-              <circle cx="56" cy="303.68421052631584" r="3"></circle>
-              <circle cx="56" cy="305.5263157894738" r="3"></circle>
-              <circle cx="56" cy="314.7368421052633" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="336.84210526315786" r="3"></circle>
-              <circle cx="56" cy="183.94736842105257" r="3"></circle>
-              <circle cx="56" cy="250.2631578947369" r="3"></circle>
-              <circle cx="56" cy="239.21052631578954" r="3"></circle>
-              <circle cx="56" cy="268.6842105263159" r="3"></circle>
-              <circle cx="56" cy="316.57894736842104" r="3"></circle>
-              <circle cx="56" cy="338.6842105263158" r="3"></circle>
-              <circle cx="56" cy="296.3157894736843" r="3"></circle>
-              <circle cx="56" cy="325.7894736842105" r="3"></circle>
-              <circle cx="56" cy="325.7894736842105" r="3"></circle>
-              <circle cx="56" cy="298.1578947368421" r="3"></circle>
-              <circle cx="56" cy="253.94736842105263" r="3"></circle>
-              <circle cx="56" cy="265.00000000000006" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="292.63157894736844" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="316.57894736842104" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="333.1578947368422" r="3"></circle>
-              <circle cx="56" cy="296.3157894736843" r="3"></circle>
-              <circle cx="56" cy="311.0526315789474" r="3"></circle>
-              <circle cx="56" cy="244.73684210526315" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(118,0)">
-              <circle cx="56" cy="279.7368421052631" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="283.42105263157896" r="3"></circle>
-              <circle cx="56" cy="283.42105263157896" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="283.42105263157896" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(173,0)">
-              <circle cx="70" cy="248.42105263157902" r="3"></circle>
-              <circle cx="70" cy="230.0000000000001" r="3"></circle>
-              <circle cx="70" cy="248.42105263157902" r="3"></circle>
-              <circle cx="70" cy="218.94736842105266" r="3"></circle>
-            </g>
+        </g>
+        <g aria-label="x-grid" aria-hidden="true" transform="translate(7,0)">
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
           </g>
-        </svg></g>
-      <g transform="translate(311,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="339" height="480" viewBox="0 0 339 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-          <style>
-            :where(.plot) {
-              --plot-background: white;
-              display: block;
-              height: auto;
-              height: intrinsic;
-              max-width: 100%;
-            }
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+        </g>
+        <g aria-label="x-axis tick label" transform="translate(7,-8.5)">
+          <g transform="translate(8,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(63,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(118,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(173,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(228,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+        </g>
+        <g aria-label="x-axis label" text-anchor="start" transform="translate(-36.5,-15.5)">
+          <text y="0.71em" transform="translate(48,60)">clarity</text>
+        </g>
+        <g aria-label="frame" transform="translate(0.5,0.5)">
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(8,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(63,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(118,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(173,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(228,0)"></line>
+        </g>
+        <g aria-label="rule" transform="translate(7,0)">
+          <g stroke="currentColor" transform="translate(8,0)">
+            <line x1="56" x2="56" y1="209.73684210526324" y2="139.7368421052633"></line>
+            <line x1="70" x2="70" y1="187.63157894736844" y2="148.94736842105277"></line>
+            <line x1="42" x2="42" y1="265.00000000000006" y2="252.10526315789474"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(63,0)">
+            <line x1="56" x2="56" y1="233.68421052631578" y2="185.78947368421066"></line>
+            <line x1="42" x2="42" y1="314.7368421052633" y2="211.57894736842115"></line>
+            <line x1="70" x2="70" y1="329.47368421052636" y2="200.52631578947376"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(118,0)">
+            <line x1="56" x2="56" y1="276.0526315789474" y2="218.94736842105266"></line>
+            <line x1="42" x2="42" y1="277.8947368421054" y2="218.94736842105266"></line>
+            <line x1="70" x2="70" y1="263.15789473684214" y2="228.15789473684214"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(173,0)">
+            <line x1="56" x2="56" y1="309.2105263157895" y2="218.94736842105266"></line>
+            <line x1="70" x2="70" y1="242.89473684210526" y2="239.21052631578954"></line>
+            <line x1="42" x2="42" y1="274.21052631578954" y2="235.52631578947373"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(228,0)">
+            <line x1="56" x2="56" y1="318.42105263157896" y2="196.8421052631579"></line>
+            <line x1="42" x2="42" y1="292.63157894736844" y2="211.57894736842115"></line>
+            <line x1="70" x2="70" y1="279.7368421052631" y2="211.57894736842115"></line>
+          </g>
+        </g>
+        <g aria-label="bar">
+          <g transform="translate(8,0)">
+            <rect x="56" width="13" y="165.52631578947367" height="23.94736842105283" fill="#efb118"></rect>
+            <rect x="70" width="13" y="157.23684210526332" height="30.394736842105118" fill="#ff725c"></rect>
+            <rect x="42" width="13" y="257.6315789473684" height="6.447368421052772" fill="#4269d0"></rect>
+          </g>
+          <g transform="translate(63,0)">
+            <rect x="56" width="13" y="204.2105263157896" height="12.894736842105175" fill="#efb118"></rect>
+            <rect x="42" width="13" y="215.26315789473688" height="84.73684210526318" fill="#4269d0"></rect>
+            <rect x="70" width="13" y="204.67105263157893" height="113.75000000000014" fill="#ff725c"></rect>
+          </g>
+          <g transform="translate(118,0)">
+            <rect x="56" width="13" y="231.842105263158" height="18.421052631578902" fill="#efb118"></rect>
+            <rect x="42" width="13" y="235.52631578947373" height="22.10526315789477" fill="#4269d0"></rect>
+            <rect x="70" width="13" y="242.89473684210526" height="11.05263157894737" fill="#ff725c"></rect>
+          </g>
+          <g transform="translate(173,0)">
+            <rect x="56" width="13" y="233.68421052631578" height="31.7763157894737" fill="#efb118"></rect>
+            <rect x="70" width="13" y="239.21052631578954" height="2.3026315789473983" fill="#ff725c"></rect>
+            <rect x="42" width="13" y="245.19736842105263" height="23.486842105263094" fill="#4269d0"></rect>
+          </g>
+          <g transform="translate(228,0)">
+            <rect x="56" width="13" y="218.94736842105266" height="41.90789473684214" fill="#efb118"></rect>
+            <rect x="42" width="13" y="226.31578947368425" height="35.921052631578874" fill="#4269d0"></rect>
+            <rect x="70" width="13" y="211.57894736842115" height="34.99999999999994" fill="#ff725c"></rect>
+          </g>
+        </g>
+        <g aria-label="tick" transform="translate(0,0.5)">
+          <g stroke="currentColor" stroke-width="2" transform="translate(8,0)">
+            <line x1="56" x2="69" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="70" x2="83" y1="173.81578947368422" y2="173.81578947368422"></line>
+            <line x1="42" x2="55" y1="263.15789473684214" y2="263.15789473684214"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(63,0)">
+            <line x1="56" x2="69" y1="209.73684210526324" y2="209.73684210526324"></line>
+            <line x1="42" x2="55" y1="242.89473684210526" y2="242.89473684210526"></line>
+            <line x1="70" x2="83" y1="206.9736842105263" y2="206.9736842105263"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(118,0)">
+            <line x1="56" x2="69" y1="241.05263157894748" y2="241.05263157894748"></line>
+            <line x1="42" x2="55" y1="243.81578947368428" y2="243.81578947368428"></line>
+            <line x1="70" x2="83" y1="248.42105263157902" y2="248.42105263157902"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(173,0)">
+            <line x1="56" x2="69" y1="248.42105263157902" y2="248.42105263157902"></line>
+            <line x1="70" x2="83" y1="241.05263157894748" y2="241.05263157894748"></line>
+            <line x1="42" x2="55" y1="252.10526315789474" y2="252.10526315789474"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(228,0)">
+            <line x1="56" x2="69" y1="233.68421052631578" y2="233.68421052631578"></line>
+            <line x1="42" x2="55" y1="242.89473684210526" y2="242.89473684210526"></line>
+            <line x1="70" x2="83" y1="218.94736842105266" y2="218.94736842105266"></line>
+          </g>
+        </g>
+        <g aria-label="dot" transform="translate(7,0.5)">
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(8,0)">
+            <circle cx="56" cy="266.842105263158" r="3"></circle>
+            <circle cx="56" cy="78.94736842105284" r="3"></circle>
+            <circle cx="56" cy="226.31578947368425" r="3"></circle>
+            <circle cx="56" cy="355.2631578947368" r="3"></circle>
+            <circle cx="56" cy="417.89473684210526" r="3"></circle>
+            <circle cx="56" cy="357.1052631578948" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(63,0)">
+            <circle cx="56" cy="250.2631578947369" r="3"></circle>
+            <circle cx="56" cy="272.36842105263156" r="3"></circle>
+            <circle cx="56" cy="239.21052631578954" r="3"></circle>
+            <circle cx="56" cy="239.21052631578954" r="3"></circle>
+            <circle cx="56" cy="318.42105263157896" r="3"></circle>
+            <circle cx="56" cy="237.36842105263165" r="3"></circle>
+            <circle cx="56" cy="253.94736842105263" r="3"></circle>
+            <circle cx="56" cy="239.21052631578954" r="3"></circle>
+            <circle cx="56" cy="301.8421052631579" r="3"></circle>
+            <circle cx="56" cy="255.78947368421058" r="3"></circle>
+            <circle cx="56" cy="180.26315789473702" r="3"></circle>
+            <circle cx="56" cy="331.31578947368433" r="3"></circle>
+            <circle cx="56" cy="266.842105263158" r="3"></circle>
+            <circle cx="56" cy="239.21052631578954" r="3"></circle>
+            <circle cx="56" cy="272.36842105263156" r="3"></circle>
+            <circle cx="56" cy="266.842105263158" r="3"></circle>
+            <circle cx="56" cy="325.7894736842105" r="3"></circle>
+            <circle cx="56" cy="255.78947368421058" r="3"></circle>
+            <circle cx="56" cy="270.52631578947364" r="3"></circle>
+            <circle cx="56" cy="301.8421052631579" r="3"></circle>
+            <circle cx="56" cy="301.8421052631579" r="3"></circle>
+            <circle cx="56" cy="242.89473684210526" r="3"></circle>
+            <circle cx="56" cy="241.05263157894748" r="3"></circle>
+            <circle cx="56" cy="183.94736842105257" r="3"></circle>
+            <circle cx="56" cy="318.42105263157896" r="3"></circle>
+            <circle cx="56" cy="316.57894736842104" r="3"></circle>
+            <circle cx="56" cy="180.26315789473702" r="3"></circle>
+            <circle cx="56" cy="265.00000000000006" r="3"></circle>
+            <circle cx="56" cy="303.68421052631584" r="3"></circle>
+            <circle cx="56" cy="305.5263157894738" r="3"></circle>
+            <circle cx="56" cy="314.7368421052633" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="336.84210526315786" r="3"></circle>
+            <circle cx="56" cy="183.94736842105257" r="3"></circle>
+            <circle cx="56" cy="250.2631578947369" r="3"></circle>
+            <circle cx="56" cy="239.21052631578954" r="3"></circle>
+            <circle cx="56" cy="268.6842105263159" r="3"></circle>
+            <circle cx="56" cy="316.57894736842104" r="3"></circle>
+            <circle cx="56" cy="338.6842105263158" r="3"></circle>
+            <circle cx="56" cy="296.3157894736843" r="3"></circle>
+            <circle cx="56" cy="325.7894736842105" r="3"></circle>
+            <circle cx="56" cy="325.7894736842105" r="3"></circle>
+            <circle cx="56" cy="298.1578947368421" r="3"></circle>
+            <circle cx="56" cy="253.94736842105263" r="3"></circle>
+            <circle cx="56" cy="265.00000000000006" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="292.63157894736844" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="316.57894736842104" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="333.1578947368422" r="3"></circle>
+            <circle cx="56" cy="296.3157894736843" r="3"></circle>
+            <circle cx="56" cy="311.0526315789474" r="3"></circle>
+            <circle cx="56" cy="244.73684210526315" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(118,0)">
+            <circle cx="56" cy="279.7368421052631" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="283.42105263157896" r="3"></circle>
+            <circle cx="56" cy="283.42105263157896" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="283.42105263157896" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(173,0)">
+            <circle cx="70" cy="248.42105263157902" r="3"></circle>
+            <circle cx="70" cy="230.0000000000001" r="3"></circle>
+            <circle cx="70" cy="248.42105263157902" r="3"></circle>
+            <circle cx="70" cy="218.94736842105266" r="3"></circle>
+          </g>
+        </g>
+      </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="339" height="480" viewBox="0 0 339 480" x="311" y="0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <style>
+          :where(.plot) {
+            --plot-background: white;
+            display: block;
+            height: auto;
+            height: intrinsic;
+            max-width: 100%;
+          }
 
-            :where(.plot text),
-            :where(.plot tspan) {
-              white-space: pre;
-            }
-          </style>
-          <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
-            <g transform="translate(8,0)">
-              <text y="0.71em" transform="translate(62,440)">Fair</text>
-            </g>
-            <g transform="translate(63,0)">
-              <text y="0.71em" transform="translate(62,440)">Good</text>
-            </g>
-            <g transform="translate(118,0)">
-              <text y="0.71em" transform="translate(62,440)">Ideal</text>
-            </g>
-            <g transform="translate(173,0)">
-              <text y="0.71em" transform="translate(62,440)">Premium</text>
-            </g>
-            <g transform="translate(228,0)">
-              <text y="0.71em" transform="translate(62,440)">Very Good</text>
-            </g>
+          :where(.plot text),
+          :where(.plot tspan) {
+            white-space: pre;
+          }
+        </style>
+        <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
+          <g transform="translate(8,0)">
+            <text y="0.71em" transform="translate(62,440)">Fair</text>
           </g>
-          <g aria-label="fx-axis label" transform="translate(0.5,37.5)">
-            <text transform="translate(180,440)">cut</text>
+          <g transform="translate(63,0)">
+            <text y="0.71em" transform="translate(62,440)">Good</text>
           </g>
-          <g aria-label="y-grid" aria-hidden="true" transform="translate(0,0.5)">
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
+          <g transform="translate(118,0)">
+            <text y="0.71em" transform="translate(62,440)">Ideal</text>
           </g>
-          <g aria-label="x-grid" aria-hidden="true" transform="translate(7,0)">
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
+          <g transform="translate(173,0)">
+            <text y="0.71em" transform="translate(62,440)">Premium</text>
           </g>
-          <g aria-label="x-axis tick label" transform="translate(7,-8.5)">
-            <g transform="translate(8,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(63,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(118,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(173,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(228,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
+          <g transform="translate(228,0)">
+            <text y="0.71em" transform="translate(62,440)">Very Good</text>
           </g>
-          <g aria-label="frame" transform="translate(0.5,0.5)">
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(8,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(63,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(118,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(173,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(228,0)"></line>
+        </g>
+        <g aria-label="fx-axis label" transform="translate(0.5,37.5)">
+          <text transform="translate(180,440)">cut</text>
+        </g>
+        <g aria-label="y-grid" aria-hidden="true" transform="translate(0,0.5)">
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="rule" transform="translate(7,0)">
-            <g stroke="currentColor" transform="translate(8,0)">
-              <line x1="70" x2="70" y1="191.31578947368428" y2="137.89473684210523"></line>
-              <line x1="56" x2="56" y1="388.421052631579" y2="99.21052631578956"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(63,0)">
-              <line x1="56" x2="56" y1="248.42105263157902" y2="182.1052631578948"></line>
-              <line x1="70" x2="70" y1="331.31578947368433" y2="195.0000000000001"></line>
-              <line x1="42" x2="42" y1="316.57894736842104" y2="171.05263157894757"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(118,0)">
-              <line x1="56" x2="56" y1="272.36842105263156" y2="209.73684210526324"></line>
-              <line x1="42" x2="42" y1="272.36842105263156" y2="218.94736842105266"></line>
-              <line x1="70" x2="70" y1="248.42105263157902" y2="233.68421052631578"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(173,0)">
-              <line x1="56" x2="56" y1="309.2105263157895" y2="218.94736842105266"></line>
-              <line x1="70" x2="70" y1="300.00000000000006" y2="228.15789473684214"></line>
-              <line x1="42" x2="42" y1="292.63157894736844" y2="220.7894736842106"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(228,0)">
-              <line x1="56" x2="56" y1="312.8947368421053" y2="196.8421052631579"></line>
-              <line x1="70" x2="70" y1="303.68421052631584" y2="213.42105263157904"></line>
-              <line x1="42" x2="42" y1="312.8947368421053" y2="202.36842105263167"></line>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="bar">
-            <g transform="translate(8,0)">
-              <rect x="70" width="13" y="154.47368421052641" height="36.84210526315786" fill="#ff725c"></rect>
-              <rect x="56" width="13" y="172.89473684210532" height="110.52631578947364" fill="#efb118"></rect>
-            </g>
-            <g transform="translate(63,0)">
-              <rect x="56" width="13" y="204.2105263157896" height="18.42105263157893" fill="#efb118"></rect>
-              <rect x="70" width="13" y="202.36842105263167" height="114.21052631578937" fill="#ff725c"></rect>
-              <rect x="42" width="13" y="196.8421052631579" height="93.94736842105269" fill="#4269d0"></rect>
-            </g>
-            <g transform="translate(118,0)">
-              <rect x="56" width="13" y="233.68421052631578" height="16.578947368421126" fill="#efb118"></rect>
-              <rect x="42" width="13" y="233.68421052631578" height="17.500000000000057" fill="#4269d0"></rect>
-              <rect x="70" width="13" y="237.36842105263165" height="7.368421052631504" fill="#ff725c"></rect>
-            </g>
-            <g transform="translate(173,0)">
-              <rect x="56" width="13" y="232.30263157894746" height="36.38157894736844" fill="#efb118"></rect>
-              <rect x="70" width="13" y="247.03947368421058" height="22.565789473684163" fill="#ff725c"></rect>
-              <rect x="42" width="13" y="242.89473684210526" height="33.15789473684214" fill="#4269d0"></rect>
-            </g>
-            <g transform="translate(228,0)">
-              <rect x="56" width="13" y="217.10526315789477" height="38.68421052631581" fill="#efb118"></rect>
-              <rect x="70" width="13" y="228.6184210526316" height="37.30263157894737" fill="#ff725c"></rect>
-              <rect x="42" width="13" y="226.31578947368425" height="50.65789473684222" fill="#4269d0"></rect>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="tick" transform="translate(0,0.5)">
-            <g stroke="currentColor" stroke-width="2" transform="translate(8,0)">
-              <line x1="70" x2="83" y1="172.89473684210532" y2="172.89473684210532"></line>
-              <line x1="56" x2="69" y1="183.94736842105257" y2="183.94736842105257"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(63,0)">
-              <line x1="56" x2="69" y1="209.73684210526324" y2="209.73684210526324"></line>
-              <line x1="70" x2="83" y1="213.42105263157904" y2="213.42105263157904"></line>
-              <line x1="42" x2="55" y1="207.8947368421053" y2="207.8947368421053"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(118,0)">
-              <line x1="56" x2="69" y1="241.05263157894748" y2="241.05263157894748"></line>
-              <line x1="42" x2="55" y1="239.21052631578954" y2="239.21052631578954"></line>
-              <line x1="70" x2="83" y1="239.21052631578954" y2="239.21052631578954"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(173,0)">
-              <line x1="56" x2="69" y1="250.2631578947369" y2="250.2631578947369"></line>
-              <line x1="70" x2="83" y1="257.6315789473685" y2="257.6315789473685"></line>
-              <line x1="42" x2="55" y1="255.78947368421058" y2="255.78947368421058"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(228,0)">
-              <line x1="56" x2="69" y1="230.0000000000001" y2="230.0000000000001"></line>
-              <line x1="70" x2="83" y1="237.36842105263165" y2="237.36842105263165"></line>
-              <line x1="42" x2="55" y1="248.42105263157902" y2="248.42105263157902"></line>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="dot" transform="translate(7,0.5)">
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(8,0)">
-              <circle cx="70" cy="-61.05263157894723" r="3"></circle>
-              <circle cx="70" cy="307.3684210526316" r="3"></circle>
-              <circle cx="70" cy="276.0526315789474" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(63,0)">
-              <circle cx="56" cy="305.5263157894738" r="3"></circle>
-              <circle cx="56" cy="285.2631578947369" r="3"></circle>
-              <circle cx="56" cy="259.4736842105264" r="3"></circle>
-              <circle cx="56" cy="318.42105263157896" r="3"></circle>
-              <circle cx="56" cy="309.2105263157895" r="3"></circle>
-              <circle cx="56" cy="259.4736842105264" r="3"></circle>
-              <circle cx="56" cy="266.842105263158" r="3"></circle>
-              <circle cx="56" cy="305.5263157894738" r="3"></circle>
-              <circle cx="56" cy="261.31578947368416" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="277.8947368421054" r="3"></circle>
-              <circle cx="56" cy="277.8947368421054" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="270.52631578947364" r="3"></circle>
-              <circle cx="56" cy="257.6315789473685" r="3"></circle>
-              <circle cx="56" cy="266.842105263158" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="331.31578947368433" r="3"></circle>
-              <circle cx="56" cy="320.2631578947369" r="3"></circle>
-              <circle cx="56" cy="300.00000000000006" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="307.3684210526316" r="3"></circle>
-              <circle cx="56" cy="325.7894736842105" r="3"></circle>
-              <circle cx="56" cy="311.0526315789474" r="3"></circle>
-              <circle cx="56" cy="303.68421052631584" r="3"></circle>
-              <circle cx="56" cy="309.2105263157895" r="3"></circle>
-              <circle cx="56" cy="257.6315789473685" r="3"></circle>
-              <circle cx="56" cy="253.94736842105263" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="172.89473684210532" r="3"></circle>
-              <circle cx="56" cy="266.842105263158" r="3"></circle>
-              <circle cx="56" cy="250.2631578947369" r="3"></circle>
-              <circle cx="56" cy="294.47368421052636" r="3"></circle>
-              <circle cx="56" cy="301.8421052631579" r="3"></circle>
-              <circle cx="56" cy="265.00000000000006" r="3"></circle>
-              <circle cx="56" cy="298.1578947368421" r="3"></circle>
-              <circle cx="56" cy="294.47368421052636" r="3"></circle>
-              <circle cx="56" cy="263.15789473684214" r="3"></circle>
-              <circle cx="56" cy="283.42105263157896" r="3"></circle>
-              <circle cx="56" cy="270.52631578947364" r="3"></circle>
-              <circle cx="56" cy="263.15789473684214" r="3"></circle>
-              <circle cx="56" cy="172.89473684210532" r="3"></circle>
-              <circle cx="56" cy="335" r="3"></circle>
-              <circle cx="56" cy="322.1052631578948" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="325.7894736842105" r="3"></circle>
-              <circle cx="56" cy="314.7368421052633" r="3"></circle>
-              <circle cx="56" cy="301.8421052631579" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="322.1052631578948" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="250.2631578947369" r="3"></circle>
-              <circle cx="56" cy="255.78947368421058" r="3"></circle>
-              <circle cx="56" cy="277.8947368421054" r="3"></circle>
-              <circle cx="56" cy="314.7368421052633" r="3"></circle>
-              <circle cx="56" cy="305.5263157894738" r="3"></circle>
-              <circle cx="56" cy="320.2631578947369" r="3"></circle>
-              <circle cx="56" cy="259.4736842105264" r="3"></circle>
-              <circle cx="56" cy="303.68421052631584" r="3"></circle>
-              <circle cx="56" cy="165.52631578947367" r="3"></circle>
-              <circle cx="56" cy="288.9473684210526" r="3"></circle>
-              <circle cx="56" cy="266.842105263158" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(118,0)">
-              <circle cx="56" cy="290.7894736842106" r="3"></circle>
-              <circle cx="70" cy="257.6315789473685" r="3"></circle>
-              <circle cx="70" cy="218.94736842105266" r="3"></circle>
-              <circle cx="56" cy="294.47368421052636" r="3"></circle>
-              <circle cx="56" cy="290.7894736842106" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="294.47368421052636" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="277.8947368421054" r="3"></circle>
-              <circle cx="56" cy="296.3157894736843" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="70" cy="222.63157894736852" r="3"></circle>
-              <circle cx="56" cy="285.2631578947369" r="3"></circle>
-              <circle cx="70" cy="261.31578947368416" r="3"></circle>
-              <circle cx="70" cy="268.6842105263159" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="70" cy="211.57894736842115" r="3"></circle>
-              <circle cx="56" cy="279.7368421052631" r="3"></circle>
-              <circle cx="56" cy="290.7894736842106" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="277.8947368421054" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(173,0)">
-              <circle cx="70" cy="303.68421052631584" r="3"></circle>
-              <circle cx="70" cy="311.0526315789474" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(228,0)">
-              <circle cx="56" cy="316.57894736842104" r="3"></circle>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-        </svg></g>
-      <g transform="translate(621,0)"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="339" height="480" viewBox="0 0 339 480" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-          <style>
-            :where(.plot) {
-              --plot-background: white;
-              display: block;
-              height: auto;
-              height: intrinsic;
-              max-width: 100%;
-            }
+        </g>
+        <g aria-label="x-grid" aria-hidden="true" transform="translate(7,0)">
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+        </g>
+        <g aria-label="x-axis tick label" transform="translate(7,-8.5)">
+          <g transform="translate(8,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(63,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(118,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(173,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(228,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+        </g>
+        <g aria-label="frame" transform="translate(0.5,0.5)">
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(8,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(63,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(118,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(173,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(228,0)"></line>
+        </g>
+        <g aria-label="rule" transform="translate(7,0)">
+          <g stroke="currentColor" transform="translate(8,0)">
+            <line x1="70" x2="70" y1="191.31578947368428" y2="137.89473684210523"></line>
+            <line x1="56" x2="56" y1="388.421052631579" y2="99.21052631578956"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(63,0)">
+            <line x1="56" x2="56" y1="248.42105263157902" y2="182.1052631578948"></line>
+            <line x1="70" x2="70" y1="331.31578947368433" y2="195.0000000000001"></line>
+            <line x1="42" x2="42" y1="316.57894736842104" y2="171.05263157894757"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(118,0)">
+            <line x1="56" x2="56" y1="272.36842105263156" y2="209.73684210526324"></line>
+            <line x1="42" x2="42" y1="272.36842105263156" y2="218.94736842105266"></line>
+            <line x1="70" x2="70" y1="248.42105263157902" y2="233.68421052631578"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(173,0)">
+            <line x1="56" x2="56" y1="309.2105263157895" y2="218.94736842105266"></line>
+            <line x1="70" x2="70" y1="300.00000000000006" y2="228.15789473684214"></line>
+            <line x1="42" x2="42" y1="292.63157894736844" y2="220.7894736842106"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(228,0)">
+            <line x1="56" x2="56" y1="312.8947368421053" y2="196.8421052631579"></line>
+            <line x1="70" x2="70" y1="303.68421052631584" y2="213.42105263157904"></line>
+            <line x1="42" x2="42" y1="312.8947368421053" y2="202.36842105263167"></line>
+          </g>
+        </g>
+        <g aria-label="bar">
+          <g transform="translate(8,0)">
+            <rect x="70" width="13" y="154.47368421052641" height="36.84210526315786" fill="#ff725c"></rect>
+            <rect x="56" width="13" y="172.89473684210532" height="110.52631578947364" fill="#efb118"></rect>
+          </g>
+          <g transform="translate(63,0)">
+            <rect x="56" width="13" y="204.2105263157896" height="18.42105263157893" fill="#efb118"></rect>
+            <rect x="70" width="13" y="202.36842105263167" height="114.21052631578937" fill="#ff725c"></rect>
+            <rect x="42" width="13" y="196.8421052631579" height="93.94736842105269" fill="#4269d0"></rect>
+          </g>
+          <g transform="translate(118,0)">
+            <rect x="56" width="13" y="233.68421052631578" height="16.578947368421126" fill="#efb118"></rect>
+            <rect x="42" width="13" y="233.68421052631578" height="17.500000000000057" fill="#4269d0"></rect>
+            <rect x="70" width="13" y="237.36842105263165" height="7.368421052631504" fill="#ff725c"></rect>
+          </g>
+          <g transform="translate(173,0)">
+            <rect x="56" width="13" y="232.30263157894746" height="36.38157894736844" fill="#efb118"></rect>
+            <rect x="70" width="13" y="247.03947368421058" height="22.565789473684163" fill="#ff725c"></rect>
+            <rect x="42" width="13" y="242.89473684210526" height="33.15789473684214" fill="#4269d0"></rect>
+          </g>
+          <g transform="translate(228,0)">
+            <rect x="56" width="13" y="217.10526315789477" height="38.68421052631581" fill="#efb118"></rect>
+            <rect x="70" width="13" y="228.6184210526316" height="37.30263157894737" fill="#ff725c"></rect>
+            <rect x="42" width="13" y="226.31578947368425" height="50.65789473684222" fill="#4269d0"></rect>
+          </g>
+        </g>
+        <g aria-label="tick" transform="translate(0,0.5)">
+          <g stroke="currentColor" stroke-width="2" transform="translate(8,0)">
+            <line x1="70" x2="83" y1="172.89473684210532" y2="172.89473684210532"></line>
+            <line x1="56" x2="69" y1="183.94736842105257" y2="183.94736842105257"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(63,0)">
+            <line x1="56" x2="69" y1="209.73684210526324" y2="209.73684210526324"></line>
+            <line x1="70" x2="83" y1="213.42105263157904" y2="213.42105263157904"></line>
+            <line x1="42" x2="55" y1="207.8947368421053" y2="207.8947368421053"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(118,0)">
+            <line x1="56" x2="69" y1="241.05263157894748" y2="241.05263157894748"></line>
+            <line x1="42" x2="55" y1="239.21052631578954" y2="239.21052631578954"></line>
+            <line x1="70" x2="83" y1="239.21052631578954" y2="239.21052631578954"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(173,0)">
+            <line x1="56" x2="69" y1="250.2631578947369" y2="250.2631578947369"></line>
+            <line x1="70" x2="83" y1="257.6315789473685" y2="257.6315789473685"></line>
+            <line x1="42" x2="55" y1="255.78947368421058" y2="255.78947368421058"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(228,0)">
+            <line x1="56" x2="69" y1="230.0000000000001" y2="230.0000000000001"></line>
+            <line x1="70" x2="83" y1="237.36842105263165" y2="237.36842105263165"></line>
+            <line x1="42" x2="55" y1="248.42105263157902" y2="248.42105263157902"></line>
+          </g>
+        </g>
+        <g aria-label="dot" transform="translate(7,0.5)">
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(8,0)">
+            <circle cx="70" cy="-61.05263157894723" r="3"></circle>
+            <circle cx="70" cy="307.3684210526316" r="3"></circle>
+            <circle cx="70" cy="276.0526315789474" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(63,0)">
+            <circle cx="56" cy="305.5263157894738" r="3"></circle>
+            <circle cx="56" cy="285.2631578947369" r="3"></circle>
+            <circle cx="56" cy="259.4736842105264" r="3"></circle>
+            <circle cx="56" cy="318.42105263157896" r="3"></circle>
+            <circle cx="56" cy="309.2105263157895" r="3"></circle>
+            <circle cx="56" cy="259.4736842105264" r="3"></circle>
+            <circle cx="56" cy="266.842105263158" r="3"></circle>
+            <circle cx="56" cy="305.5263157894738" r="3"></circle>
+            <circle cx="56" cy="261.31578947368416" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="277.8947368421054" r="3"></circle>
+            <circle cx="56" cy="277.8947368421054" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="270.52631578947364" r="3"></circle>
+            <circle cx="56" cy="257.6315789473685" r="3"></circle>
+            <circle cx="56" cy="266.842105263158" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="331.31578947368433" r="3"></circle>
+            <circle cx="56" cy="320.2631578947369" r="3"></circle>
+            <circle cx="56" cy="300.00000000000006" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="307.3684210526316" r="3"></circle>
+            <circle cx="56" cy="325.7894736842105" r="3"></circle>
+            <circle cx="56" cy="311.0526315789474" r="3"></circle>
+            <circle cx="56" cy="303.68421052631584" r="3"></circle>
+            <circle cx="56" cy="309.2105263157895" r="3"></circle>
+            <circle cx="56" cy="257.6315789473685" r="3"></circle>
+            <circle cx="56" cy="253.94736842105263" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="172.89473684210532" r="3"></circle>
+            <circle cx="56" cy="266.842105263158" r="3"></circle>
+            <circle cx="56" cy="250.2631578947369" r="3"></circle>
+            <circle cx="56" cy="294.47368421052636" r="3"></circle>
+            <circle cx="56" cy="301.8421052631579" r="3"></circle>
+            <circle cx="56" cy="265.00000000000006" r="3"></circle>
+            <circle cx="56" cy="298.1578947368421" r="3"></circle>
+            <circle cx="56" cy="294.47368421052636" r="3"></circle>
+            <circle cx="56" cy="263.15789473684214" r="3"></circle>
+            <circle cx="56" cy="283.42105263157896" r="3"></circle>
+            <circle cx="56" cy="270.52631578947364" r="3"></circle>
+            <circle cx="56" cy="263.15789473684214" r="3"></circle>
+            <circle cx="56" cy="172.89473684210532" r="3"></circle>
+            <circle cx="56" cy="335" r="3"></circle>
+            <circle cx="56" cy="322.1052631578948" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="325.7894736842105" r="3"></circle>
+            <circle cx="56" cy="314.7368421052633" r="3"></circle>
+            <circle cx="56" cy="301.8421052631579" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="322.1052631578948" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="250.2631578947369" r="3"></circle>
+            <circle cx="56" cy="255.78947368421058" r="3"></circle>
+            <circle cx="56" cy="277.8947368421054" r="3"></circle>
+            <circle cx="56" cy="314.7368421052633" r="3"></circle>
+            <circle cx="56" cy="305.5263157894738" r="3"></circle>
+            <circle cx="56" cy="320.2631578947369" r="3"></circle>
+            <circle cx="56" cy="259.4736842105264" r="3"></circle>
+            <circle cx="56" cy="303.68421052631584" r="3"></circle>
+            <circle cx="56" cy="165.52631578947367" r="3"></circle>
+            <circle cx="56" cy="288.9473684210526" r="3"></circle>
+            <circle cx="56" cy="266.842105263158" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(118,0)">
+            <circle cx="56" cy="290.7894736842106" r="3"></circle>
+            <circle cx="70" cy="257.6315789473685" r="3"></circle>
+            <circle cx="70" cy="218.94736842105266" r="3"></circle>
+            <circle cx="56" cy="294.47368421052636" r="3"></circle>
+            <circle cx="56" cy="290.7894736842106" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="294.47368421052636" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="277.8947368421054" r="3"></circle>
+            <circle cx="56" cy="296.3157894736843" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="70" cy="222.63157894736852" r="3"></circle>
+            <circle cx="56" cy="285.2631578947369" r="3"></circle>
+            <circle cx="70" cy="261.31578947368416" r="3"></circle>
+            <circle cx="70" cy="268.6842105263159" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="70" cy="211.57894736842115" r="3"></circle>
+            <circle cx="56" cy="279.7368421052631" r="3"></circle>
+            <circle cx="56" cy="290.7894736842106" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="277.8947368421054" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(173,0)">
+            <circle cx="70" cy="303.68421052631584" r="3"></circle>
+            <circle cx="70" cy="311.0526315789474" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(228,0)">
+            <circle cx="56" cy="316.57894736842104" r="3"></circle>
+          </g>
+        </g>
+      </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="339" height="480" viewBox="0 0 339 480" x="621" y="0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <style>
+          :where(.plot) {
+            --plot-background: white;
+            display: block;
+            height: auto;
+            height: intrinsic;
+            max-width: 100%;
+          }
 
-            :where(.plot text),
-            :where(.plot tspan) {
-              white-space: pre;
-            }
-          </style>
-          <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
-            <g transform="translate(8,0)">
-              <text y="0.71em" transform="translate(62,440)">Fair</text>
-            </g>
-            <g transform="translate(63,0)">
-              <text y="0.71em" transform="translate(62,440)">Good</text>
-            </g>
-            <g transform="translate(118,0)">
-              <text y="0.71em" transform="translate(62,440)">Ideal</text>
-            </g>
-            <g transform="translate(173,0)">
-              <text y="0.71em" transform="translate(62,440)">Premium</text>
-            </g>
-            <g transform="translate(228,0)">
-              <text y="0.71em" transform="translate(62,440)">Very Good</text>
-            </g>
+          :where(.plot text),
+          :where(.plot tspan) {
+            white-space: pre;
+          }
+        </style>
+        <g aria-label="fx-axis tick label" transform="translate(0.5,9.5)">
+          <g transform="translate(8,0)">
+            <text y="0.71em" transform="translate(62,440)">Fair</text>
           </g>
-          <g aria-label="fx-axis label" transform="translate(0.5,37.5)">
-            <text transform="translate(180,440)">cut</text>
+          <g transform="translate(63,0)">
+            <text y="0.71em" transform="translate(62,440)">Good</text>
           </g>
-          <g aria-label="y-grid" aria-hidden="true" transform="translate(0,0.5)">
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
-              <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
-              <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
-              <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
-              <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
-            </g>
+          <g transform="translate(118,0)">
+            <text y="0.71em" transform="translate(62,440)">Ideal</text>
           </g>
-          <g aria-label="x-grid" aria-hidden="true" transform="translate(7,0)">
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
-            <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
-              <line x1="42" x2="42" y1="60" y2="440"></line>
-              <line x1="56" x2="56" y1="60" y2="440"></line>
-              <line x1="70" x2="70" y1="60" y2="440"></line>
-            </g>
+          <g transform="translate(173,0)">
+            <text y="0.71em" transform="translate(62,440)">Premium</text>
           </g>
-          <g aria-label="x-axis tick label" transform="translate(7,-8.5)">
-            <g transform="translate(8,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(63,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(118,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(173,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
-            <g transform="translate(228,0)">
-              <text transform="translate(42,60)">IF</text>
-              <text transform="translate(56,60)">SI1</text>
-              <text transform="translate(70,60)">I1</text>
-            </g>
+          <g transform="translate(228,0)">
+            <text y="0.71em" transform="translate(62,440)">Very Good</text>
           </g>
-          <g aria-label="frame" transform="translate(0.5,0.5)">
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(8,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(63,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(118,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(173,0)"></line>
-            <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(228,0)"></line>
+        </g>
+        <g aria-label="fx-axis label" transform="translate(0.5,37.5)">
+          <text transform="translate(180,440)">cut</text>
+        </g>
+        <g aria-label="y-grid" aria-hidden="true" transform="translate(0,0.5)">
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="rule" transform="translate(7,0)">
-            <g stroke="currentColor" transform="translate(8,0)">
-              <line x1="70" x2="70" y1="237.36842105263165" y2="71.57894736842114"></line>
-              <line x1="56" x2="56" y1="364.4736842105263" y2="113.94736842105269"></line>
-              <line x1="42" x2="42" y1="416.05263157894746" y2="189.4736842105265"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(63,0)">
-              <line x1="56" x2="56" y1="281.5789473684211" y2="160.00000000000003"></line>
-              <line x1="42" x2="42" y1="344.2105263157894" y2="180.26315789473702"></line>
-              <line x1="70" x2="70" y1="259.4736842105264" y2="195.0000000000001"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(118,0)">
-              <line x1="56" x2="56" y1="274.21052631578954" y2="218.94736842105266"></line>
-              <line x1="42" x2="42" y1="274.21052631578954" y2="217.10526315789477"></line>
-              <line x1="70" x2="70" y1="272.36842105263156" y2="213.42105263157904"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(173,0)">
-              <line x1="56" x2="56" y1="311.0526315789474" y2="218.94736842105266"></line>
-              <line x1="70" x2="70" y1="311.0526315789474" y2="218.94736842105266"></line>
-              <line x1="42" x2="42" y1="287.1052631578948" y2="226.31578947368425"></line>
-            </g>
-            <g stroke="currentColor" transform="translate(228,0)">
-              <line x1="56" x2="56" y1="309.2105263157895" y2="200.52631578947376"></line>
-              <line x1="42" x2="42" y1="307.3684210526316" y2="202.36842105263167"></line>
-              <line x1="70" x2="70" y1="307.3684210526316" y2="213.42105263157904"></line>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="bar">
-            <g transform="translate(8,0)">
-              <rect x="70" width="13" y="135.13157894736855" height="49.73684210526321" fill="#ff725c"></rect>
-              <rect x="56" width="13" y="169.21052631578976" height="80.13157894736827" fill="#efb118"></rect>
-              <rect x="42" width="13" y="251.64473684210532" height="75.98684210526307" fill="#4269d0"></rect>
-            </g>
-            <g transform="translate(63,0)">
-              <rect x="56" width="13" y="204.2105263157896" height="31.315789473684134" fill="#efb118"></rect>
-              <rect x="42" width="13" y="219.86842105263162" height="78.28947368421046" fill="#4269d0"></rect>
-              <rect x="70" width="13" y="200.52631578947376" height="23.947368421052545" fill="#ff725c"></rect>
-            </g>
-            <g transform="translate(118,0)">
-              <rect x="56" width="13" y="233.22368421052633" height="17.039473684210577" fill="#efb118"></rect>
-              <rect x="42" width="13" y="235.52631578947373" height="16.578947368421012" fill="#4269d0"></rect>
-              <rect x="70" width="13" y="235.52631578947373" height="18.421052631578902" fill="#ff725c"></rect>
-            </g>
-            <g transform="translate(173,0)">
-              <rect x="56" width="13" y="231.842105263158" height="31.776315789473557" fill="#efb118"></rect>
-              <rect x="70" width="13" y="230.46052631578954" height="40.98684210526318" fill="#ff725c"></rect>
-              <rect x="42" width="13" y="243.81578947368416" height="18.42105263157896" fill="#4269d0"></rect>
-            </g>
-            <g transform="translate(228,0)">
-              <rect x="56" width="13" y="217.10526315789477" height="36.84210526315786" fill="#efb118"></rect>
-              <rect x="42" width="13" y="232.7631578947369" height="42.36842105263153" fill="#4269d0"></rect>
-              <rect x="70" width="13" y="215.26315789473688" height="49.73684210526318" fill="#ff725c"></rect>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="tick" transform="translate(0,0.5)">
-            <g stroke="currentColor" stroke-width="2" transform="translate(8,0)">
-              <line x1="70" x2="83" y1="161.8421052631581" y2="161.8421052631581"></line>
-              <line x1="56" x2="69" y1="185.78947368421066" y2="185.78947368421066"></line>
-              <line x1="42" x2="55" y1="285.2631578947368" y2="285.2631578947368"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(63,0)">
-              <line x1="56" x2="69" y1="209.73684210526324" y2="209.73684210526324"></line>
-              <line x1="42" x2="55" y1="261.31578947368416" y2="261.31578947368416"></line>
-              <line x1="70" x2="83" y1="204.2105263157896" y2="204.2105263157896"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(118,0)">
-              <line x1="56" x2="69" y1="242.89473684210526" y2="242.89473684210526"></line>
-              <line x1="42" x2="55" y1="241.9736842105264" y2="241.9736842105264"></line>
-              <line x1="70" x2="83" y1="241.9736842105264" y2="241.9736842105264"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(173,0)">
-              <line x1="56" x2="69" y1="244.73684210526315" y2="244.73684210526315"></line>
-              <line x1="70" x2="83" y1="250.2631578947369" y2="250.2631578947369"></line>
-              <line x1="42" x2="55" y1="246.5789473684211" y2="246.5789473684211"></line>
-            </g>
-            <g stroke="currentColor" stroke-width="2" transform="translate(228,0)">
-              <line x1="56" x2="69" y1="231.842105263158" y2="231.842105263158"></line>
-              <line x1="42" x2="55" y1="253.94736842105263" y2="253.94736842105263"></line>
-              <line x1="70" x2="83" y1="239.21052631578954" y2="239.21052631578954"></line>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-          <g aria-label="dot" transform="translate(7,0.5)">
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(8,0)">
-              <circle cx="70" cy="298.1578947368421" r="3"></circle>
-              <circle cx="70" cy="320.2631578947369" r="3"></circle>
-              <circle cx="70" cy="351.57894736842115" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(63,0)">
-              <circle cx="56" cy="311.0526315789474" r="3"></circle>
-              <circle cx="56" cy="320.2631578947369" r="3"></circle>
-              <circle cx="56" cy="318.42105263157896" r="3"></circle>
-              <circle cx="56" cy="296.3157894736843" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="311.0526315789474" r="3"></circle>
-              <circle cx="56" cy="333.1578947368422" r="3"></circle>
-              <circle cx="70" cy="288.9473684210526" r="3"></circle>
-              <circle cx="56" cy="329.47368421052636" r="3"></circle>
-              <circle cx="56" cy="309.2105263157895" r="3"></circle>
-              <circle cx="56" cy="322.1052631578948" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="296.3157894736843" r="3"></circle>
-              <circle cx="56" cy="314.7368421052633" r="3"></circle>
-              <circle cx="70" cy="263.15789473684214" r="3"></circle>
-              <circle cx="56" cy="318.42105263157896" r="3"></circle>
-              <circle cx="56" cy="320.2631578947369" r="3"></circle>
-              <circle cx="56" cy="316.57894736842104" r="3"></circle>
-              <circle cx="56" cy="325.7894736842105" r="3"></circle>
-              <circle cx="56" cy="283.42105263157896" r="3"></circle>
-              <circle cx="56" cy="303.68421052631584" r="3"></circle>
-              <circle cx="56" cy="287.1052631578948" r="3"></circle>
-              <circle cx="56" cy="331.31578947368433" r="3"></circle>
-              <circle cx="70" cy="323.9473684210527" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="283.42105263157896" r="3"></circle>
-              <circle cx="56" cy="290.7894736842106" r="3"></circle>
-              <circle cx="56" cy="329.47368421052636" r="3"></circle>
-              <circle cx="56" cy="327.6315789473684" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="309.2105263157895" r="3"></circle>
-              <circle cx="56" cy="303.68421052631584" r="3"></circle>
-              <circle cx="56" cy="309.2105263157895" r="3"></circle>
-              <circle cx="56" cy="316.57894736842104" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="298.1578947368421" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="325.7894736842105" r="3"></circle>
-              <circle cx="56" cy="298.1578947368421" r="3"></circle>
-              <circle cx="56" cy="322.1052631578948" r="3"></circle>
-              <circle cx="56" cy="298.1578947368421" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="309.2105263157895" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(118,0)">
-              <circle cx="56" cy="277.8947368421054" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="42" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="279.7368421052631" r="3"></circle>
-              <circle cx="56" cy="285.2631578947369" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="285.2631578947369" r="3"></circle>
-              <circle cx="56" cy="279.7368421052631" r="3"></circle>
-              <circle cx="56" cy="279.7368421052631" r="3"></circle>
-              <circle cx="56" cy="283.42105263157896" r="3"></circle>
-              <circle cx="42" cy="279.7368421052631" r="3"></circle>
-              <circle cx="42" cy="285.2631578947369" r="3"></circle>
-              <circle cx="42" cy="277.8947368421054" r="3"></circle>
-              <circle cx="56" cy="277.8947368421054" r="3"></circle>
-              <circle cx="56" cy="285.2631578947369" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="277.8947368421054" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="276.0526315789474" r="3"></circle>
-              <circle cx="56" cy="281.5789473684211" r="3"></circle>
-              <circle cx="56" cy="277.8947368421054" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(173,0)">
-              <circle cx="42" cy="311.0526315789474" r="3"></circle>
-            </g>
-            <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(228,0)">
-              <circle cx="56" cy="311.0526315789474" r="3"></circle>
-              <circle cx="56" cy="311.0526315789474" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-              <circle cx="56" cy="312.8947368421053" r="3"></circle>
-            </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+            <line x1="40" x2="84" y1="366.3157894736843" y2="366.3157894736843"></line>
+            <line x1="40" x2="84" y1="274.21052631578954" y2="274.21052631578954"></line>
+            <line x1="40" x2="84" y1="182.1052631578948" y2="182.1052631578948"></line>
+            <line x1="40" x2="84" y1="90.0000000000001" y2="90.0000000000001"></line>
           </g>
-        </svg></g>
-    </g>
+        </g>
+        <g aria-label="x-grid" aria-hidden="true" transform="translate(7,0)">
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(8,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(63,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(118,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(173,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+          <g stroke="currentColor" stroke-opacity="0.1" transform="translate(228,0)">
+            <line x1="42" x2="42" y1="60" y2="440"></line>
+            <line x1="56" x2="56" y1="60" y2="440"></line>
+            <line x1="70" x2="70" y1="60" y2="440"></line>
+          </g>
+        </g>
+        <g aria-label="x-axis tick label" transform="translate(7,-8.5)">
+          <g transform="translate(8,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(63,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(118,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(173,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+          <g transform="translate(228,0)">
+            <text transform="translate(42,60)">IF</text>
+            <text transform="translate(56,60)">SI1</text>
+            <text transform="translate(70,60)">I1</text>
+          </g>
+        </g>
+        <g aria-label="frame" transform="translate(0.5,0.5)">
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(8,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(63,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(118,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(173,0)"></line>
+          <line stroke="currentColor" stroke-linecap="square" x1="40" x2="84" y1="440" y2="440" transform="translate(228,0)"></line>
+        </g>
+        <g aria-label="rule" transform="translate(7,0)">
+          <g stroke="currentColor" transform="translate(8,0)">
+            <line x1="70" x2="70" y1="237.36842105263165" y2="71.57894736842114"></line>
+            <line x1="56" x2="56" y1="364.4736842105263" y2="113.94736842105269"></line>
+            <line x1="42" x2="42" y1="416.05263157894746" y2="189.4736842105265"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(63,0)">
+            <line x1="56" x2="56" y1="281.5789473684211" y2="160.00000000000003"></line>
+            <line x1="42" x2="42" y1="344.2105263157894" y2="180.26315789473702"></line>
+            <line x1="70" x2="70" y1="259.4736842105264" y2="195.0000000000001"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(118,0)">
+            <line x1="56" x2="56" y1="274.21052631578954" y2="218.94736842105266"></line>
+            <line x1="42" x2="42" y1="274.21052631578954" y2="217.10526315789477"></line>
+            <line x1="70" x2="70" y1="272.36842105263156" y2="213.42105263157904"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(173,0)">
+            <line x1="56" x2="56" y1="311.0526315789474" y2="218.94736842105266"></line>
+            <line x1="70" x2="70" y1="311.0526315789474" y2="218.94736842105266"></line>
+            <line x1="42" x2="42" y1="287.1052631578948" y2="226.31578947368425"></line>
+          </g>
+          <g stroke="currentColor" transform="translate(228,0)">
+            <line x1="56" x2="56" y1="309.2105263157895" y2="200.52631578947376"></line>
+            <line x1="42" x2="42" y1="307.3684210526316" y2="202.36842105263167"></line>
+            <line x1="70" x2="70" y1="307.3684210526316" y2="213.42105263157904"></line>
+          </g>
+        </g>
+        <g aria-label="bar">
+          <g transform="translate(8,0)">
+            <rect x="70" width="13" y="135.13157894736855" height="49.73684210526321" fill="#ff725c"></rect>
+            <rect x="56" width="13" y="169.21052631578976" height="80.13157894736827" fill="#efb118"></rect>
+            <rect x="42" width="13" y="251.64473684210532" height="75.98684210526307" fill="#4269d0"></rect>
+          </g>
+          <g transform="translate(63,0)">
+            <rect x="56" width="13" y="204.2105263157896" height="31.315789473684134" fill="#efb118"></rect>
+            <rect x="42" width="13" y="219.86842105263162" height="78.28947368421046" fill="#4269d0"></rect>
+            <rect x="70" width="13" y="200.52631578947376" height="23.947368421052545" fill="#ff725c"></rect>
+          </g>
+          <g transform="translate(118,0)">
+            <rect x="56" width="13" y="233.22368421052633" height="17.039473684210577" fill="#efb118"></rect>
+            <rect x="42" width="13" y="235.52631578947373" height="16.578947368421012" fill="#4269d0"></rect>
+            <rect x="70" width="13" y="235.52631578947373" height="18.421052631578902" fill="#ff725c"></rect>
+          </g>
+          <g transform="translate(173,0)">
+            <rect x="56" width="13" y="231.842105263158" height="31.776315789473557" fill="#efb118"></rect>
+            <rect x="70" width="13" y="230.46052631578954" height="40.98684210526318" fill="#ff725c"></rect>
+            <rect x="42" width="13" y="243.81578947368416" height="18.42105263157896" fill="#4269d0"></rect>
+          </g>
+          <g transform="translate(228,0)">
+            <rect x="56" width="13" y="217.10526315789477" height="36.84210526315786" fill="#efb118"></rect>
+            <rect x="42" width="13" y="232.7631578947369" height="42.36842105263153" fill="#4269d0"></rect>
+            <rect x="70" width="13" y="215.26315789473688" height="49.73684210526318" fill="#ff725c"></rect>
+          </g>
+        </g>
+        <g aria-label="tick" transform="translate(0,0.5)">
+          <g stroke="currentColor" stroke-width="2" transform="translate(8,0)">
+            <line x1="70" x2="83" y1="161.8421052631581" y2="161.8421052631581"></line>
+            <line x1="56" x2="69" y1="185.78947368421066" y2="185.78947368421066"></line>
+            <line x1="42" x2="55" y1="285.2631578947368" y2="285.2631578947368"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(63,0)">
+            <line x1="56" x2="69" y1="209.73684210526324" y2="209.73684210526324"></line>
+            <line x1="42" x2="55" y1="261.31578947368416" y2="261.31578947368416"></line>
+            <line x1="70" x2="83" y1="204.2105263157896" y2="204.2105263157896"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(118,0)">
+            <line x1="56" x2="69" y1="242.89473684210526" y2="242.89473684210526"></line>
+            <line x1="42" x2="55" y1="241.9736842105264" y2="241.9736842105264"></line>
+            <line x1="70" x2="83" y1="241.9736842105264" y2="241.9736842105264"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(173,0)">
+            <line x1="56" x2="69" y1="244.73684210526315" y2="244.73684210526315"></line>
+            <line x1="70" x2="83" y1="250.2631578947369" y2="250.2631578947369"></line>
+            <line x1="42" x2="55" y1="246.5789473684211" y2="246.5789473684211"></line>
+          </g>
+          <g stroke="currentColor" stroke-width="2" transform="translate(228,0)">
+            <line x1="56" x2="69" y1="231.842105263158" y2="231.842105263158"></line>
+            <line x1="42" x2="55" y1="253.94736842105263" y2="253.94736842105263"></line>
+            <line x1="70" x2="83" y1="239.21052631578954" y2="239.21052631578954"></line>
+          </g>
+        </g>
+        <g aria-label="dot" transform="translate(7,0.5)">
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(8,0)">
+            <circle cx="70" cy="298.1578947368421" r="3"></circle>
+            <circle cx="70" cy="320.2631578947369" r="3"></circle>
+            <circle cx="70" cy="351.57894736842115" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(63,0)">
+            <circle cx="56" cy="311.0526315789474" r="3"></circle>
+            <circle cx="56" cy="320.2631578947369" r="3"></circle>
+            <circle cx="56" cy="318.42105263157896" r="3"></circle>
+            <circle cx="56" cy="296.3157894736843" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="311.0526315789474" r="3"></circle>
+            <circle cx="56" cy="333.1578947368422" r="3"></circle>
+            <circle cx="70" cy="288.9473684210526" r="3"></circle>
+            <circle cx="56" cy="329.47368421052636" r="3"></circle>
+            <circle cx="56" cy="309.2105263157895" r="3"></circle>
+            <circle cx="56" cy="322.1052631578948" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="296.3157894736843" r="3"></circle>
+            <circle cx="56" cy="314.7368421052633" r="3"></circle>
+            <circle cx="70" cy="263.15789473684214" r="3"></circle>
+            <circle cx="56" cy="318.42105263157896" r="3"></circle>
+            <circle cx="56" cy="320.2631578947369" r="3"></circle>
+            <circle cx="56" cy="316.57894736842104" r="3"></circle>
+            <circle cx="56" cy="325.7894736842105" r="3"></circle>
+            <circle cx="56" cy="283.42105263157896" r="3"></circle>
+            <circle cx="56" cy="303.68421052631584" r="3"></circle>
+            <circle cx="56" cy="287.1052631578948" r="3"></circle>
+            <circle cx="56" cy="331.31578947368433" r="3"></circle>
+            <circle cx="70" cy="323.9473684210527" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="283.42105263157896" r="3"></circle>
+            <circle cx="56" cy="290.7894736842106" r="3"></circle>
+            <circle cx="56" cy="329.47368421052636" r="3"></circle>
+            <circle cx="56" cy="327.6315789473684" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="309.2105263157895" r="3"></circle>
+            <circle cx="56" cy="303.68421052631584" r="3"></circle>
+            <circle cx="56" cy="309.2105263157895" r="3"></circle>
+            <circle cx="56" cy="316.57894736842104" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="298.1578947368421" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="325.7894736842105" r="3"></circle>
+            <circle cx="56" cy="298.1578947368421" r="3"></circle>
+            <circle cx="56" cy="322.1052631578948" r="3"></circle>
+            <circle cx="56" cy="298.1578947368421" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="309.2105263157895" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(118,0)">
+            <circle cx="56" cy="277.8947368421054" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="42" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="279.7368421052631" r="3"></circle>
+            <circle cx="56" cy="285.2631578947369" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="285.2631578947369" r="3"></circle>
+            <circle cx="56" cy="279.7368421052631" r="3"></circle>
+            <circle cx="56" cy="279.7368421052631" r="3"></circle>
+            <circle cx="56" cy="283.42105263157896" r="3"></circle>
+            <circle cx="42" cy="279.7368421052631" r="3"></circle>
+            <circle cx="42" cy="285.2631578947369" r="3"></circle>
+            <circle cx="42" cy="277.8947368421054" r="3"></circle>
+            <circle cx="56" cy="277.8947368421054" r="3"></circle>
+            <circle cx="56" cy="285.2631578947369" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="277.8947368421054" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="276.0526315789474" r="3"></circle>
+            <circle cx="56" cy="281.5789473684211" r="3"></circle>
+            <circle cx="56" cy="277.8947368421054" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(173,0)">
+            <circle cx="42" cy="311.0526315789474" r="3"></circle>
+          </g>
+          <g fill="none" stroke="currentColor" stroke-width="1.5" transform="translate(228,0)">
+            <circle cx="56" cy="311.0526315789474" r="3"></circle>
+            <circle cx="56" cy="311.0526315789474" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+            <circle cx="56" cy="312.8947368421053" r="3"></circle>
+          </g>
+        </g>
+      </svg></g>
   </svg></figure>

--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -184,6 +184,7 @@ export * from "./movies-profit-by-genre.js";
 export * from "./movies-rating-by-genre.js";
 export * from "./multiplication-table.js";
 export * from "./music-revenue.js";
+export * from "./nested-facets.js";
 export * from "./npm-versions.js";
 export * from "./opacity.js";
 export * from "./ordinal-bar.js";

--- a/test/plots/nested-facets.ts
+++ b/test/plots/nested-facets.ts
@@ -1,0 +1,53 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export async function nestedFacets() {
+  const diamonds = await d3.csv<any>("data/diamonds.csv", d3.autoType);
+  return Plot.plot({
+    width: 960,
+    height: 480,
+    fx: {domain: ["D", "E", "F"]},
+    color: {legend: "ramp", domain: ["IF", "SI1", "I1"]},
+    y: {domain: [51, 71.9], insetTop: 20, labelAnchor: "center"},
+    marginLeft: 40,
+    marginBottom: 40,
+    marginTop: 35,
+    marks: [
+      Plot.axisFx({anchor: "top"}),
+      Plot.frame({anchor: "top", strokeOpacity: 1}),
+      Plot.dot(diamonds, {
+        fx: "color", // outer x facet
+        y: "depth", // shared y scale
+        fill: "clarity", // shared color scale
+        render(index, {scales}, _values, {facet, ...dimensions}) {
+          const data = Array.from(index, (i) => this.data[i]); // subplot dataset as a subset of the data
+          return Plot.plot({
+            ...dimensions,
+            marginTop: 60,
+            ...scales, // shared color scale, shared y scale
+            fx: {axis: "bottom", paddingOuter: 0.1, paddingInner: 0.2}, // inner x facet
+            x: {
+              domain: scales.color.domain,
+              axis: "top",
+              labelAnchor: "left",
+              labelOffset: 16,
+              ...(index["fi"] && {label: null}),
+              grid: true,
+              tickSize: 0
+            }, // new x scale with a common domain and additional axis options
+            y: {...scales.y, grid: 4, axis: null}, // shared y scale with additional options
+            marks: [
+              Plot.frame({anchor: "bottom"}),
+              Plot.boxY(data, {
+                fx: "cut",
+                x: "clarity",
+                y: "depth",
+                fill: "clarity"
+              })
+            ]
+          }) as SVGElement;
+        }
+      })
+    ]
+  });
+}


### PR DESCRIPTION
closes #2218

| before | after |
|--|--|
| ![before](https://github.com/user-attachments/assets/b2f956f3-f292-4523-a444-f7de4e03da6c) |  ![after](https://github.com/user-attachments/assets/97e07283-0d67-4336-88d6-80b5368d12f0) |

(this comment applies to the initial implementation; it would need a different code path now) ~~We could extend this mechanism in the future to accept `HTMLElement` (say, `canvas`, or `DIV`), that we would wrap in a `foreignObject` of the width and height indicated in their style. (Or even text!)~~