### PR TITLE
fix arcCollatzUp snapshot for dark mode

### DIFF
--- a/test/output/arcCollatzUp.svg
+++ b/test/output/arcCollatzUp.svg
@@ -15,53 +15,53 @@
   </style>
   <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
     <text y="0.71em" transform="translate(20,230)">1</text>
-    <text y="0.71em" transform="translate(59.814200398142006,230)">2</text>
-    <text y="0.71em" transform="translate(99.62840079628401,230)">3</text>
-    <text y="0.71em" transform="translate(139.442601194426,230)">4</text>
-    <text y="0.71em" transform="translate(179.25680159256802,230)">5</text>
-    <text y="0.71em" transform="translate(219.07100199071002,230)">6</text>
-    <text y="0.71em" transform="translate(258.885202388852,230)">7</text>
-    <text y="0.71em" transform="translate(298.699402786994,230)">8</text>
-    <text y="0.71em" transform="translate(338.51360318513605,230)">9</text>
-    <text y="0.71em" transform="translate(378.327803583278,230)">10</text>
-    <text y="0.71em" transform="translate(418.14200398142003,230)">11</text>
-    <text y="0.71em" transform="translate(457.95620437956205,230)">12</text>
-    <text y="0.71em" transform="translate(497.770404777704,230)">13</text>
-    <text y="0.71em" transform="translate(537.584605175846,230)">14</text>
-    <text y="0.71em" transform="translate(577.398805573988,230)">15</text>
-    <text y="0.71em" transform="translate(617.2130059721301,230)">16</text>
+    <text y="0.71em" transform="translate(59.814,230)">2</text>
+    <text y="0.71em" transform="translate(99.628,230)">3</text>
+    <text y="0.71em" transform="translate(139.443,230)">4</text>
+    <text y="0.71em" transform="translate(179.257,230)">5</text>
+    <text y="0.71em" transform="translate(219.071,230)">6</text>
+    <text y="0.71em" transform="translate(258.885,230)">7</text>
+    <text y="0.71em" transform="translate(298.699,230)">8</text>
+    <text y="0.71em" transform="translate(338.514,230)">9</text>
+    <text y="0.71em" transform="translate(378.328,230)">10</text>
+    <text y="0.71em" transform="translate(418.142,230)">11</text>
+    <text y="0.71em" transform="translate(457.956,230)">12</text>
+    <text y="0.71em" transform="translate(497.77,230)">13</text>
+    <text y="0.71em" transform="translate(537.585,230)">14</text>
+    <text y="0.71em" transform="translate(577.399,230)">15</text>
+    <text y="0.71em" transform="translate(617.213,230)">16</text>
   </g>
   <g aria-label="dot" transform="translate(0.5,0.5)">
-    <circle cx="457.95620437956205" cy="230" r="3"></circle>
-    <circle cx="219.07100199071002" cy="230" r="3"></circle>
-    <circle cx="99.62840079628401" cy="230" r="3"></circle>
-    <circle cx="378.327803583278" cy="230" r="3"></circle>
-    <circle cx="179.25680159256802" cy="230" r="3"></circle>
-    <circle cx="617.2130059721301" cy="230" r="3"></circle>
-    <circle cx="298.699402786994" cy="230" r="3"></circle>
-    <circle cx="139.442601194426" cy="230" r="3"></circle>
-    <circle cx="59.814200398142006" cy="230" r="3"></circle>
+    <circle cx="457.956" cy="230" r="3"></circle>
+    <circle cx="219.071" cy="230" r="3"></circle>
+    <circle cx="99.628" cy="230" r="3"></circle>
+    <circle cx="378.328" cy="230" r="3"></circle>
+    <circle cx="179.257" cy="230" r="3"></circle>
+    <circle cx="617.213" cy="230" r="3"></circle>
+    <circle cx="298.699" cy="230" r="3"></circle>
+    <circle cx="139.443" cy="230" r="3"></circle>
+    <circle cx="59.814" cy="230" r="3"></circle>
     <circle cx="20" cy="230" r="3"></circle>
   </g>
   <g aria-label="arrow" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-miterlimit="1" transform="translate(0.5,-2.5)">
