### PR TITLE
_plot_.rescale

### DIFF
--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -259,6 +259,7 @@ export * from "./raster-vapor.js";
 export * from "./raster-walmart.js";
 export * from "./rect-band.js";
 export * from "./reducer-scale-override.js";
+export * from "./rescale.js";
 export * from "./rounded-rect.js";
 export * from "./seattle-precipitation-density.js";
 export * from "./seattle-precipitation-rule.js";

--- a/test/plots/rescale.ts
+++ b/test/plots/rescale.ts
@@ -1,0 +1,18 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export async function rescaleZoom() {
+  const data = await d3.csv<any>("data/gistemp.csv", d3.autoType);
+  const plot = Plot.dot(data, {x: "Date", y: "Anomaly", stroke: "Anomaly"}).plot();
+  requestAnimationFrame(() => {
+    let frame: number;
+    (function tick(now) {
+      if (!plot.isConnected) return cancelAnimationFrame(frame);
+      const t = (Math.sin(now / 2000) + 1) / 2;
+      const [x1, x2] = plot.scale("x").domain;
+      plot.rescale({x: {domain: [+x1 + ((x2 - x1) / 2) * t, +x1 + ((x2 - x1) / 2) * (t + 1)]}});
+      frame = requestAnimationFrame(tick);
+    })(performance.now());
+  });
+  return plot;
+}


### PR DESCRIPTION
This is a first cut at an alternate take to zooming, focusing on the programmatic API first rather than the interaction. This expose a _plot_.rescale method that takes scale definitions, allowing scales to be modified after a plot is rendered; the plot is re-rendered in place with the new scale definitions.

For zooming, we would use _plot_.rescale to redefine the _x_ and _y_ domains (or, in the case of an ordinal position scale, we might redefine the range instead). But the _plot_.rescale method could have other uses as well, such as adjusting the _r_ scale as you zoom in or out, switching from [a _linear_ to a _log_ scale](https://observablehq.com/@d3/new-zealand-tourists-1921-2018), redefining the _color_ scale to highlight certain elements, and so on.

Additionally, it should be simpler to sketch this if we focus on the programmatic API first. We should be able to easily implement interactive zooming and [zoom transitions](https://observablehq.com/@d3/scatterplot-tour) on top of this API.

The implementation so far is as minimal as I could make it. The plot is re-rendered, and then the contents of the old plot are replaced with the contents of the new plot. I don’t think this approach will work as-is (for example, I think it breaks the tip mark); but I think we can make a smarter, faster implementation that has the same API.

We also need to figure out what scale options are valid to pass to _plot_.rescale. Since these options are merged not with the original options, but with the materialized scales, the results may not be what you expect; for example, passing the **scheme** option for a _color_ scale typically has no effect because it is lower priority than the materialized **range** or **interpolate** option.

https://github.com/user-attachments/assets/9d8aae3a-c275-45c8-b267-2ff4da2bb223

Fixes #1590.

Previously #2083 #1964 #1738.