### PR TITLE
simplify the availability test

### DIFF
--- a/test/plots/availability.ts
+++ b/test/plots/availability.ts
@@ -13,15 +13,12 @@ export async function availability() {
         curve: "step",
         fill: "#f2f2fe"
       }),
-      Plot.lineY(
-        data,
-        Plot.stackY2({
-          x: "date",
-          y: "value",
-          interval: "day",
-          curve: "step"
-        })
-      ),
+      Plot.lineY(data, {
+        x: "date",
+        y: "value",
+        interval: "day",
+        curve: "step"
+      }),
       Plot.ruleY([0])
     ]
   });


### PR DESCRIPTION
Note: the custom `sum` reducer was never necessary for this snapshot test, since `maybeDenseInterval` with the default `filter: null` option was introduced in the same PR #792