### PR TITLE
let the pointer's pointerdown event propagate

### DIFF
--- a/src/interactions/pointer.js
+++ b/src/interactions/pointer.js
@@ -4,6 +4,7 @@ import {isArray} from "../options.js";
 import {applyFrameAnchor} from "../style.js";
 
 const states = new WeakMap();
+const processedEvents = new WeakSet();
 
 function pointerK(kx, ky, {x, y, px, py, maxRadius = 40, channels, render, ...options} = {}) {
   maxRadius = +maxRadius;
@@ -162,12 +163,13 @@ function pointerK(kx, ky, {x, y, px, py, maxRadius = 40, channels, render, ...op
       }
 
       function pointerdown(event) {
+        if (processedEvents.has(event)) return; // ignore same event on a shared pointer
+        processedEvents.add(event);
         if (event.pointerType !== "mouse") return;
         if (i == null) return; // not pointing
         if (state.sticky && state.roots.some((r) => r?.contains(event.target))) return; // stay sticky
         if (state.sticky) (state.sticky = false), state.renders.forEach((r) => r(null)); // clear all pointers
         else (state.sticky = true), render(i);
-        event.stopImmediatePropagation(); // suppress other pointers
       }
 
       function pointerleave(event) {


### PR DESCRIPTION
Controlling this event is necessary because (internally) we only want to process it once, even when it's tied to several marks. This typically happens on the crosshair mark which uses the same shared pointer transform on its submarks, resulting in an even number of flag toggling.

However for some applications the upstream app also wants to see that event.

In this PR, instead of preventing propagation, we ignore internal duplicate handling.

closes #2052

cc: @jheer 