### PR TITLE
top-level legend option, and better types

### DIFF
--- a/docs/features/legends.md
+++ b/docs/features/legends.md
@@ -76,7 +76,7 @@ Plot does not yet generate legends for the *r* (radius) scale or the *length* sc
 
 ## Legend options
 
-If the **legend** [scale option](./scales.md#scale-options) is true, the default legend will be produced for the scale; otherwise, the meaning of the **legend** option depends on the scale: for quantitative color scales, it defaults to *ramp* but may be set to *swatches* for a discrete scale (most commonly for *threshold* color scales); for *ordinal* *color* scales and *symbol* scales, only the *swatches* value is supported.
+If the **legend** [scale option](./scales.md#scale-options) is true, the default legend will be produced for the scale; otherwise, the meaning of the **legend** option depends on the scale: for quantitative color scales, it defaults to *ramp* but may be set to *swatches* for a discrete scale (most commonly for *threshold* color scales); for *ordinal* *color* scales and *symbol* scales, only the *swatches* value is supported. If the **legend* scale option is undefined, it will be inherited from the top-level **legend** plot option. <VersionBadge pr="2247" />
 
 <!-- TODO Describe the color and opacity options. -->
 

--- a/src/legends.d.ts
+++ b/src/legends.d.ts
@@ -1,7 +1,89 @@
 import type {ScaleName, ScaleOptions} from "./scales.js";
 
+export interface SwatchesLegendOptions {
+  /**
+   * The width of the legend in pixels. Defaults to undefined, allowing swatches
+   * to wrap based on content flow.
+   */
+  width?: number;
+
+  /**
+   * The [CSS columns property][1], for a multi-column layout.
+   *
+   * [1]: https://developer.mozilla.org/en-US/docs/Web/CSS/columns
+   */
+  columns?: string;
+
+  /** The swatch width and height in pixels; defaults to 15. */
+  swatchSize?: number;
+
+  /** The swatch width in pixels; defaults to **swatchSize**. */
+  swatchWidth?: number;
+
+  /** The swatch height in pixels; defaults to **swatchSize**. */
+  swatchHeight?: number;
+}
+
+export interface RampLegendOptions {
+  /** The width of the legend in pixels; defaults to 240. */
+  width?: number;
+  /** The height of the legend in pixels; defaults to 44 plus **tickSize**. */
+  height?: number;
+  /** The top margin in pixels; defaults to 18. */
+  marginTop?: number;
+  /** The right margin in pixels; defaults to 0. */
+  marginRight?: number;
+  /** The bottom margin in pixels; defaults to 16 plus **tickSize**. */
+  marginBottom?: number;
+  /** The left margin in pixels; defaults to 0. */
+  marginLeft?: number;
+
+  /**
+   * The desired approximate number of axis ticks, or an explicit array of tick
+   * values, or an interval such as *day* or *month*.
+   */
+  ticks?: ScaleOptions["ticks"];
+
+  /**
+   * The length of axis tick marks in pixels; negative values extend in the
+   * opposite direction.
+   */
+  tickSize?: ScaleOptions["tickSize"];
+
+  /**
+   * If true, round the output value to the nearest integer (pixel); useful for
+   * crisp edges when rendering.
+   */
+  round?: ScaleOptions["round"];
+}
+
+export interface OpacityLegendOptions extends RampLegendOptions {
+  /** The constant color the ramp; defaults to black. */
+  color?: string;
+}
+
+export interface ColorLegendOptions extends SwatchesLegendOptions, RampLegendOptions {
+  /** The desired opacity of the color swatches or ramp; defaults to 1. */
+  opacity?: number;
+}
+
+export interface SymbolLegendOptions extends SwatchesLegendOptions {
+  /** The desired fill color of symbols; use *color* for a redundant encoding. */
+  fill?: string;
+  /** The desired fill opacity of symbols; defaults to 1. */
+  fillOpacity?: number;
+  /** The desired stroke color of symbols; use *color* for a redundant encoding. */
+  stroke?: string;
+  /** The desired stroke opacity of symbols; defaults to 1. */
+  strokeOpacity?: number;
+  /** The desired stroke width of symbols; defaults to 1.5. */
+  strokeWidth?: number;
+  /** The desired radius of symbols in pixels; defaults to 4.5. */
+  r?: number;
+}
+
 /** Options for generating a scale legend. */
-export interface LegendOptions {
+export interface LegendOptions extends ColorLegendOptions, SymbolLegendOptions, OpacityLegendOptions {
   /**
    * The desired legend type; one of:
    *
@@ -14,6 +96,9 @@ export interface LegendOptions {
    * cannot be changed.
    */
   legend?: "ramp" | "swatches";
+
+  /** A textual label to place above the legend. */
+  label?: string | null;
 
   /**
    * How to format tick values sampled from the scale’s domain. This may be a
@@ -44,81 +129,6 @@ export interface LegendOptions {
    * default, a random string prefixed with “plot-”.
    */
   className?: string | null;
-
-  /** The constant color the ramp; defaults to black. For *ramp* *opacity* legends only. */
-  color?: string;
-  /** The desired fill color of symbols; use *color* for a redundant encoding. For *symbol* legends only. */
-  fill?: string;
-  /** The desired fill opacity of symbols. For *symbol* legends only. */
-  fillOpacity?: number;
-  /** The desired opacity of the color swatches or ramp. For *color* legends only. */
-  opacity?: number;
-  /** The desired stroke color of symbols; use *color* for a redundant encoding. For *symbol* legends only. */
-  stroke?: string;
-  /** The desired stroke opacity of symbols. For *symbol* legends only. */
-  strokeOpacity?: number;
-  /** The desired stroke width of symbols. For *symbol* legends only. */
-  strokeWidth?: number;
-  /** The desired radius of symbols in pixels. For *symbol* legends only. */
-  r?: number;
-
-  /**
-   * The width of the legend in pixels. For *ramp* legends, defaults to 240; for
-   * *swatch* legends, defaults to undefined, allowing the swatches to wrap
-   * based on content flow.
-   */
-  width?: number;
-
-  /**
-   * The height of the legend in pixels; defaults to 44 plus **tickSize**. For
-   * *ramp* legends only.
-   */
-  height?: number;
-
-  /** The top margin in pixels; defaults to 18. For *ramp* legends only. */
-  marginTop?: number;
-  /** The right margin in pixels; defaults to 0. For *ramp* legends only. */
-  marginRight?: number;
-  /** The bottom margin in pixels; defaults to 16 plus **tickSize**. For *ramp* legends only. */
-  marginBottom?: number;
-  /** The left margin in pixels; defaults to 0. For *ramp* legends only. */
-  marginLeft?: number;
-
-  /** A textual label to place above the legend. For *ramp* legends only. */
-  label?: string | null;
-
-  /**
-   * The desired approximate number of axis ticks, or an explicit array of tick
-   * values, or an interval such as *day* or *month*. For *ramp* legends only.
-   */
-  ticks?: ScaleOptions["ticks"];
-
-  /**
-   * The length of axis tick marks in pixels; negative values extend in the
-   * opposite direction. For *ramp* legends only.
-   */
-  tickSize?: ScaleOptions["tickSize"];
-
-  /**
-   * If true, round the output value to the nearest integer (pixel); useful for
-   * crisp edges when rendering. For *ramp* legends only.
-   */
-  round?: ScaleOptions["round"];
-
-  /**
-   * The [CSS columns property][1], for a multi-column layout. For *swatches*
-   * legends only.
-   *
-   * [1]: https://developer.mozilla.org/en-US/docs/Web/CSS/columns
-   */
-  columns?: string;
-
-  /** The swatch width and height in pixels; defaults to 15; For *swatches* legends only. */
-  swatchSize?: number;
-  /** The swatch width in pixels; defaults to **swatchSize**; For *swatches* legends only. */
-  swatchWidth?: number;
-  /** The swatch height in pixels; defaults to **swatchSize**; For *swatches* legends only. */
-  swatchHeight?: number;
 }
 
 /** Scale definitions and options for a standalone legend. */

--- a/src/legends.js
+++ b/src/legends.js
@@ -1,7 +1,7 @@
 import {rgb} from "d3";
 import {createContext} from "./context.js";
 import {legendRamp} from "./legends/ramp.js";
-import {legendSwatches, legendSymbols} from "./legends/swatches.js";
+import {isSymbolColorLegend, legendSwatches, legendSymbols} from "./legends/swatches.js";
 import {inherit, isScaleOptions} from "./options.js";
 import {normalizeScale} from "./scales.js";
 
@@ -70,12 +70,16 @@ function interpolateOpacity(color) {
 
 export function createLegends(scales, context, options) {
   const legends = [];
+  let hasColor = false;
   for (const [key, value] of legendRegistry) {
-    const o = options[key];
-    if (o?.legend && key in scales) {
-      const legend = value(scales[key], legendOptions(context, scales[key], o), (key) => scales[key]);
-      if (legend != null) legends.push(legend);
-    }
+    if (!(key in scales)) continue;
+    if (key === "color" && hasColor) continue;
+    const o = inherit(options[key], {legend: options.legend});
+    if (!o.legend) continue;
+    const legend = value(scales[key], legendOptions(context, scales[key], o), (key) => scales[key]);
+    if (legend == null) continue;
+    if (key === "symbol" && isSymbolColorLegend(legend)) hasColor = true;
+    legends.push(legend);
   }
   return legends;
 }

--- a/src/legends/swatches.js
+++ b/src/legends/swatches.js
@@ -29,6 +29,8 @@ export function legendSwatches(color, {opacity, ...options} = {}) {
   );
 }
 
+const legendSymbolColor = new WeakSet();
+
 export function legendSymbols(
   symbol,
   {
@@ -50,7 +52,7 @@ export function legendSymbols(
   fillOpacity = maybeNumberChannel(fillOpacity)[1];
   strokeOpacity = maybeNumberChannel(strokeOpacity)[1];
   strokeWidth = maybeNumberChannel(strokeWidth)[1];
-  return legendItems(symbol, options, (selection, scale, width, height) =>
+  const legend = legendItems(symbol, options, (selection, scale, width, height) =>
     selection
       .append("svg")
       .attr("viewBox", "-8 -8 16 16")
@@ -68,6 +70,17 @@ export function legendSymbols(
         return p;
       })
   );
+  if (vf === "color" || vs === "color") legendSymbolColor.add(legend);
+  return legend;
+}
+
+/**
+ * Symbol legends can serve as color legends when the associated symbol channel
+ * is also bound to the color scale; this test allows Plot to avoid displaying a
+ * redundant color legend when a satisfying symbol legend is present.
+ */
+export function isSymbolColorLegend(legend) {
+  return legendSymbolColor.has(legend);
 }
 
 function legendItems(scale, options = {}, swatch) {

--- a/src/plot.d.ts
+++ b/src/plot.d.ts
@@ -1,5 +1,5 @@
 import type {ChannelValue} from "./channel.js";
-import type {LegendOptions} from "./legends.js";
+import type {ColorLegendOptions, LegendOptions, OpacityLegendOptions, SymbolLegendOptions} from "./legends.js";
 import type {Data, MarkOptions, Markish} from "./mark.js";
 import type {ProjectionFactory, ProjectionImplementation, ProjectionName, ProjectionOptions} from "./projection.js";
 import type {Scale, ScaleDefaults, ScaleName, ScaleOptions} from "./scales.js";
@@ -244,7 +244,7 @@ export interface PlotOptions extends ScaleDefaults {
    * scale associated with a channel by specifying the value as a {value, scale}
    * object.
    */
-  color?: ScaleOptions;
+  color?: ScaleOptions & ColorLegendOptions;
 
   /**
    * Options for the *opacity* scale for fill or stroke opacity. The *opacity*
@@ -257,7 +257,7 @@ export interface PlotOptions extends ScaleDefaults {
    * override the scale associated with a channel by specifying the value as a
    * {value, scale} object.
    */
-  opacity?: ScaleOptions;
+  opacity?: ScaleOptions & OpacityLegendOptions;
 
   /**
    * Options for the categorical *symbol* scale for dots. The *symbol* scale
@@ -270,7 +270,7 @@ export interface PlotOptions extends ScaleDefaults {
    * override the scale associated with a channel by specifying the value as a
    * {value, scale} object.
    */
-  symbol?: ScaleOptions;
+  symbol?: ScaleOptions & SymbolLegendOptions;
 
   /**
    * Options for the *length* scale for vectors. The *length* scale defaults to

--- a/src/scales.d.ts
+++ b/src/scales.d.ts
@@ -324,6 +324,17 @@ export interface ScaleDefaults extends InsetOptions {
   grid?: boolean | string | RangeInterval | Iterable<any>;
 
   /**
+   * If true, produces a legend for the scale. For quantitative color scales,
+   * the legend defaults to *ramp* but may be set to *swatches* for discrete
+   * scale types such as *threshold*. An opacity scale is treated as a color
+   * scale with varying transparency. The symbol legend is combined with color
+   * if they encode the same channels.
+   *
+   * For *color*, *opacity*, and *symbol* scales only. See also *plot*.legend.
+   */
+  legend?: LegendOptions["legend"] | boolean | null;
+
+  /**
    * A textual label to show on the axis or legend; if null, show no label. By
    * default the scale label is inferred from channel definitions, possibly with
    * an arrow (↑, →, ↓, or ←) to indicate the direction of increasing value.
@@ -533,17 +544,6 @@ export interface ScaleOptions extends ScaleDefaults {
    * last bands.
    */
   paddingOuter?: number;
-
-  /**
-   * If true, produces a legend for the scale. For quantitative color scales,
-   * the legend defaults to *ramp* but may be set to *swatches* for discrete
-   * scale types such as *threshold*. An opacity scale is treated as a color
-   * scale with varying transparency. The symbol legend is combined with color
-   * if they encode the same channels.
-   *
-   * For *color*, *opacity*, and *symbol* scales only. See also *plot*.legend.
-   */
-  legend?: LegendOptions["legend"] | boolean | null;
 
   /**
    * The desired approximate number of axis ticks, or an explicit array of tick

--- a/test/output/colorLegendOrdinalRampInline.html
+++ b/test/output/colorLegendOrdinalRampInline.html
@@ -1,0 +1,120 @@
+<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+      :where(.plot-ramp) {
+        display: block;
+        height: auto;
+        height: intrinsic;
+        max-width: 100%;
+        overflow: visible;
+      }
+
+      :where(.plot-ramp text) {
+        white-space: pre;
+      }
+    </style>
+    <g>
+      <rect x="0" y="18" width="23" height="10" fill="rgb(35, 23, 27)"></rect>
+      <rect x="24" y="18" width="23" height="10" fill="rgb(72, 96, 230)"></rect>
+      <rect x="48" y="18" width="23" height="10" fill="rgb(42, 171, 238)"></rect>
+      <rect x="72" y="18" width="23" height="10" fill="rgb(46, 229, 174)"></rect>
+      <rect x="96" y="18" width="23" height="10" fill="rgb(106, 253, 106)"></rect>
+      <rect x="120" y="18" width="23" height="10" fill="rgb(192, 238, 61)"></rect>
+      <rect x="144" y="18" width="23" height="10" fill="rgb(254, 185, 39)"></rect>
+      <rect x="168" y="18" width="23" height="10" fill="rgb(254, 110, 26)"></rect>
+      <rect x="192" y="18" width="23" height="10" fill="rgb(194, 39, 10)"></rect>
+      <rect x="216" y="18" width="23" height="10" fill="rgb(144, 12, 0)"></rect>
+    </g>
+    <g transform="translate(0,28)" fill="none" text-anchor="middle">
+      <g class="tick" opacity="1" transform="translate(12.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">A</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(36.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">B</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(60.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">C</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(84.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">D</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(108.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">E</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(132.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">F</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(156.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">G</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(180.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">H</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(204.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">I</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(228.5,0)">
+        <line stroke="currentColor" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em">J</text>
+      </g>
+    </g>
+  </svg><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+      :where(.plot) {
+        --plot-background: white;
+        display: block;
+        height: auto;
+        height: intrinsic;
+        max-width: 100%;
+      }
+
+      :where(.plot text),
+      :where(.plot tspan) {
+        white-space: pre;
+      }
+    </style>
+    <g aria-label="x-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(27,0)">
+      <path transform="translate(28,30)" d="M0,0L0,6"></path>
+      <path transform="translate(87,30)" d="M0,0L0,6"></path>
+      <path transform="translate(146,30)" d="M0,0L0,6"></path>
+      <path transform="translate(205,30)" d="M0,0L0,6"></path>
+      <path transform="translate(264,30)" d="M0,0L0,6"></path>
+      <path transform="translate(323,30)" d="M0,0L0,6"></path>
+      <path transform="translate(382,30)" d="M0,0L0,6"></path>
+      <path transform="translate(441,30)" d="M0,0L0,6"></path>
+      <path transform="translate(500,30)" d="M0,0L0,6"></path>
+      <path transform="translate(559,30)" d="M0,0L0,6"></path>
+    </g>
+    <g aria-label="x-axis tick label" transform="translate(27,9.5)">
+      <text y="0.71em" transform="translate(28,30)">0</text>
+      <text y="0.71em" transform="translate(87,30)">1</text>
+      <text y="0.71em" transform="translate(146,30)">2</text>
+      <text y="0.71em" transform="translate(205,30)">3</text>
+      <text y="0.71em" transform="translate(264,30)">4</text>
+      <text y="0.71em" transform="translate(323,30)">5</text>
+      <text y="0.71em" transform="translate(382,30)">6</text>
+      <text y="0.71em" transform="translate(441,30)">7</text>
+      <text y="0.71em" transform="translate(500,30)">8</text>
+      <text y="0.71em" transform="translate(559,30)">9</text>
+    </g>
+    <g aria-label="cell">
+      <rect x="28" width="53" y="0" height="30" fill="rgb(35, 23, 27)"></rect>
+      <rect x="87" width="53" y="0" height="30" fill="rgb(72, 96, 230)"></rect>
+      <rect x="146" width="53" y="0" height="30" fill="rgb(42, 171, 238)"></rect>
+      <rect x="205" width="53" y="0" height="30" fill="rgb(46, 229, 174)"></rect>
+      <rect x="264" width="53" y="0" height="30" fill="rgb(106, 253, 106)"></rect>
+      <rect x="323" width="53" y="0" height="30" fill="rgb(192, 238, 61)"></rect>
+      <rect x="382" width="53" y="0" height="30" fill="rgb(254, 185, 39)"></rect>
+      <rect x="441" width="53" y="0" height="30" fill="rgb(254, 110, 26)"></rect>
+      <rect x="500" width="53" y="0" height="30" fill="rgb(194, 39, 10)"></rect>
+      <rect x="559" width="53" y="0" height="30" fill="rgb(144, 12, 0)"></rect>
+    </g>
+  </svg></figure>

--- a/test/plots/athletes-sort.ts
+++ b/test/plots/athletes-sort.ts
@@ -16,7 +16,7 @@ export async function athletesSortFacet() {
 export async function athletesSortNationality() {
   const athletes = await d3.csv<any>("data/athletes.csv", d3.autoType);
   return Plot.plot({
-    color: {legend: true},
+    legend: true,
     marks: [
       Plot.dot(
         athletes,
@@ -34,7 +34,7 @@ export async function athletesSortNationality() {
 export async function athletesSortNullLimit() {
   const athletes = await d3.csv<any>("data/athletes.csv", d3.autoType);
   return Plot.plot({
-    color: {legend: true},
+    legend: true,
     marks: [Plot.dot(athletes, {x: "height", y: "weight", stroke: "nationality", sort: {color: null, limit: 10}})]
   });
 }
@@ -42,7 +42,6 @@ export async function athletesSortNullLimit() {
 export async function athletesSortWeightLimit() {
   const athletes = await d3.csv<any>("data/athletes.csv", d3.autoType);
   return Plot.plot({
-    color: {legend: true},
     marks: [
       Plot.dot(athletes, {x: "weight", y: "nationality", sort: {y: "x", reduce: "median", limit: 10}}),
       Plot.tickX(athletes, Plot.groupY({x: "median"}, {x: "weight", y: "nationality", stroke: "red", strokeWidth: 2}))

--- a/test/plots/decathlon.ts
+++ b/test/plots/decathlon.ts
@@ -6,9 +6,7 @@ export async function decathlon() {
   return Plot.plot({
     grid: true,
     inset: 12,
-    symbol: {
-      legend: true
-    },
+    symbol: {legend: true},
     marks: [Plot.dot(decathlon, {x: "Long Jump", y: "100 Meters", symbol: "Country", stroke: "Country"})]
   });
 }

--- a/test/plots/legend-color.ts
+++ b/test/plots/legend-color.ts
@@ -58,6 +58,14 @@ export function colorLegendOrdinalRamp() {
   return Plot.legend({color: {type: "ordinal", domain: "ABCDEFGHIJ"}, legend: "ramp"});
 }
 
+export function colorLegendOrdinalRampInline() {
+  return Plot.plot({
+    legend: "ramp",
+    color: {type: "ordinal", domain: "ABCDEFGHIJ"},
+    marks: [Plot.cellX("ABCDEFGHIJ")]
+  });
+}
+
 export function colorLegendOrdinalRampTickSize() {
   return Plot.legend({
     color: {


### PR DESCRIPTION
This introduces a new top-level **legend** option which is inherited by scales that support legends (_color_, _symbol_, and _opacity_). This makes it slightly more concise to enable legends, and takes us a step closer to enabling them automatically if desired. For example:

<img width="660" alt="Screenshot 2024-11-23 at 9 31 27 AM" src="https://github.com/user-attachments/assets/1c469f7a-c23b-452f-81f7-a947af19dd92">

```js
Plot.plot({
  grid: true,
  inset: 12,
  legend: true,
  marks: [Plot.dot(decathlon, {x: "Long Jump", y: "100 Meters", symbol: "Country", stroke: "Country"})]
})
```

Note above that Plot is smart enough to realize that the _symbol_ legend subsumes the _color_ legend, and hence the _color_ legend does not need to be displayed separately. Plot now suppresses the _color_ legend automatically when the _symbol_ legend also encodes _color_. You can force separate legends by using the **stroke** _symbol_ legend option:

<img width="662" alt="Screenshot 2024-11-23 at 9 35 04 AM" src="https://github.com/user-attachments/assets/a67b26e8-6fef-4189-93a9-c3cea84b913a">

```js
Plot.plot({
  grid: true,
  inset: 12,
  legend: true,
  symbol: {stroke: "currentColor"},
  marks: [Plot.dot(decathlon, {x: "Long Jump", y: "100 Meters", symbol: "Country", stroke: "Country"})]
})
```

I considered the alternative below, which we could have display a colorless _symbol_ legend and no _color_ legend, but it would require more finagling to allow the _symbol_ legend to read the _color_ legend options; let me know if you prefer it:

```js
Plot.plot({
  grid: true,
  inset: 12,
  legend: true,
  color: {legend: false},
  marks: [Plot.dot(decathlon, {x: "Long Jump", y: "100 Meters", symbol: "Country", stroke: "Country"})]
})
```

I also wasn’t sure if we wanted a way to force the display of separate _symbol_ and _color_ legends, as this currently displays only a joint legend (which I think makes sense, since it’s equivalent to inheriting the top-level option):

```js
Plot.plot({
  grid: true,
  inset: 12,
  color: {legend: true},
  symbol: {legend: true},
  marks: [Plot.dot(decathlon, {x: "Long Jump", y: "100 Meters", symbol: "Country", stroke: "Country"})]
})
```

Lastly, this fixes a types bug where legend options were not allowed on scale options. For example, setting the **stroke** _symbol_ legend option previously errored with `Object literal may only specify known properties, and 'stroke' does not exist in type 'ScaleOptions'.` This also introduces more specific types for legend options for additional safety.