### PR TITLE
Handle null titles/empty channels in Tip

### DIFF
--- a/src/marks/tip.js
+++ b/src/marks/tip.js
@@ -155,7 +155,7 @@ export class Tip extends Mark {
                 for (const line of mark.splitLines(lines)) {
                   renderLine(that, {value: mark.clipLine(line)});
                 }
-              } else {
+              } else if (isIterable(lines)) {
                 const labels = new Set();
                 for (const line of lines) {
                   const {label = ""} = line;


### PR DESCRIPTION
Aims to fix https://github.com/observablehq/plot/issues/2274

This PR allows the `render` function of tooltips (`Tip`) to handle `null` values for a `title`.

See the issue linked above for steps to reproduce the issue and some more reasoning behind this PR.