### PR TITLE
standalone Plot.scale respects the transform and percent options

### DIFF
--- a/src/scales.js
+++ b/src/scales.js
@@ -70,21 +70,16 @@ export function createScales(
     });
     if (scale) {
       // populate generic scale options (percent, transform, insets)
-      let {
+      const {
         label = key === "fx" || key === "fy" ? facetLabel : globalLabel,
-        percent,
-        transform,
         inset,
         insetTop = inset !== undefined ? inset : key === "y" ? globalInsetTop : 0, // not fy
         insetRight = inset !== undefined ? inset : key === "x" ? globalInsetRight : 0, // not fx
         insetBottom = inset !== undefined ? inset : key === "y" ? globalInsetBottom : 0, // not fy
         insetLeft = inset !== undefined ? inset : key === "x" ? globalInsetLeft : 0 // not fx
       } = scaleOptions || {};
-      if (transform == null) transform = undefined;
-      else if (typeof transform !== "function") throw new Error("invalid scale transform; not a function");
-      scale.percent = !!percent;
+      applyScaleOptions(scale, scaleOptions);
       scale.label = label === undefined ? inferScaleLabel(channels, scale) : label;
-      scale.transform = transform;
       if (key === "x" || key === "fx") {
         scale.insetLeft = +insetLeft;
         scale.insetRight = +insetRight;
@@ -96,6 +91,17 @@ export function createScales(
     }
   }
   return scales;
+}
+
+// Applies the generic scale options (percent, transform) that createScale
+// doesn't handle, and that both plot scales and standalone scales expose.
+// Mutates scale!
+function applyScaleOptions(scale, {percent, transform} = {}) {
+  if (transform == null) transform = undefined;
+  else if (typeof transform !== "function") throw new Error("invalid scale transform; not a function");
+  scale.percent = !!percent;
+  scale.transform = transform;
+  return scale;
 }
 
 export function createScaleFunctions(descriptors) {
@@ -524,9 +530,10 @@ export function scale(options = {}) {
   let scale;
   for (const key in options) {
     if (!registry.has(key)) continue; // ignore unknown properties
-    if (!isScaleOptions(options[key])) continue; // e.g., ignore {color: "red"}
+    const scaleOptions = options[key];
+    if (!isScaleOptions(scaleOptions)) continue; // e.g., ignore {color: "red"}
     if (scale !== undefined) throw new Error("ambiguous scale definition; multiple scales found");
-    scale = exposeScale(normalizeScale(key, options[key]));
+    scale = exposeScale(applyScaleOptions(normalizeScale(key, scaleOptions), scaleOptions));
   }
   if (scale === undefined) throw new Error("invalid scale definition; no scale found");
   return scale;

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -76,6 +76,34 @@ it("Plot.scale({color: {}}) throws an error", () => {
   assert.throws(() => Plot.scale({color: {}}), /invalid scale definition/);
 });
 
+it("Plot.scale(description) reflects the given transform", () => {
+  const transform = (d) => 1 / d;
+  scaleEqual(Plot.scale({x: {type: "linear", domain: [2700, 6300], range: [20, 620], transform}}), {
+    type: "linear",
+    domain: [2700, 6300],
+    range: [20, 620],
+    interpolate: d3.interpolateNumber,
+    clamp: false,
+    transform
+  });
+});
+
+it("Plot.scale(description) reflects the percent option", () => {
+  assert.strictEqual(Plot.scale({x: {type: "linear", domain: [0, 1], percent: true}}).percent, true);
+  assert.strictEqual(Plot.scale({x: {type: "linear", domain: [0, 1]}}).percent, undefined);
+});
+
+it("Plot.scale(description) throws an error if the transform is not a function", () => {
+  assert.throws(() => Plot.scale({x: {type: "linear", transform: 42}}), /invalid scale transform/);
+});
+
+it("Plot.scale(description) returns a scale that a plot can reuse, applying the transform", () => {
+  const options = {type: "linear", domain: [0, 20], transform: (d) => d * 2};
+  const expected = Plot.dotX([1, 2, 3]).plot({x: options});
+  const actual = Plot.dotX([1, 2, 3]).plot({x: Plot.scale({x: options})});
+  assert.strictEqual(actual.outerHTML, expected.outerHTML);
+});
+
 it("plot(…).scale(name) returns undefined for an unused scale", () => {
   const plot = Plot.dot([1, 2], {x: (d) => d, y: (d) => d}).plot();
   assert.deepStrictEqual(plot.scale("r"), undefined);


### PR DESCRIPTION
This PR proposes making the standalone `Plot.scale` respect the **transform** and **percent** scale options, so that it materializes the same options as *plot*.scale (fixes #2325). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/456. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`createScales` populates the generic scale options — **percent** and **transform** — onto the scale descriptor *after* `createScale` returns, which is why `plot(…).scale(name)` exposes them. The standalone `Plot.scale` goes straight from `normalizeScale` to `exposeScale` and never runs that step, so both options are silently dropped from the returned scale. At `356f579` on `main`:

```
$ node --input-type=module -e '
import * as Plot from "./src/index.js";
const transform = (d) => d * 2;
console.log("transform:", Plot.scale({x: {type: "linear", domain: [0, 10], transform}}).transform);
console.log("percent:", Plot.scale({x: {type: "linear", domain: [0, 10], percent: true}}).percent);
'
transform: undefined
percent: undefined
```

This is not only cosmetic on the returned object. The scales documentation says a standalone scale object can be passed to `Plot.plot` as the corresponding scale options, and `applyScaleTransform` in `src/plot.js` reads **transform** and **percent** back out of those options — so a plot that reuses a standalone scale renders untransformed data, while the identical inline options transform it. That asymmetry is what #2325 reports.

## The change

The **percent** and **transform** handling moves out of `createScales` into a small `applyScaleOptions` helper that both `createScales` and `scale` call, so the two paths materialize scale options identically instead of one of them re-implementing the other. `Plot.plot` behavior is unchanged: the helper keeps the existing ordering (**percent** is applied before the label is inferred, so the “(%)” label suffix still works) and the existing `invalid scale transform; not a function` error, which the standalone path now raises as well.

## Verification

`test/scales/scales-test.js` gains four tests: the exposed **transform**, the exposed **percent**, the not-a-function **transform** error, and an end-to-end check that a plot handed a standalone scale renders byte-identical output to the same plot handed the equivalent inline options. All four fail on `main` and pass here.

```
$ pnpm run test        # main @ 356f579
Test Files  404 passed (404)
     Tests  1349 passed | 2 skipped (1351)
Type Errors  no errors

$ pnpm run test        # this branch
Test Files  404 passed (404)
     Tests  1353 passed | 2 skipped (1355)
Type Errors  no errors
```

ESLint and Prettier are clean on both trees, and the 28 existing snapshots carrying a “(%)” axis label are unchanged, which is what covers the reordered label inference. One note on merge order: #2427 edits the same line of `scale`, so whichever of the two lands second needs a one-line rebase.

## How this was managed

We ran this work on a board imported from this repository's own issues and pull requests (1875 stories). The story covering this fix is [Plot.scale(…) ignores the transform option](https://eastagiletracker.com/projects/456/stories/403410), on the board at https://eastagiletracker.com/projects/456.

![board](https://raw.githubusercontent.com/eastagiletracker/plot/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
