### PR TITLE
fix: preserve iterator data for mark facets

### DIFF
--- a/src/plot.js
+++ b/src/plot.js
@@ -483,7 +483,9 @@ function maybeMarkFacet(mark, topFacetState, options) {
   // here with maybeTopFacet that we could reduce.
   const {fx, fy} = mark;
   if (fx != null || fy != null) {
-    const data = dataify(mark.data ?? fx ?? fy);
+    const value = mark.data ?? fx ?? fy;
+    const data = dataify(value);
+    if (mark.data === value && value?.[Symbol.iterator]?.() === value) mark.data = data;
     if (data === undefined) throw new Error(`missing facet data in ${mark.ariaLabel}`);
     if (data === null) return; // ignore channel definitions if no data is provided TODO this right?
     const channels = {};

--- a/test/facet-test.js
+++ b/test/facet-test.js
@@ -36,3 +36,18 @@ it("detects missing facet data", async () => {
   assert.throws(() => Plot.barY([], {x: "x", y: "y"}).plot({facet: {x: "fx"}}), /missing facet data/);
   assert.throws(() => Plot.barY([], {x: "x", y: "y"}).plot({facet: {data: null, x: "fx"}}), /missing facet data/);
 });
+it("supports mark-level faceting with iterator data", () => {
+  assert.deepStrictEqual(Plot.dot(["ab"], {fy: "1"}).plot().scale("y").domain, ["b"]);
+  assert.deepStrictEqual(
+    Plot.dot(new Set(["ab"]), {fy: "1"})
+      .plot()
+      .scale("y").domain,
+    ["b"]
+  );
+  assert.deepStrictEqual(
+    Plot.dot(new Set(["ab"]).values(), {fy: "1"})
+      .plot()
+      .scale("y").domain,
+    ["b"]
+  );
+});


### PR DESCRIPTION
Fixes #2430.

This preserves iterator-backed mark data when mark-level facets are evaluated. The facet setup already materializes the iterator through `dataify`; without assigning that materialized array back to the mark, the mark later sees an exhausted iterator and derives an invalid y domain.

Added regression coverage for array, iterable, and iterator mark data with `fy`.

Verification:
- `pnpm run test:vitest run test/facet-test.js`
- `pnpm run test:tsc`
- `pnpm run test:lint`
- `pnpm run test:prettier`
