### PR TITLE
Allow tip format functions to return DOM nodes for rich text

### DIFF
--- a/docs/marks/tip.md
+++ b/docs/marks/tip.md
@@ -135,6 +135,19 @@ Plot.rectY(olympians, Plot.binX({y: "sum"}, {x: "weight", y: (d) => d.sex === "m
 
 The order and formatting of channels in the tip can be customized with the **format** option <VersionBadge version="0.6.11" pr="1823" />, which accepts a key-value object mapping channel names to formats. Each [format](../features/formats.md) can be a string (for number or time formats), a function that receives the value as input and returns a string, true to use the default format, and null or false to suppress. The order of channels in the tip follows their order in the format object followed by any additional channels. When using the **title** channel, the **format** option may be specified as a string or a function; the given format will then apply to the **title** channel. <VersionBadge version="0.6.15" pr="2074" />
 
+A format function may also return a DOM node instead of a string, such as an SVG tspan or anchor element (say generated with [Hypertext Literal](https://github.com/observablehq/htl)); the returned node is appended directly to the tip, allowing styled and hyperlinked rich text. <VersionBadge version="0.6.18" pr="1767" /> For example, to render the **title** channel in bold followed by a link:
+
+```js
+Plot.tip(data, {
+  title: "name",
+  format: {
+    title: (name) => htl.svg`<tspan><tspan font-weight="bold">${name}</tspan> <a fill="blue" href="/details/${name}">details</a></tspan>`
+  }
+})
+```
+
+Only DOM nodes returned by a format function are treated as rich content; plain strings are always rendered as text, so this does not introduce any HTML injection. Because a returned node is appended as-is rather than measured, the **lineWidth** and **textOverflow** options do not apply to it.
+
 A channel’s label can be specified alongside its value as a {value, label} object; if a channel label is not specified, the associated scale’s label is used, if any; if there is no associated scale, or if the scale has no label, the channel name is used instead.
 
 :::plot defer https://observablehq.com/@observablehq/plot-tip-format

--- a/docs/marks/tip.md
+++ b/docs/marks/tip.md
@@ -135,7 +135,7 @@ Plot.rectY(olympians, Plot.binX({y: "sum"}, {x: "weight", y: (d) => d.sex === "m
 
 The order and formatting of channels in the tip can be customized with the **format** option <VersionBadge version="0.6.11" pr="1823" />, which accepts a key-value object mapping channel names to formats. Each [format](../features/formats.md) can be a string (for number or time formats), a function that receives the value as input and returns a string, true to use the default format, and null or false to suppress. The order of channels in the tip follows their order in the format object followed by any additional channels. When using the **title** channel, the **format** option may be specified as a string or a function; the given format will then apply to the **title** channel. <VersionBadge version="0.6.15" pr="2074" />
 
-A format function may also return a DOM node instead of a string, such as an SVG tspan or anchor element (say generated with [Hypertext Literal](https://github.com/observablehq/htl)); the returned node is appended directly to the tip, allowing styled and hyperlinked rich text. <VersionBadge version="0.6.18" pr="1767" /> For example, to render the **title** channel in bold followed by a link:
+A format function may also return a DOM node, such as an SVG tspan or anchor element (say generated with [Hypertext Literal](https://github.com/observablehq/htl)); the returned node is appended directly to the tip, allowing styled and hyperlinked rich text. <VersionBadge pr="2444" /> For example, to render the **title** channel in bold followed by a link:
 
 ```js
 Plot.tip(data, {
@@ -146,7 +146,7 @@ Plot.tip(data, {
 })
 ```
 
-Only DOM nodes returned by a format function are treated as rich content; plain strings are always rendered as text, so this does not introduce any HTML injection. Because a returned node is appended as-is rather than measured, the **lineWidth** and **textOverflow** options do not apply to it.
+When returning nodes, the **lineWidth** and **textOverflow** options are ignored.
 
 A channel’s label can be specified alongside its value as a {value, label} object; if a channel label is not specified, the associated scale’s label is used, if any; if there is no associated scale, or if the scale has no label, the channel name is used instead.
 

--- a/src/marks/tip.d.ts
+++ b/src/marks/tip.d.ts
@@ -93,10 +93,15 @@ export interface TipOptions extends MarkOptions, TextStyles {
  * - a [d3-time-format][2] string for temporal scales
  * - a function passed a channel *value* and *index*, returning a string
  *
+ * A format function may also return a DOM node (such as an SVG tspan or anchor
+ * element, say generated with Hypertext Literal); the returned node is appended
+ * directly to the tip, allowing styled and hyperlinked rich text. Nodes are not
+ * measured, so the **lineWidth** and **textOverflow** options do not apply.
+ *
  * [1]: https://d3js.org/d3-time
  * [2]: https://d3js.org/d3-time-format
  */
-export type TipFormat = string | ((d: any, i: number) => string);
+export type TipFormat = string | ((d: any, i: number) => string | Node);
 
 /**
  * Returns a new tip mark for the given *data* and *options*.

--- a/src/marks/tip.js
+++ b/src/marks/tip.js
@@ -157,10 +157,10 @@ export class Tip extends Mark {
               this.setAttribute("stroke", "none");
               // iteratively render each channel value
               const lines = T[i];
-              if (isNode(lines)) {
+              if (lines?.ownerDocument) {
                 // A format function may return a DOM node (e.g., an SVG tspan
                 // or anchor) to display styled or hyperlinked rich text.
-                renderLine(that, {value: lines});
+                renderNodeLine(that, {value: lines});
               } else if (typeof lines === "string") {
                 for (const line of mark.splitLines(lines)) {
                   renderLine(that, {value: mark.clipLine(line)});
@@ -184,21 +184,9 @@ export class Tip extends Mark {
     // exact text metrics and translate the text as needed once we know the
     // tip’s orientation (anchor).
     function renderLine(selection, {label, value, color, opacity}) {
+      if (value?.ownerDocument) return renderNodeLine(selection, {label, value, color, opacity});
       (label ??= ""), (value ??= "");
       const swatch = color != null || opacity != null;
-
-      // If the value is a DOM node — such as an SVG tspan or anchor returned by
-      // a custom format function — append it directly rather than wrapping it
-      // in a text node. This allows styled and hyperlinked rich text in the
-      // tip. Such values are appended as-is and hence are not measured, so the
-      // lineWidth and textOverflow options do not apply.
-      if (isNode(value)) {
-        const line = selection.append("tspan").attr("x", 0).attr("dy", `${lineHeight}em`).text("\u200b"); // zwsp for double-click
-        if (label) line.append("tspan").attr("font-weight", "bold").text(label);
-        line.append(() => value);
-        if (swatch) line.append("tspan").text(" ■").attr("fill", color).attr("fill-opacity", opacity).style("user-select", "none"); // prettier-ignore
-        return;
-      }
 
       let title;
       let w = lineWidth * 100;
@@ -222,6 +210,22 @@ export class Tip extends Mark {
       if (value) line.append(() => document.createTextNode(value));
       if (swatch) line.append("tspan").text(" ■").attr("fill", color).attr("fill-opacity", opacity).style("user-select", "none"); // prettier-ignore
       if (title) line.append("title").text(title);
+    }
+
+    // Renders a single line whose value is a DOM node, such as an SVG tspan or
+    // anchor returned by a custom format function. The node is appended
+    // directly rather than wrapped in a text node, allowing styled and
+    // hyperlinked rich text. Such values are appended as-is and hence are not
+    // measured, so the lineWidth and textOverflow options are ignored.
+    function renderNodeLine(selection, {label, value, color, opacity}) {
+      const swatch = color != null || opacity != null;
+      const line = selection.append("tspan").attr("x", 0).attr("dy", `${lineHeight}em`).text("\u200b"); // zwsp for double-click
+      if (label) {
+        line.append("tspan").attr("font-weight", "bold").text(label);
+        line.append(() => document.createTextNode(" "));
+      }
+      line.append(() => value);
+      if (swatch) line.append("tspan").text(" ■").attr("fill", color).attr("fill-opacity", opacity).style("user-select", "none"); // prettier-ignore
     }
 
     // Only after the plot is attached to the page can we compute the exact text
@@ -284,12 +288,6 @@ export class Tip extends Mark {
 export function tip(data, {x, y, ...options} = {}) {
   if (options.frameAnchor === undefined) [x, y] = maybeTuple(x, y);
   return new Tip(data, {...options, x, y});
-}
-
-// Returns true if the given value is a DOM node, such as an SVG element
-// returned by a custom format function for rich-text tip content.
-function isNode(value) {
-  return value != null && typeof value === "object" && typeof value.nodeType === "number";
 }
 
 function getLineOffset(anchor, length, lineHeight) {

--- a/src/marks/tip.js
+++ b/src/marks/tip.js
@@ -157,7 +157,11 @@ export class Tip extends Mark {
               this.setAttribute("stroke", "none");
               // iteratively render each channel value
               const lines = T[i];
-              if (typeof lines === "string") {
+              if (isNode(lines)) {
+                // A format function may return a DOM node (e.g., an SVG tspan
+                // or anchor) to display styled or hyperlinked rich text.
+                renderLine(that, {value: lines});
+              } else if (typeof lines === "string") {
                 for (const line of mark.splitLines(lines)) {
                   renderLine(that, {value: mark.clipLine(line)});
                 }
@@ -182,6 +186,20 @@ export class Tip extends Mark {
     function renderLine(selection, {label, value, color, opacity}) {
       (label ??= ""), (value ??= "");
       const swatch = color != null || opacity != null;
+
+      // If the value is a DOM node — such as an SVG tspan or anchor returned by
+      // a custom format function — append it directly rather than wrapping it
+      // in a text node. This allows styled and hyperlinked rich text in the
+      // tip. Such values are appended as-is and hence are not measured, so the
+      // lineWidth and textOverflow options do not apply.
+      if (isNode(value)) {
+        const line = selection.append("tspan").attr("x", 0).attr("dy", `${lineHeight}em`).text("\u200b"); // zwsp for double-click
+        if (label) line.append("tspan").attr("font-weight", "bold").text(label);
+        line.append(() => value);
+        if (swatch) line.append("tspan").text(" ■").attr("fill", color).attr("fill-opacity", opacity).style("user-select", "none"); // prettier-ignore
+        return;
+      }
+
       let title;
       let w = lineWidth * 100;
       const [j] = cut(label, w, widthof, ee);
@@ -266,6 +284,12 @@ export class Tip extends Mark {
 export function tip(data, {x, y, ...options} = {}) {
   if (options.frameAnchor === undefined) [x, y] = maybeTuple(x, y);
   return new Tip(data, {...options, x, y});
+}
+
+// Returns true if the given value is a DOM node, such as an SVG element
+// returned by a custom format function for rich-text tip content.
+function isNode(value) {
+  return value != null && typeof value === "object" && typeof value.nodeType === "number";
 }
 
 function getLineOffset(anchor, length, lineHeight) {

--- a/test/output/tipFormatChannelMarkup.svg
+++ b/test/output/tipFormatChannelMarkup.svg
@@ -22,7 +22,7 @@
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
     <g transform="translate(320,60)">
       <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
-      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">Name</tspan><tspan fill="red">Bob</tspan></tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">Name</tspan> <tspan fill="red">Bob</tspan></tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
     </g>
   </g>
 </svg>

--- a/test/output/tipFormatChannelMarkup.svg
+++ b/test/output/tipFormatChannelMarkup.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan font-weight="bold">Name</tspan><tspan fill="red">Bob</tspan></tspan><tspan x="0" dy="1em">​<tspan font-weight="bold">x</tspan> 0</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/output/tipFormatTitleMarkup.svg
+++ b/test/output/tipFormatTitleMarkup.svg
@@ -1,0 +1,28 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="90" viewBox="0 0 640 90" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0.5,0)">
+    <path transform="translate(320,60)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0.5,9.5)">
+    <text y="0.71em" transform="translate(320,60)">0</text>
+  </g>
+  <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)" visibility="hidden">
+    <g transform="translate(320,60)">
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))"></path>
+      <text fill="currentColor" fill-opacity="1" stroke="none"><tspan x="0" dy="1em">​<tspan><tspan font-weight="bold">Plot</tspan> <a fill="blue" href="https://observablehq.com/plot/">docs</a></tspan></tspan></text>
+    </g>
+  </g>
+</svg>

--- a/test/plots/tip-format.ts
+++ b/test/plots/tip-format.ts
@@ -1,4 +1,5 @@
 import * as Plot from "@observablehq/plot";
+import {svg} from "htl";
 import {test} from "test/plot";
 
 function tip(
@@ -119,4 +120,21 @@ test(async function tipFormatTitleFormatShorthand() {
 
 test(async function tipFormatTitlePrimitive() {
   return tip(["hello\nworld"], {x: 0});
+});
+
+test(async function tipFormatTitleMarkup() {
+  return tip(
+    {length: 1},
+    {
+      title: ["Plot"],
+      format: {title: (d) => svg`<tspan><tspan font-weight="bold">${d}</tspan> <a fill="blue" href="https://observablehq.com/plot/">docs</a></tspan>`} // prettier-ignore
+    }
+  );
+});
+
+test(async function tipFormatChannelMarkup() {
+  return tip([{value: 1}], {
+    channels: {Name: ["Bob"]},
+    format: {Name: (d) => svg`<tspan fill="red">${d}</tspan>`}
+  });
 });


### PR DESCRIPTION
Closes the long-standing request for rich text and markup in tips (#1767).

This implements the "relatively easy" direction that mbostock outlined in the thread: a custom format function for the title channel, or any other channel, may now return a DOM node instead of a string. The returned node is appended directly to the tip rather than being wrapped in a text node, so you can style and hyperlink tip content, for example with an SVG tspan or anchor element built with Hypertext Literal:

```js
Plot.tip(data, {
  title: "name",
  format: {
    title: (name) => htl.svg`<tspan><tspan font-weight="bold">${name}</tspan> <a fill="blue" href="/details/${name}">details</a></tspan>`
  }
})
```

Safety: only a DOM node returned by a format function is treated as rich content. Plain string formats are unchanged and always rendered as text, so no HTML is ever parsed and this adds no injection surface. Because a returned node is appended as-is rather than measured, the lineWidth and textOverflow options do not apply to it.

Changes:
- src/marks/tip.js: append a returned node directly in renderLine, and route a title-channel node through renderLine; small isNode helper.
- src/marks/tip.d.ts: TipFormat may now return string | Node.
- docs/marks/tip.md: document the behavior, safety note, and an example.
- test/plots/tip-format.ts: snapshot tests for a title node and a name-value channel node.

I scoped this to the format-function approach only, and did not add the separate content channel or the href channel also floated in the thread, since those are larger API surfaces you may want to design yourselves. The VersionBadge version in the docs is a placeholder for you to set to whatever you plan to release.

Fixes #1767
