### PR TITLE
the window transform should respect *z* series

### DIFF
--- a/test/plots/index.ts
+++ b/test/plots/index.ts
@@ -356,4 +356,5 @@ export * from "./yearly-requests-dot.js";
 export * from "./yearly-requests-line.js";
 export * from "./yearly-requests.js";
 export * from "./young-adults.js";
+export * from "./window.js";
 export * from "./zero.js";

--- a/test/plots/window.ts
+++ b/test/plots/window.ts
@@ -1,0 +1,40 @@
+import * as Plot from "@observablehq/plot";
+import * as d3 from "d3";
+
+export async function windowZ() {
+  const random = d3.randomLcg(42);
+  const data = d3.sort(
+    ["a", "b", "c"].flatMap((type, i) =>
+      d3.utcDay.range(new Date("2024-01-01"), new Date("2025-01-01"), [1, 7, 30][i]).map((date) => ({
+        type,
+        date,
+        value: ((random() * 1000) | 0) + i * 1500
+      }))
+    ),
+    (d) => d.date
+  );
+
+  return Plot.plot({
+    y: {grid: true},
+    marks: [
+      Plot.dot(data, {
+        x: "date",
+        y: "value",
+        fill: "type",
+        r: 1.5
+      }),
+      Plot.lineY(
+        data,
+        Plot.windowY({
+          x: "date",
+          y: "value",
+          anchor: "end",
+          stroke: {value: "type"},
+          k: 10,
+          reduce: "mean",
+          tip: true
+        })
+      )
+    ]
+  });
+}


### PR DESCRIPTION
Currently *z* is specified as `stroke: {value: "series"}`, it is ignored and we get the incorrect chart.


| correct | incorrect |
|--|--|
| <img width="643" alt="Image" src="https://github.com/user-attachments/assets/000b2ead-a5ce-4d67-9659-9401ba4c074b" /> | <img width="657" alt="Image" src="https://github.com/user-attachments/assets/73a6afae-91e2-4eda-a9d1-704ec459edf6" /> |