### PR TITLE
Rounded tooltips

### DIFF
--- a/docs/marks/text.md
+++ b/docs/marks/text.md
@@ -220,7 +220,7 @@ The following text-specific constant options are also supported:
 * **fontStyle** - the [font style](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style); defaults to *normal*
 * **fontVariant** - the [font variant](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant); defaults to *normal*
 * **fontWeight** - the [font weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight); defaults to *normal*
-* **frameAnchor** - how to position the text within the frame; defaults to *middle*
+* **frameAnchor** - how to position the text within the frame. Options are *middle* (default), *top-left*, *top*, *top-right*, *right*, *bottom-right*, *bottom-left*, *left*
 * **rotate** - the rotation angle in degrees clockwise; defaults to 0
 
 If a **lineWidth** is specified, input text values will be wrapped as needed to fit while preserving existing newlines. The line wrapping implementation is rudimentary: it replaces the space before the word that overflows with a line feed (`\n`). Lines might also be split on words that contain a soft-hyphen (`\xad`), replacing it with a hyphen (-). For non-ASCII, non-U.S. English text, or for when a different font is used, you may get better results by hard-wrapping the text yourself (by supplying line feeds in the input). If the **monospace** option is truthy, the default **fontFamily** changes to monospace and the **lineWidth** option is interpreted as characters (ch) rather than ems.

