### PR TITLE
default zero offset in windowless environments

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -6,7 +6,7 @@ import {isNone, isNoneish, isRound, maybeColorChannel, maybeNumberChannel} from 
 import {keyof, number, string} from "./options.js";
 import {warn} from "./warnings.js";
 
-export let offset = typeof window === "undefined" || window.devicePixelRatio > 1 ? 0 : 0.5;
+export let offset = typeof window !== "undefined" && !(window.devicePixelRatio > 1) ? 0.5 : 0;
 
 export function setOffset(o) {
   offset = o;


### PR DESCRIPTION
No tests here (because the tests now explicitly set the offset to 0.5), but as we’ve been discussing, this is probably a better default for server-side (“windowless”) environments.