-    <path d="M456.5284561815613,226.26348623940657A125.62523272957182,125.62523272957182 0,0,0 223.28574421658072,226.26348623940655M229.57470709714275,221.3188987048479L223.28574421658072,226.26348623940655L222.1480872406981,218.34479085410314" stroke="url(#gradient1)"></path>
-    <path d="M214.79259700830744,226.2884378807972A60.58822354242419,60.58822354242419 0,0,0 103.90680577868648,226.28843788079743M110.36111266683405,221.5617135823418L103.90680577868648,226.28843788079743L103.04049590361251,218.33548200261293" stroke="url(#gradient1)"></path>
-    <path d="M98.2590676323372,226.25964738628778A151.25871192059745,151.25871192059745 0,0,1 379.6971367472248,226.25964738628778M380.8775106157225,218.3472067052736L379.6971367472248,226.25964738628778L373.43494904577796,221.28119328969842" stroke="url(#gradient0)"></path>
-    <path d="M374.09997124419647,226.26851437615696A102.95761063502849,102.95761063502849 0,0,0 183.48463393164946,226.26851437615719M189.80810994787174,221.36814183192533L183.48463393164946,226.26851437615719L182.40252482844804,218.34203723377112" stroke="url(#gradient1)"></path>
-    <path d="M177.86969333582354,226.25295852334335A235.99748610580613,235.99748610580613 0,0,1 618.6001142288738,226.25295852334165M619.8555702259351,218.35208324022L618.6001142288738,226.25295852334165L612.3854835200885,221.21526409499216" stroke="url(#gradient0)"></path>
-    <path d="M613.0128828337062,226.25793290855145A166.51169127393499,166.51169127393499 0,0,0 302.89952592541783,226.25793290855145M309.1496343918226,221.26432257551826L302.89952592541783,226.25793290855145L301.69998675361296,218.34837503372017" stroke="url(#gradient1)"></path>
-    <path d="M294.4528055185841,226.27581440040845A81.77291708872636,81.77291708872636 0,0,0 143.6891984628359,226.27581440040865M150.06168742567,221.43935035954598L143.6891984628359,226.27581440040865L142.68694222037593,218.33884505282703" stroke="url(#gradient1)"></path>
-    <path d="M135.09850655640054,226.31551391780982A39.40352999612204,39.40352999612204 0,0,0 64.15829503616749,226.31551391780988M70.7764154813151,221.82101931068004L64.15829503616749,226.31551391780988L63.575008751794705,218.33680618344195" stroke="url(#gradient1)"></path>
-    <path d="M55.2846262362921,226.39952579836236A19.701764998061012,19.701764998061012 0,0,0 21.742580133979974,226.39952579836233M28.783264927613768,222.60100534472596L21.742580133979974,226.39952579836233L21.973307321152987,218.40285368021847" stroke="url(#gradient1)"></path>
+    <path d="M456.528,226.263A125.625,125.625 0,0,0 223.286,226.263M229.575,221.319L223.286,226.263L222.148,218.345" stroke="url(#gradient1)"></path>
+    <path d="M214.793,226.288A60.588,60.588 0,0,0 103.907,226.288M110.361,221.562L103.907,226.288L103.04,218.335" stroke="url(#gradient1)"></path>
+    <path d="M98.259,226.26A151.259,151.259 0,0,1 379.697,226.26M380.878,218.347L379.697,226.26L373.435,221.281" stroke="url(#gradient0)"></path>
+    <path d="M374.1,226.269A102.958,102.958 0,0,0 183.485,226.269M189.808,221.368L183.485,226.269L182.403,218.342" stroke="url(#gradient1)"></path>
+    <path d="M177.87,226.253A235.997,235.997 0,0,1 618.6,226.253M619.856,218.352L618.6,226.253L612.385,221.215" stroke="url(#gradient0)"></path>
+    <path d="M613.013,226.258A166.512,166.512 0,0,0 302.9,226.258M309.15,221.264L302.9,226.258L301.7,218.348" stroke="url(#gradient1)"></path>
+    <path d="M294.453,226.276A81.773,81.773 0,0,0 143.689,226.276M150.062,221.439L143.689,226.276L142.687,218.339" stroke="url(#gradient1)"></path>
+    <path d="M135.099,226.316A39.404,39.404 0,0,0 64.158,226.316M70.776,221.821L64.158,226.316L63.575,218.337" stroke="url(#gradient1)"></path>
+    <path d="M55.285,226.4A19.702,19.702 0,0,0 21.743,226.4M28.783,222.601L21.743,226.4L21.973,218.403" stroke="url(#gradient1)"></path>
   </g>
   <defs>
     <linearGradient id="gradient0" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="5%" stop-opacity="0.3"></stop>
-      <stop offset="95%" stop-opacity="1"></stop>
+      <stop offset="5%" stop-color="currentColor" stop-opacity="0.3"></stop>
+      <stop offset="95%" stop-color="currentColor" stop-opacity="1"></stop>
     </linearGradient>
     <linearGradient id="gradient1" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="5%" stop-opacity="1"></stop>
-      <stop offset="95%" stop-opacity="0.3"></stop>
+      <stop offset="5%" stop-color="currentColor" stop-opacity="1"></stop>
+      <stop offset="95%" stop-color="currentColor" stop-opacity="0.3"></stop>
     </linearGradient>
   </defs>
 </svg>

--- a/test/plots/arc.ts
+++ b/test/plots/arc.ts
@@ -52,12 +52,12 @@ export async function arcCollatzUp() {
       () =>
         svg`<defs>
         <linearGradient id="gradient0" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="5%" stop-opacity="0.3"></stop>
-          <stop offset="95%" stop-opacity="1"></stop>
+          <stop offset="5%" stop-color="currentColor" stop-opacity="0.3"></stop>
+          <stop offset="95%" stop-color="currentColor" stop-opacity="1"></stop>
         </linearGradient>
         <linearGradient id="gradient1" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="5%" stop-opacity="1"></stop>
-          <stop offset="95%" stop-opacity="0.3"></stop>
+          <stop offset="5%" stop-color="currentColor" stop-opacity="1"></stop>
+          <stop offset="95%" stop-color="currentColor" stop-opacity="0.3"></stop>
         </linearGradient>`
     ]
   });


### PR DESCRIPTION
Straightforward fix on a snapshot test, to support dark mode (adopt currentColor)

| before | after |
|-|-|
| <img width="1306" height="534" alt="before" src="https://github.com/user-attachments/assets/d42ce7a7-2d22-4ed6-9ecf-994bdea0b0b9" /> | <img width="1306" height="534" alt="after" src="https://github.com/user-attachments/assets/77be21e3-1482-4c2a-8c27-8b993911a5e9" /> |