--- a/docs/marks/tip.md
+++ b/docs/marks/tip.md
@@ -246,6 +246,7 @@ Plot.tip(["Danger! This tip is red."], {
 These [standard text options](./text.md#text-options) control the display of text within the tip:
 
 - **monospace** - if true, changes the default **fontFamily** and metrics to monospace
+- **fontColor** - usa color hex to set the font color; defaults to currentColor 
 - **fontFamily** - the font name; defaults to [*system-ui*](https://drafts.csswg.org/css-fonts-4/#valdef-font-family-system-ui)
 - **fontSize** - the font size in pixels; defaults to 10
 - **fontStyle** - the [font style](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style); defaults to *normal*

--- a/docs/marks/tip.md
+++ b/docs/marks/tip.md
@@ -229,6 +229,7 @@ These tip-specific options control the tip appearance:
 - **pointerSize** - the size of the tip’s pointer in pixels; defaults to 12
 - **pathFilter** - the image filter for the tip’s box; defaults to a drop shadow
 - **textPadding** - the padding around the text in pixels; defaults to 8
+- **radius** - round the corners of the tip - like a CSS border-radius; defaults to null which means square corners
 
 The tip mark does not support the [standard style channels](../features/marks.md#mark-options) such as varying **fill** or **stroke**; channels are used exclusively to control the displayed values rather than the tip’s appearance. You can however use the these options for a constant **fill**, **fillOpacity**, **stroke**, **strokeOpacity**, or **strokeWidth** on the path element surrounding the tip text.
 

--- a/src/marks/tip.d.ts
+++ b/src/marks/tip.d.ts
@@ -84,6 +84,9 @@ export interface TipOptions extends MarkOptions, TextStyles {
 
   /** The padding around the text in pixels; defaults to 8. */
   textPadding?: number;
+
+  /** The "border-radius" equivalent, in pixels; defaults to null for square corners. */
+  radius?: number;
 }
 
 /**

--- a/src/marks/tip.js
+++ b/src/marks/tip.js
@@ -87,8 +87,8 @@ export class Tip extends Mark {
     this.splitLines = splitter(this);
     this.clipLine = clipper(this);
     this.format = typeof format === "string" || typeof format === "function" ? {title: format} : {...format}; // defensive copy before mutate; also promote nullish to empty
-	this.radius = number(radius);  
-  }
+	this.radius = number(radius);
+  }	 
   render(index, scales, values, dimensions, context) {
     const mark = this;
     const {x, y, fx, fy} = scales;
@@ -240,7 +240,7 @@ export class Tip extends Mark {
         }
         const path = this.firstChild; // note: assumes exactly two children!
         const text = this.lastChild; // note: assumes exactly two children!
-          path.setAttribute("d", getPath(a, m, r, w, h, radius));
+	    path.setAttribute("d", getPath(a, m, r, w, h, rad));
         if (tx) for (const t of text.childNodes) t.setAttribute("x", -tx);
         text.setAttribute("y", `${+getLineOffset(a, text.childNodes.length, lineHeight).toFixed(6)}em`);
         text.setAttribute("transform", `translate(${getTextTranslate(a, m, r, w, h)})`);
@@ -300,62 +300,38 @@ function getTextTranslate(anchor, m, r, width, height) {
       return [r + m / 2, height / 2];
   }
 }
-
-/*function getPath(anchor, m, r, width, height) {
-  const w = width + r * 2;
-  const h = height + r * 2;
-  switch (anchor) {
-    case "middle":
-      return `M${-w / 2},${-h / 2}h${w}v${h}h${-w}z`;
-    case "top-left":
-      return `M0,0l${m / 2},${m / 2}h${w - m / 2}v${h}h${-w}z`;
-    case "top":
-      return `M0,0l${m / 2},${m / 2}h${(w - m) / 2}v${h}h${-w}v${-h}h${(w - m) / 2}z`;
-    case "top-right":
-      return `M0,0l${-m / 2},${m / 2}h${m / 2 - w}v${h}h${w}z`;
-    case "right":
-      return `M0,0l${-m / 2},${-m / 2}v${m / 2 - h / 2}h${-w}v${h}h${w}v${m / 2 - h / 2}z`;
-    case "bottom-left":
-      return `M0,0l${m / 2},${-m / 2}h${w - m / 2}v${-h}h${-w}z`;
-    case "bottom":
-      return `M0,0l${m / 2},${-m / 2}h${(w - m) / 2}v${-h}h${-w}v${h}h${(w - m) / 2}z`;
-    case "bottom-right":
-      return `M0,0l${-m / 2},${-m / 2}h${m / 2 - w}v${-h}h${w}z`;
-    case "left":
-      return `M0,0l${m / 2},${-m / 2}v${m / 2 - h / 2}h${w}v${h}h${-w}v${m / 2 - h / 2}z`;
-  }
-}*/
 function getPath(anchor, m, r, width, height, borderRadius) {
   
-	var w = width + r * 2, h = height + r * 2,tlc='',trc='',brc='',blc='';
+	let w = width + r * 2, h = height + r * 2, halfM = m / 2, br = 0, tlc = '', trc = '', brc = '', blc = '';
 	if(borderRadius){
-		const br = Math.min(borderRadius,w,h);
+		br = Math.min(borderRadius,w/2,h/2);
 		w = w - br - br;
 		h = h - br - br;
-		trc = `q ${br} 0 ${br} ${br}`;//top right corner
-		brc = `q 0 ${br} ${-br} ${br}`;
-		tlc = `q 0 ${-br} ${br} ${-br}`;
-		blc = `q ${-br} 0 ${-br} ${-br}`; //bottom left corner
+		trc = ` q ${br} 0 ${br} ${br} `;//top right corner
+		brc = ` q 0 ${br} ${-br} ${br} `;
+		tlc = ` q 0 ${-br} ${br} ${-br} `;
+		blc = ` q ${-br} 0 ${-br} ${-br} `; //bottom left corner
 	}
-  switch (anchor) {
+	switch (anchor) {
+		//all paths must go clockwise to use the rounded corners defined above
     case "middle":
-	  return `M${-w / 2},${-h / 2 - br} h${w} ${trc} v${h} ${brc} h${-w} ${blc} v ${-h} ${tlc} z`;
+		return `M${-w / 2},${-h / 2 - br}h${w}${trc}v${h}${brc}h${-w}${blc}v${-h}${tlc}z`;
     case "top-left":
-      return `M0,0l${m / 2},${m / 2} h${w - m / 2} ${trc} v${h} ${brc}  h${-w}  ${blc} z`;
+      return `M0,0l${halfM},${halfM}h${w - halfM + br}${trc}v${h}${brc}h${-w}${blc}z`;
     case "top":
-      return `M0,0l${m / 2},${m / 2} h${(w - m) / 2} ${trc} v${h} ${brc} h${-w} ${blc} v${-h} ${tlc} h${(w - m) / 2} z`;
+      return `M0,0l${halfM},${halfM}h${(w - m) / 2}${trc}v${h}${brc}h${-w}${blc}v${-h}${tlc}h${(w - m) / 2}z`;
     case "top-right":
-      return `M0,0l${-m / 2},${m / 2} h${m / 2 - w} ${tlc} v${h} ${blc} h${w} ${brc} z`;
+	  return `M0,0v${h + halfM + br}${brc}h${-w}${blc}v${-h}${tlc}h${w - halfM + br}z`;
     case "right":
-      return `M0,0l${-m / 2},${-m / 2} v${m / 2 - h / 2} ${trc} h${-w} ${tlc} v${h} ${blc} h${w} ${brc} v${m / 2 - h / 2} z`;
+      return `M0,0l${-halfM},${halfM}v${h / 2 - halfM}${brc}h${-w}${blc}v${-h}${tlc}h${w}${trc}v${h / 2 - halfM}z`;
     case "bottom-left":
-      return `M0,0l${m / 2},${-m / 2} h${w - m / 2} ${brc}  v${-h} ${trc} h${-w} ${tlc} z`;
+      return `M0,0v${-h - halfM - br}${tlc}h${w}${trc}v${h}${brc}h${-w + halfM - br }z`;
     case "bottom":
-      return `M0,0l${m / 2},${-m / 2} h${(w - m) / 2}  ${brc}  v${-h} ${trc} h${-w} ${tlc}  v${h}  ${blc} h${(w - m) / 2} z`;
+		return `M0,0l${-halfM},${-halfM}h${(m - w) / 2}${blc}v${-h}${tlc}h${w}${trc}v${h}${brc}h${(m - w) / 2}z`;
     case "bottom-right":
-      return `M0,0l${-m / 2},${-m / 2} h${m / 2 - w} ${blc} v${-h} ${tlc} h${w} ${trc} z`;
+      return `M0,0l${-halfM},${-halfM}h${halfM - w - br}${blc}v${-h}${tlc}h${w}${trc}z`;
     case "left":
-      return `M0,0l${m / 2},${-m / 2} v${m / 2 - h / 2} h${w} v${h} h${-w} v${m / 2 - h / 2} z`;
+      return `M0,0l${halfM},${-halfM}v${halfM - h / 2}${tlc}h${w}${trc}v${h}${brc}h${-w}${blc}v${halfM - h / 2}z`;
   }
 }
 

--- a/src/marks/tip.js
+++ b/src/marks/tip.js
@@ -50,7 +50,8 @@ export class Tip extends Mark {
       textPadding = 8,
       title,
       pointerSize = 12,
-      pathFilter = "drop-shadow(0 3px 4px rgba(0,0,0,0.2))"
+	  pathFilter = "drop-shadow(0 3px 4px rgba(0,0,0,0.2))",
+	  radius,
     } = options;
     super(
       data,
@@ -86,13 +87,14 @@ export class Tip extends Mark {
     this.splitLines = splitter(this);
     this.clipLine = clipper(this);
     this.format = typeof format === "string" || typeof format === "function" ? {title: format} : {...format}; // defensive copy before mutate; also promote nullish to empty
+	this.radius = number(radius);  
   }
   render(index, scales, values, dimensions, context) {
     const mark = this;
     const {x, y, fx, fy} = scales;
     const {ownerSVGElement: svg, document} = context;
     const {anchor, monospace, lineHeight, lineWidth} = this;
-    const {textPadding: r, pointerSize: m, pathFilter} = this;
+    const {textPadding: r, pointerSize: m, pathFilter, radius: rad} = this;
     const {marginTop, marginLeft} = dimensions;
 
     // The anchor position is the middle of x1 & y1 and x2 & y2, if available,
@@ -238,7 +240,7 @@ export class Tip extends Mark {
         }
         const path = this.firstChild; // note: assumes exactly two children!
         const text = this.lastChild; // note: assumes exactly two children!
-        path.setAttribute("d", getPath(a, m, r, w, h));
+          path.setAttribute("d", getPath(a, m, r, w, h, radius));
         if (tx) for (const t of text.childNodes) t.setAttribute("x", -tx);
         text.setAttribute("y", `${+getLineOffset(a, text.childNodes.length, lineHeight).toFixed(6)}em`);
         text.setAttribute("transform", `translate(${getTextTranslate(a, m, r, w, h)})`);
@@ -299,7 +301,7 @@ function getTextTranslate(anchor, m, r, width, height) {
   }
 }
 
-function getPath(anchor, m, r, width, height) {
+/*function getPath(anchor, m, r, width, height) {
   const w = width + r * 2;
   const h = height + r * 2;
   switch (anchor) {
@@ -321,6 +323,39 @@ function getPath(anchor, m, r, width, height) {
       return `M0,0l${-m / 2},${-m / 2}h${m / 2 - w}v${-h}h${w}z`;
     case "left":
       return `M0,0l${m / 2},${-m / 2}v${m / 2 - h / 2}h${w}v${h}h${-w}v${m / 2 - h / 2}z`;
+  }
+}*/
+function getPath(anchor, m, r, width, height, borderRadius) {
+  
+	var w = width + r * 2, h = height + r * 2,tlc='',trc='',brc='',blc='';
+	if(borderRadius){
+		const br = Math.min(borderRadius,w,h);
+		w = w - br - br;
+		h = h - br - br;
+		trc = `q ${br} 0 ${br} ${br}`;//top right corner
+		brc = `q 0 ${br} ${-br} ${br}`;
+		tlc = `q 0 ${-br} ${br} ${-br}`;
+		blc = `q ${-br} 0 ${-br} ${-br}`; //bottom left corner
+	}
+  switch (anchor) {
+    case "middle":
+	  return `M${-w / 2},${-h / 2 - br} h${w} ${trc} v${h} ${brc} h${-w} ${blc} v ${-h} ${tlc} z`;
+    case "top-left":
+      return `M0,0l${m / 2},${m / 2} h${w - m / 2} ${trc} v${h} ${brc}  h${-w}  ${blc} z`;
+    case "top":
+      return `M0,0l${m / 2},${m / 2} h${(w - m) / 2} ${trc} v${h} ${brc} h${-w} ${blc} v${-h} ${tlc} h${(w - m) / 2} z`;
+    case "top-right":
+      return `M0,0l${-m / 2},${m / 2} h${m / 2 - w} ${tlc} v${h} ${blc} h${w} ${brc} z`;
+    case "right":
+      return `M0,0l${-m / 2},${-m / 2} v${m / 2 - h / 2} ${trc} h${-w} ${tlc} v${h} ${blc} h${w} ${brc} v${m / 2 - h / 2} z`;
+    case "bottom-left":
+      return `M0,0l${m / 2},${-m / 2} h${w - m / 2} ${brc}  v${-h} ${trc} h${-w} ${tlc} z`;
+    case "bottom":
+      return `M0,0l${m / 2},${-m / 2} h${(w - m) / 2}  ${brc}  v${-h} ${trc} h${-w} ${tlc}  v${h}  ${blc} h${(w - m) / 2} z`;
+    case "bottom-right":
+      return `M0,0l${-m / 2},${-m / 2} h${m / 2 - w} ${blc} v${-h} ${tlc} h${w} ${trc} z`;
+    case "left":
+      return `M0,0l${m / 2},${-m / 2} v${m / 2 - h / 2} h${w} v${h} h${-w} v${m / 2 - h / 2} z`;
   }
 }
 

--- a/src/marks/tip.js
+++ b/src/marks/tip.js
@@ -35,7 +35,8 @@ export class Tip extends Mark {
       y2,
       anchor,
       preferredAnchor = "bottom",
-      monospace,
+	  monospace,
+	  fontColor = "currentColor",	
       fontFamily = monospace ? "ui-monospace, monospace" : undefined,
       fontSize,
       fontStyle,
@@ -78,6 +79,7 @@ export class Tip extends Mark {
     this.lineWidth = +lineWidth;
     this.textOverflow = maybeTextOverflow(textOverflow);
     this.monospace = !!monospace;
+	this.fontColor = string(fontColor);
     this.fontFamily = string(fontFamily);
     this.fontSize = number(fontSize);
     this.fontStyle = string(fontStyle);
@@ -94,7 +96,7 @@ export class Tip extends Mark {
     const {x, y, fx, fy} = scales;
     const {ownerSVGElement: svg, document} = context;
     const {anchor, monospace, lineHeight, lineWidth} = this;
-    const {textPadding: r, pointerSize: m, pathFilter, radius: rad} = this;
+      const {textPadding: r, pointerSize: m, pathFilter, radius: rad, fontColor:color} = this;
     const {marginTop, marginLeft} = dimensions;
 
     // The anchor position is the middle of x1 & y1 and x2 & y2, if available,
@@ -154,7 +156,7 @@ export class Tip extends Mark {
             g.append("text").each(function (i) {
               const that = select(this);
               // prevent style inheritance (from path)
-              this.setAttribute("fill", "currentColor");
+              this.setAttribute("fill", color);
               this.setAttribute("fill-opacity", 1);
               this.setAttribute("stroke", "none");
               // iteratively render each channel value

--- a/test/output/tipBorderRadiusForAnchors.svg
+++ b/test/output/tipBorderRadiusForAnchors.svg
@@ -82,7 +82,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(0,159)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0v-19 q 0 -3 3 -3 h10 q 3 0 3 3 v10 q 0 3 -3 3 h-4z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0v-19 q 0 -3 3 -3 h10 q 3 0 3 3 v10 q 0 3 -3 3 h-7z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-1.29em" transform="translate(8,-14)"><tspan x="0" dy="1em">​bottom-left</tspan></text>
     </g>
   </g>

--- a/test/output/tipBorderRadiusForAnchors.svg
+++ b/test/output/tipBorderRadiusForAnchors.svg
@@ -19,7 +19,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(320,0)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l6,6h2v16h-16v-16h2z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l6,6h-1 q 3 0 3 3 v10 q 0 3 -3 3 h-10 q -3 0 -3 -3 v-10 q 0 -3 3 -3 h-1z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-0.06em" transform="translate(0,14)"><tspan x="0" dy="1em">​top</tspan></text>
     </g>
   </g>
@@ -28,7 +28,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(639,80)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l-6,6v2h-16v-16h16v2z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l-6,6v-1 q 0 3 -3 3 h-10 q -3 0 -3 -3 v-10 q 0 -3 3 -3 h10 q 3 0 3 3 v-1z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-1.29em" transform="translate(-14,0)"><tspan x="0" dy="1em">​right</tspan></text>
     </g>
   </g>
@@ -37,7 +37,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(320,159)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l-6,-6h-2v-16h16v16h-2z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l-6,-6h1 q -3 0 -3 -3 v-10 q 0 -3 3 -3 h10 q 3 0 3 3 v10 q 0 3 -3 3 h1z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-1.29em" transform="translate(0,-14)"><tspan x="0" dy="1em">​bottom</tspan></text>
     </g>
   </g>
@@ -46,7 +46,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(0,80)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l6,-6v-2h16v16h-16v-2z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l6,-6v1 q 0 -3 3 -3 h10 q 3 0 3 3 v10 q 0 3 -3 3 h-10 q -3 0 -3 -3 v1z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-1.29em" transform="translate(14,0)"><tspan x="0" dy="1em">​left</tspan></text>
     </g>
   </g>
@@ -55,7 +55,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(0,0)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l6,6h10v16h-16z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l6,6h7 q 3 0 3 3 v10 q 0 3 -3 3 h-10 q -3 0 -3 -3 z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-0.06em" transform="translate(8,14)"><tspan x="0" dy="1em">​top-left</tspan></text>
     </g>
   </g>
@@ -64,7 +64,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(639,0)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0v22h-16v-16h10z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0v19 q 0 3 -3 3 h-10 q -3 0 -3 -3 v-10 q 0 -3 3 -3 h7z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-0.06em" transform="translate(-8,14)"><tspan x="0" dy="1em">​top-right</tspan></text>
     </g>
   </g>
@@ -73,7 +73,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(639,159)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l-6,-6h-10v-16h16z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l-6,-6h-7 q -3 0 -3 -3 v-10 q 0 -3 3 -3 h10 q 3 0 3 3 z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-1.29em" transform="translate(-8,-14)"><tspan x="0" dy="1em">​bottom-right</tspan></text>
     </g>
   </g>
@@ -82,7 +82,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(0,159)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0v-22h16v16h-10z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0v-19 q 0 -3 3 -3 h10 q 3 0 3 3 v10 q 0 3 -3 3 h-4z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-1.29em" transform="translate(8,-14)"><tspan x="0" dy="1em">​bottom-left</tspan></text>
     </g>
   </g>
@@ -91,7 +91,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(320,80)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M-8,-8h16v16h-16v-16z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M-5,-8h10 q 3 0 3 3 v10 q 0 3 -3 3 h-10 q -3 0 -3 -3 v-10 q 0 -3 3 -3 z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-1.29em" transform="translate(0,0)"><tspan x="0" dy="1em">​middle</tspan></text>
     </g>
   </g>

--- a/test/output/tipDispatch.svg
+++ b/test/output/tipDispatch.svg
@@ -399,7 +399,7 @@
   </g>
   <g aria-label="tip" fill="var(--plot-background)" stroke="currentColor" pointer-events="none" text-anchor="start" transform="translate(0.5,0.5)">
     <g transform="translate(198,199)">
-      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l6,-6h2v-16h-16v16h2z"></path>
+      <path filter="drop-shadow(0 3px 4px rgba(0,0,0,0.2))" d="M0,0l-6,-6h-2v-16h16v16h-2z"></path>
       <text fill="currentColor" fill-opacity="1" stroke="none" y="-1.29em" transform="translate(0,-14)"><tspan x="0" dy="1em">​Torgersen</tspan></text>
     </g>
   </g>

--- a/test/plots/tip.ts
+++ b/test/plots/tip.ts
@@ -48,7 +48,7 @@ test(async function tipBorderRadiusForAnchors() {
           "bottom-left", // corners
           "middle"
         ] as const
-      ).map((anchor, ind ) => [
+      ).map((anchor) => [
         Plot.dot({length: 1}, {frameAnchor: anchor, fill: "blue"}),
         Plot.tip([anchor], { frameAnchor: anchor, anchor, radius: 3})
       ])

--- a/test/plots/tip.ts
+++ b/test/plots/tip.ts
@@ -30,6 +30,33 @@ test(async function tipAnchors() {
   return Object.assign(plot, {ready: new Promise((resolve) => setTimeout(resolve, 100))}); // postrender
 });
 
+test(async function tipBorderRadiusForAnchors() {
+  const plot = Plot.plot({
+    style: "overflow: visible;",
+    height: 160,
+    marks: [
+      Plot.frame({strokeOpacity: 0.2}),
+      (
+        [
+          "top",
+          "right",
+          "bottom",
+          "left", // sides
+          "top-left",
+          "top-right",
+          "bottom-right",
+          "bottom-left", // corners
+          "middle"
+        ] as const
+      ).map((anchor, ind ) => [
+        Plot.dot({length: 1}, {frameAnchor: anchor, fill: "blue"}),
+        Plot.tip([anchor], {radius: ind + 2, frameAnchor: anchor, anchor})
+      ])
+    ]
+  });
+  return Object.assign(plot, {ready: new Promise((resolve) => setTimeout(resolve, 100))}); // postrender
+});
+
 test(async function tipAreaBand() {
   const aapl = await d3.csv<any>("data/aapl.csv", d3.autoType);
   return Plot.areaY(aapl, {x: "Date", y1: "Low", y2: "High", tip: true, curve: "step", stroke: "currentColor"}).plot();

--- a/test/plots/tip.ts
+++ b/test/plots/tip.ts
@@ -50,7 +50,7 @@ test(async function tipBorderRadiusForAnchors() {
         ] as const
       ).map((anchor, ind ) => [
         Plot.dot({length: 1}, {frameAnchor: anchor, fill: "blue"}),
-        Plot.tip([anchor], {radius: ind + 2, frameAnchor: anchor, anchor})
+        Plot.tip([anchor], { frameAnchor: anchor, anchor, radius: 3})
       ])
     ]
   });


### PR DESCRIPTION
For a tip mark set a `radius` and this will make a rounded tooltip. 

Changed the tip paths to draw themselves in the clockwise direction. If a radius is set then add quadratic bezier curves in the appropriate corners based on the `frameAnchor`. 

I did not make curves from the flat edge to the "point".  Just the outer corners. 

<img width="640" height="160" alt="image" src="https://github.com/user-attachments/assets/64f935d8-6088-453d-9ae8-ccdc31196265" />

Add tests  

