### PR TITLE
fix tickFormat type inference for empty domain

### DIFF
--- a/src/marks/axis.js
+++ b/src/marks/axis.js
@@ -672,10 +672,10 @@ export function inferTickFormat(scale, data, ticks, tickFormat, anchor) {
     ? inferTimeFormat(scale.type, data, anchor) ?? formatDefault
     : scale.tickFormat
     ? scale.tickFormat(typeof ticks === "number" ? ticks : null, tickFormat)
+    : typeof tickFormat === "string" && scale.domain().length > 0
+    ? (isTemporal(scale.domain()) ? utcFormat : format)(tickFormat)
     : tickFormat === undefined
     ? formatDefault
-    : typeof tickFormat === "string"
-    ? (isTemporal(scale.domain()) ? utcFormat : format)(tickFormat)
     : constant(tickFormat);
 }
 

--- a/test/output/tickFormatEmptyDomain.svg
+++ b/test/output/tickFormatEmptyDomain.svg
@@ -1,0 +1,17 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="80" viewBox="0 0 640 80" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <rect aria-label="frame" fill="none" stroke="currentColor" transform="translate(0.5,0.5)" x="40" y="20" width="580" height="30"></rect>
+</svg>

--- a/test/output/tickFormatEmptyFacetDomain.svg
+++ b/test/output/tickFormatEmptyFacetDomain.svg
@@ -1,0 +1,17 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="80" viewBox="0 0 640 80" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <rect aria-label="frame" fill="none" stroke="currentColor" transform="translate(0.5,0.5)" x="40" y="20" width="580" height="30"></rect>
+</svg>

--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -308,6 +308,7 @@ export * from "./style-overrides.js";
 export * from "./symbol-set.js";
 export * from "./text-overflow.js";
 export * from "./this-is-just-to-say.js";
+export * from "./tick-format.js";
 export * from "./time-axis.js";
 export * from "./tip-format.js";
 export * from "./tip.js";

--- a/test/plots/tick-format.ts
+++ b/test/plots/tick-format.ts
@@ -1,0 +1,9 @@
+import * as Plot from "@observablehq/plot";
+
+export async function tickFormatEmptyDomain() {
+  return Plot.plot({y: {tickFormat: "%W"}, marks: [Plot.barX([]), Plot.frame()]});
+}
+
+export async function tickFormatEmptyFacetDomain() {
+  return Plot.plot({fy: {tickFormat: "%W"}, marks: [Plot.barX([]), Plot.frame()]});
+}


### PR DESCRIPTION
Fixes #2231. If an (ordinal) domain is empty, ignore the **tickFormat** since we can’t infer whether the data is temporal or quantitative, and instead use the default format. This shouldn’t affect the axis as we assume the tick format won’t be used anyway because the domain is empty and hence there can’t be any ticks.