### PR TITLE
remove module-alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "docs:build": "node --experimental-network-imports node_modules/vitepress/dist/node/cli.js build docs",
     "docs:preview": "vitepress preview docs"
   },
-  "_moduleAliases": {
-    "@observablehq/plot": "./src/index.js"
-  },
   "sideEffects": [
     "./src/index.js"
   ],
@@ -67,7 +64,6 @@
     "jsdom": "^24.0.0",
     "markdown-it-container": "^4.0.0",
     "mocha": "^10.0.0",
-    "module-alias": "^2.0.0",
     "prettier": "~3.0.0",
     "rollup": "^4.9.1",
     "topojson-client": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2853,11 +2853,6 @@ mocha@^10.0.0:
     yargs-parser "^20.2.9"
     yargs-unparser "^2.0.0"
 
-module-alias@^2.0.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.3.tgz#ec2e85c68973bda6ab71ce7c93b763ec96053221"
-  integrity sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"


### PR DESCRIPTION
This wasn’t being used for anything; the imports of `@observablehq/plot` in the tests already worked without it.